### PR TITLE
fix: forward measured_palette to prepare_image in drawcustom/upload_image

### DIFF
--- a/custom_components/opendisplay/services.py
+++ b/custom_components/opendisplay/services.py
@@ -528,6 +528,7 @@ async def _async_send_image(
             tone=tone,
             fit=fit,
             rotate=rotate,
+            use_measured_palettes=use_measured_palettes,
         )
     )
 

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -328,3 +328,31 @@ async def test_live_send_passes_state_and_refresh_mode():
 
 if __name__ == "__main__":
     raise SystemExit(pytest.main([__file__, "-v"]))
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("measured", [True, False])
+async def test_send_image_forwards_measured_palette_choice(measured):
+    """The service's measured_palette option must reach prepare_image.
+
+    Regression: ``_async_send_image`` accepted ``use_measured_palettes`` but
+    never forwarded it, so ``prepare_image``'s default (True) silently won and
+    ``measured_palette: false`` in drawcustom/upload_image was a no-op — flat
+    UI colors were always quantized against the measured panel palette.
+    """
+    hass, entry, _, _ = _make_env(last_seen=time.time())  # awake -> live path
+    device = MagicMock()
+    device.upload_prepared_image = AsyncMock()
+    od = _device_ctx_factory(device=device)
+    p1, p2, p3, p4, p5 = _patches(od)
+    img = PILImage.new("RGB", (1, 1))
+    with p1 as prep, p2, p3, p4, p5:
+        await _async_send_image(
+            hass,
+            entry,
+            img,
+            dither_mode=DitherMode.NONE,
+            refresh_mode=RefreshMode.FULL,
+            use_measured_palettes=measured,
+        )
+    assert prep.call_args.kwargs.get("use_measured_palettes") is measured


### PR DESCRIPTION
Fixes #70.

`_async_send_image()` accepts `use_measured_palettes` but never forwarded it to `prepare_image()`, whose default (`True`) silently overrode the caller's choice — `measured_palette: false` in `drawcustom`/`upload_image` was a no-op and every frame was quantized against the measured panel palette. On calibrated panels this mis-inks flat UI colors (observed: named `green` text rendering in the yellow ink on Spectra 6, varying with frame content).

**Change**: forward the parameter in the `functools.partial(prepare_image, ...)` call (one line).

**Test**: adds `test_send_image_forwards_measured_palette_choice` in the existing `tests/test_services.py` style (patched `prepare_image`, no HA harness), parametrized over both values.

- Before the fix: fails with `assert None is False` — the captured `prepare_image` kwargs contain no `use_measured_palettes` key at all.
- After the fix: `13 passed` (full `tests/test_services.py`).
