### PR TITLE
Keep last seen sensor available after first value

### DIFF
--- a/custom_components/opendisplay/sensor.py
+++ b/custom_components/opendisplay/sensor.py
@@ -141,6 +141,20 @@ class OpenDisplaySensorEntity(OpenDisplayEntity, SensorEntity):
 class OpenDisplayLastSeenSensor(OpenDisplaySensorEntity):
     """last_seen sourced from the bluetooth stack, not the gated callback."""
 
+    def __init__(
+        self,
+        coordinator,
+        description: OpenDisplaySensorEntityDescription,
+    ) -> None:
+        """Initialize the last_seen sensor."""
+        super().__init__(coordinator, description)
+        self._last_seen: datetime | None = None
+
+    @property
+    def available(self) -> bool:
+        """Stay available once a last_seen value has been observed."""
+        return self._last_seen is not None or super().available
+
     @property
     def native_value(self) -> datetime | None:
         # connectable=False matches the Bluetooth advertisement monitor's
@@ -150,8 +164,9 @@ class OpenDisplayLastSeenSensor(OpenDisplaySensorEntity):
             self.hass, self.coordinator.address, connectable=False
         )
         if info is None:
-            return None
+            return self._last_seen
         # info.time is a monotonic clock (monotonic_time_coarse); convert to
         # wall time with the same offset the advertisement monitor uses.
         wall = info.time + (time.time() - time.monotonic())
-        return datetime.fromtimestamp(wall, tz=timezone.utc)
+        self._last_seen = datetime.fromtimestamp(wall, tz=timezone.utc)
+        return self._last_seen

--- a/tests/test_last_seen.py
+++ b/tests/test_last_seen.py
@@ -59,6 +59,35 @@ def test_native_value_none_when_no_service_info():
         assert entity.native_value is None
 
 
+def test_last_seen_available_after_first_value_when_coordinator_unavailable():
+    entity = _make_sensor()
+    entity.coordinator.available = False
+    mono = time.monotonic()
+
+    with patch.object(
+        sensor_mod,
+        "async_last_service_info",
+        return_value=SimpleNamespace(time=mono),
+    ):
+        value = entity.native_value
+
+    assert value is not None
+    assert entity.available is True
+
+    with patch.object(sensor_mod, "async_last_service_info", return_value=None):
+        assert entity.native_value == value
+    assert entity.available is True
+
+
+def test_last_seen_unavailable_before_first_value_when_coordinator_unavailable():
+    entity = _make_sensor()
+    entity.coordinator.available = False
+
+    with patch.object(sensor_mod, "async_last_service_info", return_value=None):
+        assert entity.native_value is None
+    assert entity.available is False
+
+
 if __name__ == "__main__":
     import pytest
 


### PR DESCRIPTION
## Why

This follows up on the concern raised in https://github.com/OpenDisplay/Home_Assistant_Integration/pull/31#issuecomment-4995652056.

The `last_seen` sensor represents historical Bluetooth observation data, not the current live state of the display. If the device disappears for a while, the last-seen timestamp is still meaningful; making the entity unavailable effectively turns "last seen at X" into "unknown" at exactly the time the timestamp is most useful.

Other entities like temperature, RSSI, battery, button events, and touch events are live advertisement-derived state, so tying them to device availability makes sense. `last_seen` is different: once it has observed a timestamp, it should remain available and keep reporting that timestamp.

## What Changed

- Changed only the `last_seen` sensor availability behavior.
- `last_seen` now caches the first observed timestamp.
- Before any timestamp has been observed, it still follows the coordinator availability.
- After a timestamp has been observed, it remains available even if the coordinator later marks the device unavailable.
- If Bluetooth history later returns no service info, the sensor keeps returning the cached last-seen timestamp.

## Validation

- `PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=/mnt/n/Personal/opendisplay-work/Home_Assistant_Integration /home/mike/.venvs/hass-dev/bin/python -m pytest -q tests/test_last_seen.py -p no:cacheprovider`
- Result: `4 passed`
