### PR TITLE
Offload image prepare to executor, keep BLE transfer on the loop

### DIFF
--- a/custom_components/opendisplay/services.py
+++ b/custom_components/opendisplay/services.py
@@ -5,6 +5,7 @@ from collections.abc import Awaitable, Callable
 import contextlib
 from datetime import timedelta
 from enum import IntEnum
+import functools
 import io
 import logging
 import os
@@ -25,6 +26,7 @@ from opendisplay import (
     OpenDisplayError,
     RefreshMode,
     Rotation,
+    prepare_image,
 )
 from PIL import Image as PILImage, ImageOps
 import voluptuous as vol
@@ -344,15 +346,33 @@ async def _async_send_image(
     rotate: Rotation = Rotation.ROTATE_0,
 ) -> None:
     """Upload a PIL image to the device."""
-    async def _upload(device: OpenDisplayDevice) -> None:
-        await device.upload_image(
+    # Split the upload into its heavy CPU half and its BLE-I/O half. The CPU
+    # work (rotate + fit + dither + encode + zlib on a full frame) is offloaded
+    # to an executor thread so it never blocks the event loop; only the BLE
+    # transfer runs on the loop. This mirrors what device.upload_image() does
+    # internally, but that call ran _prepare_image synchronously on the loop.
+    config = entry.runtime_data.device_config
+    display_cfg = config.displays[0] if config and config.displays else None
+    # Match upload_image(): only ask prepare_image() to build compressed data
+    # when the panel actually supports zip. upload_prepared_image() then falls
+    # back to the uncompressed protocol when compressed_data is None.
+    supports_compression = display_cfg.supports_zip if display_cfg else True
+    prepared = await hass.async_add_executor_job(
+        functools.partial(
+            prepare_image,
             img,
-            refresh_mode=refresh_mode,
+            config=config,
             dither_mode=dither_mode,
+            compress=supports_compression,
             tone=tone,
             fit=fit,
             rotate=rotate,
         )
+    )
+
+    async def _upload(device: OpenDisplayDevice) -> None:
+        await device.upload_prepared_image(prepared, refresh_mode=refresh_mode)
+
     await _async_connect_and_run(hass, entry, _upload)
     jpeg = await hass.async_add_executor_job(_pil_to_jpeg, img)
     async_dispatcher_send(hass, f"{SIGNAL_IMAGE_UPDATED}_{entry.unique_id}", jpeg)


### PR DESCRIPTION
## Problem

`_async_send_image` (the shared upload path behind both the `upload_image` and `drawcustom` services) awaited `device.upload_image(...)`. Inside the library that call runs `_prepare_image` **synchronously on the event loop**: rotate + fit + dither + encode + zlib on a full frame. So every upload/drawcustom blocked the Home Assistant event loop for the entire CPU stage before any BLE I/O even started.

## Fix

py-opendisplay 7.9.0 exposes the split deliberately:

- `prepare_image(image, config=..., ...)` — module-level, does the heavy CPU work (rotate/fit/dither/encode/compress) from the device **config only**, no BLE connection.
- `device.upload_prepared_image(prepared, refresh_mode=...)` — sends the pre-computed data over BLE.

`_async_send_image` now runs `prepare_image` in the executor via `hass.async_add_executor_job` (passing the same `dither_mode`/`tone`/`fit`/`rotate` options previously handed to `upload_image`), then does only `upload_prepared_image` on the loop inside `_async_connect_and_run`. The heavy CPU work is off the loop; only the BLE transfer stays on it.

`compress` is gated on `display.supports_zip`, mirroring `upload_image()` which passes `compress and supports_compression` into `_prepare_image`. When the panel has no zip support, `prepare_image()` returns `compressed_data=None` and `upload_prepared_image()` falls back to the uncompressed protocol — identical behavior to before, just moved off-loop.

## Interaction with the per-MAC `ble_lock` (#53)

This is written so the two compose correctly. #53 wraps the whole `_async_connect_and_run` connection lifetime (`async with entry.runtime_data.ble_lock, OpenDisplayDevice(...)`) in the BLE lock. By moving the `prepare_image` executor call **before** `_async_connect_and_run` (before the connection is opened), the CPU work runs **outside** the lock, and the lock is held only around the `upload_prepared_image` BLE transfer — exactly the desired scoping (don't hold the per-tag BLE lock while burning CPU on dithering). #53 is not yet merged into `feat/clean-port`; this branch is based on the current `feat/clean-port` state and does not touch the lock itself, so it merges cleanly in either order.

## Testing

- `python -m py_compile custom_components/opendisplay/services.py` passes.
- Verified the v7.9.0 API by signature: `prepare_image` is a module-level function exported from `opendisplay`, deriving capabilities and `panel_ic_type` from `config` when not supplied (equivalent to a config-constructed device that skips interrogation); `upload_prepared_image(prepared_data, refresh_mode=..., compress=True, ...)` accepts the `(uncompressed, compressed_or_None, processed_image)` tuple `prepare_image` returns. Only args that exist at the pinned v7.9.0 are used.
- Reasoned end-to-end: the dither/encode/zlib CPU stage now runs in an executor thread; the BLE transfer stays on the loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012g2e8mr132vcizx92WsgiR