### PR TITLE
Fix minor issues in update and services (NEW-3..NEW-6)

### DIFF
--- a/custom_components/opendisplay/services.py
+++ b/custom_components/opendisplay/services.py
@@ -11,11 +11,11 @@ import os
 from typing import TYPE_CHECKING, Any
 
 import aiohttp
-from epaper_dithering import ColorScheme
 from odl_renderer import generate_image
 from opendisplay import (
     AuthenticationFailedError,
     AuthenticationRequiredError,
+    ColorScheme,
     DitherMode,
     FitMode,
     LedFlashConfig,
@@ -261,7 +261,9 @@ async def _async_download_image(hass: HomeAssistant, url: str) -> PILImage.Image
         )
     session = async_get_clientsession(hass)
     try:
-        async with session.get(url) as resp:
+        async with session.get(
+            url, timeout=aiohttp.ClientTimeout(total=30)
+        ) as resp:
             resp.raise_for_status()
             data = await resp.read()
     except aiohttp.ClientError as err:
@@ -590,7 +592,7 @@ async def _drawcustom_for_device(
         accent_color=color_scheme.accent_color,
         session=async_get_clientsession(hass),
         data_provider=HADataProvider(hass),
-        font_dirs=_font_search_dirs(hass),
+        font_dirs=await hass.async_add_executor_job(_font_search_dirs, hass),
     )
 
     if call.data["dry-run"]:

--- a/custom_components/opendisplay/update.py
+++ b/custom_components/opendisplay/update.py
@@ -83,6 +83,7 @@ class OpenDisplayFirmwareUpdateEntity(OpenDisplayEntity[UpdateEntityDescription]
     """Firmware update entity for an OpenDisplay device."""
 
     _attr_latest_version: str | None = None
+    _attr_release_notes: str | None = None
     should_poll = True  # override coordinator's should_poll=False; GitHub needs regular polling
 
     def __init__(self, coordinator, entry: OpenDisplayConfigEntry) -> None:
@@ -145,6 +146,7 @@ class OpenDisplayFirmwareUpdateEntity(OpenDisplayEntity[UpdateEntityDescription]
             async with session.get(
                 _GITHUB_LATEST.format(repo=self._firmware_repo),
                 headers=_GITHUB_HEADERS,
+                timeout=aiohttp.ClientTimeout(total=30),
             ) as resp:
                 resp.raise_for_status()
                 data = await resp.json()
@@ -258,6 +260,7 @@ class OpenDisplayFirmwareUpdateEntity(OpenDisplayEntity[UpdateEntityDescription]
             async with session.get(
                 _GITHUB_RELEASE.format(repo=self._firmware_repo, tag=tag),
                 headers=_GITHUB_HEADERS,
+                timeout=aiohttp.ClientTimeout(total=30),
             ) as resp:
                 resp.raise_for_status()
                 release = await resp.json()
@@ -276,7 +279,9 @@ class OpenDisplayFirmwareUpdateEntity(OpenDisplayEntity[UpdateEntityDescription]
 
         _LOGGER.debug("Downloading %s from %s", asset_name, download_url)
         try:
-            async with session.get(download_url) as resp:
+            async with session.get(
+                download_url, timeout=aiohttp.ClientTimeout(total=120)
+            ) as resp:
                 resp.raise_for_status()
                 return await resp.read()
         except aiohttp.ClientError as err:


### PR DESCRIPTION
Batch of four small, surgical fixes to the HA integration.

- [x] **NEW-3** `async_release_notes()` could raise `AttributeError` — `_attr_release_notes` was only assigned on the successful GitHub-fetch path, but RELEASE_NOTES is advertised for every device. Added a class-level `_attr_release_notes: str | None = None` default so calls before/without a successful fetch (e.g. unknown IC type, fetch failure) return `None`.
- [x] **NEW-4** Undeclared direct `epaper_dithering` import — `services.py` imported `ColorScheme` directly from `epaper_dithering`, which is only present transitively via py-opendisplay. Now imported from `opendisplay`, which re-exports it (confirmed at pinned v7.9.0).
- [x] **NEW-5** External HTTP calls had no explicit timeout — added `aiohttp.ClientTimeout` to every external `session.get`: GitHub metadata (30s) in `update.py`, firmware asset download (120s) in `update.py`, and media download (30s) in `services.py`.
- [x] **NEW-6** Blocking `os.path.isdir` on the event loop — `_font_search_dirs` does blocking stat calls and is invoked from async `_drawcustom_for_device`; it now runs via `hass.async_add_executor_job`.

Verified: both edited files pass `py_compile`; `ColorScheme` resolves from `opendisplay` at v7.9.0. No test harness present in the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012g2e8mr132vcizx92WsgiR