### PR TITLE
chore: bump py-opendisplay to 7.4.1

### DIFF
--- a/custom_components/opendisplay/manifest.json
+++ b/custom_components/opendisplay/manifest.json
@@ -15,6 +15,6 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/OpenDisplay/Home_Assistant_Integration/issues",
   "loggers": ["opendisplay"],
-  "requirements": ["py-opendisplay==7.3.2", "odl-renderer==0.5.9"],
+  "requirements": ["py-opendisplay==7.4.1", "odl-renderer==0.5.9"],
   "version": "3.0.0-beta.3"
 }


### PR DESCRIPTION
Bumps py-opendisplay to get 4-gray support on some additional devices.