### PR TITLE
fix: stop scaling firmware minor version by 10

### DIFF
--- a/custom_components/opendisplay/update.py
+++ b/custom_components/opendisplay/update.py
@@ -65,13 +65,11 @@ _OTA_INSTALL_IC_TYPES = {ICType.EFR32BG22}
 def _format_firmware_version(major: int, minor: int) -> str:
     """Format firmware version to match GitHub tag convention.
 
-    The 1.x firmware era uses single-digit minor tags (1.0–1.9 on GitHub),
-    but the firmware byte may store minor*10 (e.g. minor=60 → "1.6").
-    Dividing by 10 aligns the installed string with GitHub tag_names so
-    AwesomeVersion comparisons work correctly.
+    Firmware parses its own BUILD_VERSION string with a plain int conversion
+    (e.g. `atoi` on the substring after the dot), so the minor byte already
+    equals the literal digits in the tag_name (1.6 → 6, 1.71 → 71, 2.20 → 20).
+    No scaling is needed.
     """
-    if major >= 1 and minor >= 10:
-        minor = minor // 10
     return f"{major}.{minor}"
 
 

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -1,0 +1,28 @@
+"""Unit tests for the firmware update entity's version formatting.
+
+``_format_firmware_version`` used to divide two-digit minors by 10, on the
+theory that the firmware byte stored minor*10. That's not true: both
+Firmware_NRF52840_ESP32/src/communication.cpp and Firmware_NRF52/EPD/EPD_service.c
+parse BUILD_VERSION with a plain int conversion on the substring after the dot,
+so the minor byte always equals the literal tag digits (2.20 -> 20, 1.71 -> 71,
+1.6 -> 6). See issue #62: a device on 2.20 was displayed as 2.2.
+"""
+
+import pytest
+
+from custom_components.opendisplay.update import _format_firmware_version
+
+
+@pytest.mark.parametrize(
+    ("major", "minor", "expected"),
+    [
+        (2, 20, "2.20"),
+        (1, 71, "1.71"),
+        (1, 82, "1.82"),
+        (1, 6, "1.6"),
+        (1, 0, "1.0"),
+        (0, 68, "0.68"),
+    ],
+)
+def test_format_firmware_version(major, minor, expected):
+    assert _format_firmware_version(major, minor) == expected


### PR DESCRIPTION
## Summary
- The firmware parses `BUILD_VERSION` with a plain int conversion on the digits after the dot, so the minor byte already equals the literal tag digits (2.20 -> 20, 1.71 -> 71, 1.6 -> 6). `_format_firmware_version()` was dividing by 10 for minor >= 10, corrupting two-digit versions.
- Removes the scaling so the installed version displays exactly as the firmware reports it.
- Also explains OpenDisplay/Firmware#46 (1.10 appearing stuck below 1.71).

Fixes #62

## Test plan
- [x] Added `tests/test_update.py` covering `_format_firmware_version` for single- and double-digit minors (2.20, 1.71, 1.82, 1.6, 1.0, 0.68)
- [ ] Note: could not execute the test suite in this environment due to an unrelated pre-existing dependency mismatch (installed `epaper-dithering==5.0.9` lacks `ColorScheme.BWGBRY_SPLIT` expected by the local `py-opendisplay` checkout), reproduced on the unmodified tree as well