### PR TITLE
chore: bump py-opendisplay to 7.11.2 and odl-renderer to 0.5.12

### DIFF
--- a/custom_components/opendisplay/manifest.json
+++ b/custom_components/opendisplay/manifest.json
@@ -15,6 +15,6 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/OpenDisplay/Home_Assistant_Integration/issues",
   "loggers": ["opendisplay"],
-  "requirements": ["py-opendisplay[silabs-ota]==7.11.1", "odl-renderer==0.5.10"],
+  "requirements": ["py-opendisplay[silabs-ota]==7.11.2", "odl-renderer==0.5.12"],
   "version": "3.0.0-beta.7"
 }


### PR DESCRIPTION
Final dependency set for 3.0.0: py-opendisplay 7.11.2 (partial support, compression gate fixes, epaper-dithering 5.0.9 with the tone-map NaN fix and FFI validation hardening) and odl-renderer 0.5.12 (plot crash/hang fixes, text rendering fixes, coercion tolerance, render perf). Hardware smoke test on the EN05 follows before the release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)