### PR TITLE
feat: WiFi/LAN transport with mDNS discovery and BLE fallback

### DIFF
--- a/custom_components/opendisplay/__init__.py
+++ b/custom_components/opendisplay/__init__.py
@@ -33,6 +33,7 @@ from homeassistant.helpers import config_validation as cv, device_registry as dr
 from homeassistant.helpers.device_registry import CONNECTION_BLUETOOTH
 from homeassistant.helpers.typing import ConfigType
 
+from .ble_lock import async_get_ble_lock, ble_connection
 from .const import CONF_CACHED_STATE, CONF_ENCRYPTION_KEY, DOMAIN, SETUP_DEADLINE_S
 from .coordinator import OpenDisplayCoordinator
 from .delivery import DeliveryManager
@@ -70,12 +71,15 @@ class OpenDisplayRuntimeData:
     is_flex: bool
     # Resolved deep-sleep behavior (options + device power config).
     sleep_profile: SleepProfile
+    # Serializes every BLE connection to this tag. Process-global per-MAC
+    # (ble_lock.py), so the same lock object is shared across every connect site
+    # and survives entry reloads. The device exposes a single BLE link with no
+    # per-address lock in the library, so drawcustom/upload_image, LED, buzzer
+    # and OTA must not open overlapping connections or they race and surface a
+    # confusing upload_error. Required (no default) so a future construction
+    # can't silently mint a private, non-shared lock and recreate this bug.
+    ble_lock: asyncio.Lock
     upload_task: asyncio.Task | None = None
-    # Serializes every BLE connection to this tag (one config entry == one MAC).
-    # The device exposes a single BLE link with no per-address lock in the
-    # library, so drawcustom/upload_image, LED, buzzer and OTA must not open
-    # overlapping connections or they race and surface a confusing upload_error.
-    ble_lock: asyncio.Lock = field(default_factory=asyncio.Lock)
     # Tracks the last uploaded frame + etag for differential partial updates
     # (0x76). Replaced with a fresh instance on every full/fast refresh so the
     # next partial diffs against the frame actually on the panel.
@@ -235,7 +239,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: OpenDisplayConfigEntry) 
             # wedged BLE link can't stall setup forever; a breach is treated like
             # any other connect failure below (sleepy-cache fallback / retry).
             async with asyncio.timeout(SETUP_DEADLINE_S):
-                async with OpenDisplayDevice(
+                async with ble_connection(address, "setup interrogation"), OpenDisplayDevice(
                     mac_address=address,
                     ble_device=ble_device,
                     encryption_key=encryption_key,
@@ -314,6 +318,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: OpenDisplayConfigEntry) 
         device_config=device_config,
         is_flex=is_flex,
         sleep_profile=profile,
+        ble_lock=async_get_ble_lock(address),
         config_resync_pending=from_cache,
     )
 

--- a/custom_components/opendisplay/__init__.py
+++ b/custom_components/opendisplay/__init__.py
@@ -89,6 +89,13 @@ class OpenDisplayRuntimeData:
     config_resync_pending: bool = False
     # Owns queued work delivered at the next wake (set in async_setup_entry).
     delivery: DeliveryManager | None = None
+    # Monotonic timestamp of the last mDNS sighting (fed by the zeroconf config
+    # step). Drives the WiFi-vs-BLE transport choice (see transport.py); None
+    # until the device is first seen via mDNS.
+    mdns_last_seen: float | None = None
+    # Label of the transport the most recent delivery completed over
+    # ("wifi"/"ble"); surfaced in diagnostics. None until a delivery runs.
+    last_transport: str | None = None
 
 
 type OpenDisplayConfigEntry = ConfigEntry[OpenDisplayRuntimeData]

--- a/custom_components/opendisplay/binary_sensor.py
+++ b/custom_components/opendisplay/binary_sensor.py
@@ -4,13 +4,20 @@ from datetime import datetime, timezone
 from typing import Any
 
 from homeassistant.components.binary_sensor import BinarySensorEntity
+from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.device_registry import CONNECTION_BLUETOOTH, DeviceInfo
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from . import OpenDisplayConfigEntry
-from .const import SIGNAL_PENDING_STATE
+from .const import (
+    CONF_HOST,
+    CONF_PORT,
+    CONF_TLS,
+    DEFAULT_LAN_PORT,
+    SIGNAL_PENDING_STATE,
+)
 from .delivery import DeliveryManager, DeliverySnapshot
 
 PARALLEL_UPDATES = 0
@@ -21,13 +28,22 @@ async def async_setup_entry(
     entry: OpenDisplayConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
-    """Set up the OpenDisplay update-pending binary sensor."""
+    """Set up the OpenDisplay binary sensors."""
+    entities: list[BinarySensorEntity] = []
+
     manager = entry.runtime_data.delivery
-    if manager is None:
-        return
-    async_add_entities(
-        [OpenDisplayUpdatePendingSensor(entry.unique_id or "", manager)]
-    )
+    if manager is not None:
+        entities.append(OpenDisplayUpdatePendingSensor(entry.unique_id or "", manager))
+
+    # WiFi (LAN) status. Only for WiFi-capable/-configured tags (device carries a
+    # wifi_config packet, or a LAN host is already stored) so pure-BLE devices
+    # don't get a permanently-off entity.
+    if entry.runtime_data.device_config.wifi_config is not None or entry.data.get(
+        CONF_HOST
+    ):
+        entities.append(OpenDisplayWifiSensor(entry))
+
+    async_add_entities(entities)
 
 
 def _to_iso(epoch: float | None) -> str | None:
@@ -91,3 +107,46 @@ class OpenDisplayUpdatePendingSensor(BinarySensorEntity):
         """Handle a delivery-state change."""
         self._apply(snapshot)
         self.async_write_ha_state()
+
+
+class OpenDisplayWifiSensor(BinarySensorEntity):
+    """Whether the WiFi (LAN) transport is enabled for an OpenDisplay device.
+
+    On when the integration holds a LAN endpoint (IP) for this tag — learned
+    from the device's mDNS announcement and stored on the config entry. The IP,
+    port and TLS flag are surfaced as attributes so the device page shows where
+    WiFi delivery connects. Backed entirely by config-entry data, so it stays
+    available and meaningful while the device is asleep. The config entry is
+    reloaded whenever mDNS updates the host, which recreates this entity, so
+    reading ``entry.data`` on each access always reflects the current endpoint.
+    """
+
+    _attr_has_entity_name = True
+    _attr_translation_key = "wifi"
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+
+    def __init__(self, entry: OpenDisplayConfigEntry) -> None:
+        """Initialize from the config entry that stores the LAN endpoint."""
+        self._entry = entry
+        address = entry.unique_id or ""
+        self._attr_unique_id = f"{address}-wifi"
+        self._attr_device_info = DeviceInfo(
+            connections={(CONNECTION_BLUETOOTH, address)},
+        )
+
+    @property
+    def is_on(self) -> bool:
+        """True when a LAN endpoint (IP) is configured for this device."""
+        return bool(self._entry.data.get(CONF_HOST))
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Expose the LAN endpoint while WiFi is enabled."""
+        host = self._entry.data.get(CONF_HOST)
+        if not host:
+            return {}
+        return {
+            "ip_address": host,
+            "port": int(self._entry.data.get(CONF_PORT) or DEFAULT_LAN_PORT),
+            "tls": bool(self._entry.data.get(CONF_TLS)),
+        }

--- a/custom_components/opendisplay/ble_lock.py
+++ b/custom_components/opendisplay/ble_lock.py
@@ -1,0 +1,78 @@
+"""Process-global per-MAC BLE connection lock for OpenDisplay tags.
+
+An OpenDisplay tag exposes a single BLE link and the library holds no
+per-address lock, so every host-side connect to a given MAC must be serialized
+or overlapping connects race and wedge BlueZ (the dongle-only config-read
+investigation, 2026-07-16). The lock has to be *process-global and keyed by
+MAC* rather than per config entry, because two of the connect sites run before
+(or without) a config entry: the config-flow probe and the entry-setup
+interrogation. A per-entry lock leaves those two unguarded against each other
+and against a reloading entry.
+
+``WeakValueDictionary`` here is **load-bearing, not hygiene**: an
+``asyncio.Lock`` binds to the event loop that first acquires it, and
+pytest-asyncio spins up a fresh loop per test while the test modules reuse one
+``ADDRESS`` constant. A plain ``dict`` would cache a lock bound to a now-dead
+loop and raise ``RuntimeError`` on the next test's acquire. Weak references let
+the entry drop the moment nothing holds the lock, so each test's first
+``async_get_ble_lock`` mints a lock bound to that test's live loop. In
+production the same weakness is harmless: a lock lingers only while a connect
+holds it and is otherwise collected.
+"""
+
+import asyncio
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+import logging
+from weakref import WeakValueDictionary
+
+from homeassistant.helpers.device_registry import format_mac
+
+_LOGGER = logging.getLogger(__name__)
+
+# Normalized MAC -> lock serializing every BLE connect to that tag. Weak values
+# so a lock is collected once nothing references it (see module docstring).
+_LOCKS: WeakValueDictionary[str, asyncio.Lock] = WeakValueDictionary()
+# Normalized MAC -> purpose string of the operation currently holding the lock,
+# used only to name the holder in the contention WARNING.
+_HOLDERS: dict[str, str] = {}
+
+
+def async_get_ble_lock(address: str) -> asyncio.Lock:
+    """Return the shared BLE lock for ``address``, creating it on first use.
+
+    ``address`` is normalized with ``format_mac`` because config_flow keys off
+    raw discovery addresses while everything else uses ``entry.unique_id``; both
+    must map to the same lock. There is no ``await`` between the lookup and the
+    insert, so this is atomic on the event loop.
+    """
+    key = format_mac(address)
+    if (lock := _LOCKS.get(key)) is None:
+        _LOCKS[key] = lock = asyncio.Lock()
+    return lock
+
+
+@asynccontextmanager
+async def ble_connection(address: str, purpose: str) -> AsyncIterator[None]:
+    """Hold the shared per-MAC BLE lock for the duration of a connection.
+
+    Emits a WARNING (before awaiting the lock) when the link is already held,
+    naming both the waiting ``purpose`` and the current holder, so overlapping
+    connect attempts on the same tag are diagnosable.
+    """
+    key = format_mac(address)
+    lock = async_get_ble_lock(address)
+    if lock.locked():
+        _LOGGER.warning(
+            "%s: BLE connection for %s requested while %s holds the device's "
+            "single BLE link; waiting for it to finish",
+            address,
+            purpose,
+            _HOLDERS.get(key, "another operation"),
+        )
+    async with lock:
+        _HOLDERS[key] = purpose
+        try:
+            yield
+        finally:
+            _HOLDERS.pop(key, None)

--- a/custom_components/opendisplay/config_flow.py
+++ b/custom_components/opendisplay/config_flow.py
@@ -39,6 +39,7 @@ from homeassistant.helpers.selector import (
     SelectSelectorMode,
 )
 
+from .ble_lock import ble_connection
 from .const import (
     CONF_BLOCKS_PER_ACK,
     CONF_ENCRYPTION_KEY,
@@ -156,7 +157,9 @@ class OpenDisplayConfigFlow(ConfigFlow, domain=DOMAIN):
         # maps to "cannot_connect"; AuthenticationRequiredError still propagates.
         try:
             async with asyncio.timeout(CONNECT_PROBE_DEADLINE_S):
-                async with OpenDisplayDevice(
+                async with ble_connection(
+                    address, "connection probe (config flow)"
+                ), OpenDisplayDevice(
                     mac_address=address,
                     ble_device=ble_device,
                     encryption_key=encryption_key,

--- a/custom_components/opendisplay/config_flow.py
+++ b/custom_components/opendisplay/config_flow.py
@@ -2,6 +2,7 @@
 
 import asyncio
 from collections.abc import Mapping
+import contextlib
 import logging
 from typing import TYPE_CHECKING, Any
 
@@ -38,30 +39,55 @@ from homeassistant.helpers.selector import (
     SelectSelectorConfig,
     SelectSelectorMode,
 )
+from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 
 from .ble_lock import ble_connection
 from .const import (
     CONF_BLOCKS_PER_ACK,
     CONF_ENCRYPTION_KEY,
+    CONF_HOST,
     CONF_MAX_QUEUE_SIZE,
     CONF_MISSED_CYCLES,
+    CONF_PORT,
     CONF_PROBE_BEFORE_QUEUE,
     CONF_QUEUE_TIMEOUT_HOURS,
     CONF_SLEEP_MODE,
+    CONF_TLS,
     CONNECT_PROBE_DEADLINE_S,
     DEFAULT_BLOCKS_PER_ACK,
+    DEFAULT_LAN_PORT,
     DEFAULT_MAX_QUEUE_SIZE,
     DEFAULT_MISSED_CYCLES,
     DEFAULT_PROBE_BEFORE_QUEUE,
     DEFAULT_QUEUE_TIMEOUT_HOURS,
     DEFAULT_SLEEP_MODE,
+    DEFAULT_TLS_PORT,
     DOMAIN,
     SLEEP_MODE_AUTO,
     SLEEP_MODE_OFF,
     SLEEP_MODE_ON,
+    TCP_CONNECT_TIMEOUT_S,
 )
+from .transport import note_mdns_seen
 
 _LOGGER = logging.getLogger(__name__)
+
+
+def _txt_str(properties: Mapping[str, Any], key: str) -> str | None:
+    """Read a zeroconf TXT value as a stripped str (bytes tolerated), or None."""
+    value = properties.get(key)
+    if value is None:
+        return None
+    if isinstance(value, bytes):
+        value = value.decode("utf-8", "ignore")
+    text = str(value).strip()
+    return text or None
+
+
+def _txt_bool(properties: Mapping[str, Any], key: str) -> bool:
+    """Interpret a zeroconf TXT flag as boolean (``1``/``true``/``yes`` → True)."""
+    value = _txt_str(properties, key)
+    return value is not None and value.lower() in ("1", "true", "yes")
 
 
 def _options_schema() -> vol.Schema:
@@ -136,6 +162,11 @@ class OpenDisplayConfigFlow(ConfigFlow, domain=DOMAIN):
         """Initialize the config flow."""
         self._discovery_info: BluetoothServiceInfoBleak | None = None
         self._discovered_devices: dict[str, BluetoothServiceInfoBleak] = {}
+        # Zeroconf (WiFi/LAN) discovery of a not-yet-configured device.
+        self._zeroconf_host: str | None = None
+        self._zeroconf_port: int = DEFAULT_LAN_PORT
+        self._zeroconf_tls: bool = False
+        self._zeroconf_name: str = ""
 
     @staticmethod
     @callback
@@ -169,6 +200,113 @@ class OpenDisplayConfigFlow(ConfigFlow, domain=DOMAIN):
             raise BLEConnectionError(
                 f"Connection probe exceeded {CONNECT_PROBE_DEADLINE_S:.0f}s"
             ) from err
+
+    async def _async_test_connection_tcp(self, host: str, port: int) -> None:
+        """Probe a TCP/LAN endpoint for reachability (zeroconf confirm step).
+
+        A lightweight reachability check: open a TCP connection with a short
+        timeout, then close it immediately. It does not speak the protocol (no
+        interrogation) — full interrogation happens at entry setup, over WiFi or a
+        BLE fallback. Deliberately separate from the BLE-only
+        ``_async_test_connection`` so the two transports' probes stay independent.
+
+        Raises:
+            OSError / TimeoutError: if the endpoint is unreachable.
+        """
+        async with asyncio.timeout(TCP_CONNECT_TIMEOUT_S):
+            _reader, writer = await asyncio.open_connection(host, port)
+        writer.close()
+        with contextlib.suppress(OSError):
+            await writer.wait_closed()
+
+    async def async_step_zeroconf(
+        self, discovery_info: ZeroconfServiceInfo
+    ) -> ConfigFlowResult:
+        """Handle a WiFi (mDNS) discovery of an OpenDisplay device.
+
+        The device is identified by its BLE MAC (the ``mac`` TXT key), so a
+        WiFi-discovered tag dedups onto its existing BLE entry (and vice versa):
+        the unique_id is the uppercase-colon MAC, matching the raw BlueZ form the
+        bluetooth step stores. An already-configured entry just gains
+        host/port/tls (and an mDNS-presence timestamp so the resolver can prefer
+        WiFi); a brand-new device goes through a confirm step.
+        """
+        properties = discovery_info.properties
+        mac = _txt_str(properties, "mac")
+        if not mac:
+            # Identity is anchored on the BLE MAC (SECTION 9); without it the
+            # device can't be correlated with a BLE entry — ignore the record.
+            return self.async_abort(reason="no_mac")
+
+        unique_id = mac.upper()
+        await self.async_set_unique_id(unique_id)
+
+        tls = _txt_bool(properties, "tls")
+        host = discovery_info.host
+        port = discovery_info.port or (DEFAULT_TLS_PORT if tls else DEFAULT_LAN_PORT)
+
+        # Feed mDNS presence to an already-loaded entry before the abort below
+        # short-circuits: this doubles as a "device seen" wake trigger (union of
+        # BLE advert + mDNS) and refreshes the WiFi-preference freshness window.
+        self._async_note_mdns_for_configured(unique_id)
+
+        # Existing entry (BLE or WiFi): merge in the live host/port/tls and abort.
+        self._abort_if_unique_id_configured(
+            updates={CONF_HOST: host, CONF_PORT: port, CONF_TLS: tls}
+        )
+
+        # New device discovered over WiFi first — confirm, then create the entry.
+        self._zeroconf_host = host
+        self._zeroconf_port = port
+        self._zeroconf_tls = tls
+        self._zeroconf_name = discovery_info.name.removesuffix(
+            "._opendisplay._tcp.local."
+        ) or host
+        self.context["title_placeholders"] = {"name": self._zeroconf_name}
+        return await self.async_step_zeroconf_confirm()
+
+    @callback
+    def _async_note_mdns_for_configured(self, unique_id: str) -> None:
+        """Record the mDNS sighting on a matching loaded entry, if any."""
+        for entry in self.hass.config_entries.async_entries(DOMAIN):
+            if entry.unique_id == unique_id:
+                note_mdns_seen(entry)
+                return
+
+    async def async_step_zeroconf_confirm(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Confirm a WiFi-discovered device and create its entry."""
+        assert self._zeroconf_host is not None
+        errors: dict[str, str] = {}
+        name = self.context["title_placeholders"]["name"]
+
+        if user_input is not None:
+            try:
+                await self._async_test_connection_tcp(
+                    self._zeroconf_host, self._zeroconf_port
+                )
+            except (OSError, TimeoutError):
+                errors["base"] = "cannot_connect"
+            except Exception:  # noqa: BLE001
+                _LOGGER.exception("Unexpected error probing WiFi device")
+                errors["base"] = "unknown"
+            else:
+                return self.async_create_entry(
+                    title=name,
+                    data={
+                        CONF_HOST: self._zeroconf_host,
+                        CONF_PORT: self._zeroconf_port,
+                        CONF_TLS: self._zeroconf_tls,
+                    },
+                )
+
+        self._set_confirm_only()
+        return self.async_show_form(
+            step_id="zeroconf_confirm",
+            description_placeholders={"name": name},
+            errors=errors,
+        )
 
     async def async_step_bluetooth(
         self, discovery_info: BluetoothServiceInfoBleak

--- a/custom_components/opendisplay/const.py
+++ b/custom_components/opendisplay/const.py
@@ -1,7 +1,36 @@
 """Constants for the OpenDisplay integration."""
 
+from datetime import timedelta
+
 DOMAIN = "opendisplay"
 CONF_ENCRYPTION_KEY = "encryption_key"
+
+# --- WiFi (LAN) transport ---------------------------------------------------
+# Entry-data keys for a WiFi-reachable device (protocol 2.2 SECTION 9). Reuse
+# the Home Assistant const string values ("host"/"port") so the keys are
+# interchangeable with homeassistant.const.CONF_HOST/CONF_PORT; CONF_TLS stores
+# the mDNS ``tls`` flag so the resolver knows which channel (plaintext vs
+# TLS-PSK) the device is serving.
+CONF_HOST = "host"
+CONF_PORT = "port"
+CONF_TLS = "tls"
+
+# Default LAN ports (SECTION 9). Plaintext is the configured base port; TLS is
+# derived as base + 1. Clients learn the live port from the mDNS SRV record.
+DEFAULT_LAN_PORT = 2446
+DEFAULT_TLS_PORT = 2447
+
+# Prefer WiFi only when the device was seen via mDNS within this window. The SRV
+# record TTL is 120 s, so 10 min gives comfortable margin: a device that has
+# stopped announcing (powered off, left the network) ages out and delivery
+# falls back to BLE rather than stalling on a dead TCP connect.
+MDNS_FRESHNESS_WINDOW = timedelta(minutes=10)
+MDNS_FRESHNESS_WINDOW_S = MDNS_FRESHNESS_WINDOW.total_seconds()
+
+# TCP connect timeout for the config-flow reachability probe and the delivery
+# WiFi attempt. Short: a reachable LAN device connects in well under a second,
+# so 5 s only bounds an unreachable/stale host before falling back to BLE.
+TCP_CONNECT_TIMEOUT_S = 5.0
 
 # Dispatcher signals (suffixed with the device address at send/subscribe time).
 # Carries the JPEG preview of the frame shown by the image entity.

--- a/custom_components/opendisplay/delivery.py
+++ b/custom_components/opendisplay/delivery.py
@@ -44,6 +44,7 @@ from homeassistant.helpers.device_registry import CONNECTION_BLUETOOTH
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.helpers.event import async_call_later
 
+from .ble_lock import ble_connection
 from .const import (
     CONF_BLOCKS_PER_ACK,
     CONF_ENCRYPTION_KEY,
@@ -307,7 +308,7 @@ class DeliveryManager:
             return
 
         runtime = self._entry.runtime_data
-        async with runtime.ble_lock:
+        async with ble_connection(self._address, "queued content delivery"):
             ble_device = async_ble_device_from_address(
                 self._hass, self._address, connectable=True
             )

--- a/custom_components/opendisplay/delivery.py
+++ b/custom_components/opendisplay/delivery.py
@@ -36,7 +36,6 @@ from opendisplay import (
     RefreshMode,
 )
 
-from homeassistant.components.bluetooth import async_ble_device_from_address
 from homeassistant.core import CALLBACK_TYPE, HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import device_registry as dr
@@ -56,6 +55,7 @@ from .const import (
     SIGNAL_IMAGE_UPDATED,
     SIGNAL_PENDING_STATE,
 )
+from .transport import async_run_with_fallback
 
 if TYPE_CHECKING:
     from . import OpenDisplayConfigEntry
@@ -308,37 +308,46 @@ class DeliveryManager:
             return
 
         runtime = self._entry.runtime_data
-        async with ble_connection(self._address, "queued content delivery"):
-            ble_device = async_ble_device_from_address(
-                self._hass, self._address, connectable=True
-            )
-            if ble_device is None:
-                # The advertisement that woke us has already aged out; retry next.
-                self._register_attempt_failure("device not connectable")
-                return
+        upload = self._pending_upload
+        use_measured = upload.use_measured_palettes if upload else True
+        base_kwargs: dict[str, Any] = {
+            "config": runtime.device_config,
+            "use_measured_palettes": use_measured,
+            "encryption_key": key,
+            "blocks_per_ack": self._entry.options.get(
+                CONF_BLOCKS_PER_ACK, DEFAULT_BLOCKS_PER_ACK
+            ),
+            "max_queue_size": self._entry.options.get(
+                CONF_MAX_QUEUE_SIZE, DEFAULT_MAX_QUEUE_SIZE
+            ),
+        }
 
-            upload = self._pending_upload
-            use_measured = upload.use_measured_palettes if upload else True
-            async with (
-                asyncio.timeout(DELIVERY_DEADLINE_S),
-                OpenDisplayDevice(
-                    mac_address=self._address,
-                    ble_device=ble_device,
-                    config=runtime.device_config,
-                    use_measured_palettes=use_measured,
-                    encryption_key=key,  # type: ignore[arg-type]
-                    blocks_per_ack=self._entry.options.get(
-                        CONF_BLOCKS_PER_ACK, DEFAULT_BLOCKS_PER_ACK
-                    ),
-                    max_queue_size=self._entry.options.get(
-                        CONF_MAX_QUEUE_SIZE, DEFAULT_MAX_QUEUE_SIZE
-                    ),
-                ) as device,
-            ):
-                if upload is not None and not upload.paused:
-                    await self._drain_upload(device, upload)
-                if self._pending_config_resync:
-                    await self._drain_resync(device)
+        async def _run(device: OpenDisplayDevice) -> None:
+            # Re-read pending state each invocation: if a WiFi attempt uploaded
+            # then failed on resync, the BLE fallback re-runs this and must not
+            # re-upload an already-delivered frame (``_drain_upload`` clears it).
+            pending = self._pending_upload
+            if pending is not None and not pending.paused:
+                await self._drain_upload(device, pending)
+            if self._pending_config_resync:
+                await self._drain_resync(device)
+
+        # Prefer WiFi when the entry has a fresh mDNS host; fall back to BLE on any
+        # WiFi failure. All inside the per-MAC lock (MAC-keyed, transport-neutral).
+        # A missing connectable BLE device raises BLEConnectionError, which
+        # ``_deliver`` turns into a retry-next-wake attempt failure — the same
+        # outcome as the previous inline "device not connectable" check.
+        async with (
+            ble_connection(self._address, "queued content delivery"),
+            asyncio.timeout(DELIVERY_DEADLINE_S),
+        ):
+            await async_run_with_fallback(
+                self._hass,
+                self._entry,
+                _run,
+                base_kwargs=base_kwargs,
+                ble_unavailable=lambda: BLEConnectionError("device not connectable"),
+            )
 
     async def _drain_upload(
         self, device: OpenDisplayDevice, upload: PendingUpload

--- a/custom_components/opendisplay/diagnostics.py
+++ b/custom_components/opendisplay/diagnostics.py
@@ -7,6 +7,7 @@ from homeassistant.components.diagnostics import async_redact_data
 from homeassistant.core import HomeAssistant
 
 from . import OpenDisplayConfigEntry
+from .const import CONF_HOST, CONF_PORT, CONF_TLS
 
 TO_REDACT = {"ssid", "password", "server_url"}
 
@@ -52,6 +53,20 @@ async def async_get_config_entry_diagnostics(
             "last_error": state.last_error,
         }
 
+    # Transport diagnostics: WiFi/LAN endpoint (host/port/tls are not secret; the
+    # redaction set already covers ssid/password/server_url), the last transport a
+    # delivery used, and how recently the device was seen via mDNS. host is None
+    # for a pure-BLE entry.
+    system = getattr(runtime.device_config, "system", None)
+    transport_diag: dict[str, Any] = {
+        "host": entry.data.get(CONF_HOST),
+        "port": entry.data.get(CONF_PORT),
+        "tls": entry.data.get(CONF_TLS),
+        "last_transport": getattr(runtime, "last_transport", None),
+        "mdns_last_seen": getattr(runtime, "mdns_last_seen", None),
+        "communication_modes": getattr(system, "communication_modes", None),
+    }
+
     return {
         "firmware": {
             "major": fw["major"],
@@ -61,5 +76,6 @@ async def async_get_config_entry_diagnostics(
         },
         "is_flex": runtime.is_flex,
         "sleep": sleep_diag,
+        "transport": transport_diag,
         "device_config": async_redact_data(_asdict(runtime.device_config), TO_REDACT),
     }

--- a/custom_components/opendisplay/icons.json
+++ b/custom_components/opendisplay/icons.json
@@ -6,6 +6,12 @@
         "state": {
           "off": "mdi:image-check"
         }
+      },
+      "wifi": {
+        "default": "mdi:wifi",
+        "state": {
+          "off": "mdi:wifi-off"
+        }
       }
     },
     "update": {

--- a/custom_components/opendisplay/manifest.json
+++ b/custom_components/opendisplay/manifest.json
@@ -15,7 +15,7 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/OpenDisplay/Home_Assistant_Integration/issues",
   "loggers": ["opendisplay"],
-  "requirements": ["py-opendisplay[silabs-ota]@git+https://github.com/davelee98/py-opendisplay.git@feat/wifi-transport", "odl-renderer==0.5.12"],
+  "requirements": ["py-opendisplay[silabs-ota]==7.14.2", "odl-renderer==0.5.12"],
   "version": "3.0.0-beta.9",
   "zeroconf": ["_opendisplay._tcp.local."]
 }

--- a/custom_components/opendisplay/manifest.json
+++ b/custom_components/opendisplay/manifest.json
@@ -16,5 +16,6 @@
   "issue_tracker": "https://github.com/OpenDisplay/Home_Assistant_Integration/issues",
   "loggers": ["opendisplay"],
   "requirements": ["py-opendisplay[silabs-ota]==7.14.1", "odl-renderer==0.5.12"],
-  "version": "3.0.0-beta.9"
+  "version": "3.0.0-beta.9",
+  "zeroconf": ["_opendisplay._tcp.local."]
 }

--- a/custom_components/opendisplay/manifest.json
+++ b/custom_components/opendisplay/manifest.json
@@ -15,7 +15,7 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/OpenDisplay/Home_Assistant_Integration/issues",
   "loggers": ["opendisplay"],
-  "requirements": ["py-opendisplay[silabs-ota]==7.14.1", "odl-renderer==0.5.12"],
+  "requirements": ["py-opendisplay[silabs-ota]@git+https://github.com/davelee98/py-opendisplay.git@feat/wifi-transport", "odl-renderer==0.5.12"],
   "version": "3.0.0-beta.9",
   "zeroconf": ["_opendisplay._tcp.local."]
 }

--- a/custom_components/opendisplay/services.py
+++ b/custom_components/opendisplay/services.py
@@ -41,7 +41,6 @@ import voluptuous as vol
 from homeassistant.components.bluetooth import (
     BluetoothReachabilityIntent,
     async_address_reachability_diagnostics,
-    async_ble_device_from_address,
 )
 from homeassistant.components.http.auth import async_sign_path
 from homeassistant.components.media_source import async_resolve_media
@@ -76,6 +75,7 @@ from .const import (
     SIGNAL_IMAGE_UPDATED,
 )
 from .delivery import DELIVERY_DEADLINE_S, DeliveryReceipt
+from .transport import async_run_with_fallback
 
 ATTR_IMAGE = "image"
 ATTR_ROTATION = "rotation"
@@ -401,11 +401,17 @@ async def _async_connect_and_run(
     """
     address = entry.unique_id
     assert address is not None
-    ble_device = async_ble_device_from_address(hass, address, connectable=True)
-    if ble_device is None:
+
+    def _ble_unavailable() -> BaseException:
+        """Build the error to raise when no connectable BLE device exists.
+
+        Called by the transport helper only when BLE is the selected (or
+        fallen-back-to) transport and the device is not connectable — a WiFi
+        delivery that succeeds never reaches this.
+        """
         if reraise_ble:
-            raise _DeviceUnavailable
-        raise HomeAssistantError(
+            return _DeviceUnavailable()
+        return HomeAssistantError(
             translation_domain=DOMAIN,
             translation_key="device_not_found",
             translation_placeholders={
@@ -440,44 +446,49 @@ async def _async_connect_and_run(
             translation_domain=DOMAIN, translation_key="authentication_error"
         ) from err
 
-    device_kwargs: dict[str, Any] = {}
+    base_kwargs: dict[str, Any] = {
+        "config": entry.runtime_data.device_config,
+        "use_measured_palettes": use_measured_palettes,
+        "encryption_key": encryption_key,
+    }
     if connect_timeout is not None:
-        device_kwargs["timeout"] = connect_timeout
+        base_kwargs["timeout"] = connect_timeout
     if max_attempts is not None:
-        device_kwargs["max_attempts"] = max_attempts
+        base_kwargs["max_attempts"] = max_attempts
     # Sliding-window pipe-transfer tuning (max_queue_size == 1 disables it).
     options = entry.options
-    device_kwargs["blocks_per_ack"] = options.get(
+    base_kwargs["blocks_per_ack"] = options.get(
         CONF_BLOCKS_PER_ACK, DEFAULT_BLOCKS_PER_ACK
     )
-    device_kwargs["max_queue_size"] = options.get(
+    base_kwargs["max_queue_size"] = options.get(
         CONF_MAX_QUEUE_SIZE, DEFAULT_MAX_QUEUE_SIZE
     )
 
     try:
-        # Serialize all BLE access to this tag: the device has a single BLE link
-        # and the library has no per-address lock, so overlapping connections
-        # (two automations, or a drawcustom racing an LED/buzzer/upload on the
-        # same MAC) fail with a confusing upload_error. The lock is held for the
-        # full connection lifetime and released on error. Keyed per MAC, so
-        # different tags are not serialized against each other.
+        # Serialize all access to this tag: the device has a single link (BLE or
+        # the one-client WiFi/LAN endpoint) and the library has no per-address
+        # lock, so overlapping connections (two automations, or a drawcustom
+        # racing an LED/buzzer/upload on the same MAC) fail with a confusing
+        # upload_error. The lock is MAC-keyed — hence transport-neutral — held for
+        # the full connection lifetime and released on error, so different tags
+        # are not serialized against each other.
         # Same wall-clock ceiling as the queued-delivery drain: without it a
         # wedged transfer would hold the lock forever and block every later
         # operation on this MAC (the library's per-read timeouts bound normal
         # failures, but not adversarial/buggy-firmware frame streams).
+        # The transport helper prefers WiFi when the entry has a fresh mDNS host
+        # and falls back to BLE on any WiFi failure, all inside this lock.
         async with (
             asyncio.timeout(DELIVERY_DEADLINE_S),
             ble_connection(address, "service call (upload/drawcustom/LED/buzzer)"),
-            OpenDisplayDevice(
-                mac_address=address,
-                ble_device=ble_device,
-                config=entry.runtime_data.device_config,
-                use_measured_palettes=use_measured_palettes,
-                encryption_key=encryption_key,
-                **device_kwargs,
-            ) as device,
         ):
-            await action(device)
+            await async_run_with_fallback(
+                hass,
+                entry,
+                action,
+                base_kwargs=base_kwargs,
+                ble_unavailable=_ble_unavailable,
+            )
     except TimeoutError as err:
         raise HomeAssistantError(
             translation_domain=DOMAIN,

--- a/custom_components/opendisplay/services.py
+++ b/custom_components/opendisplay/services.py
@@ -65,6 +65,7 @@ from homeassistant.helpers.selector import MediaSelector, MediaSelectorConfig
 if TYPE_CHECKING:
     from . import OpenDisplayConfigEntry
 
+from .ble_lock import ble_connection
 from .const import (
     CONF_BLOCKS_PER_ACK,
     CONF_ENCRYPTION_KEY,
@@ -458,15 +459,15 @@ async def _async_connect_and_run(
         # and the library has no per-address lock, so overlapping connections
         # (two automations, or a drawcustom racing an LED/buzzer/upload on the
         # same MAC) fail with a confusing upload_error. The lock is held for the
-        # full connection lifetime and released on error. Held per config entry,
-        # i.e. per MAC, so different tags are not serialized against each other.
+        # full connection lifetime and released on error. Keyed per MAC, so
+        # different tags are not serialized against each other.
         # Same wall-clock ceiling as the queued-delivery drain: without it a
-        # wedged transfer would hold ble_lock forever and block every later
+        # wedged transfer would hold the lock forever and block every later
         # operation on this MAC (the library's per-read timeouts bound normal
         # failures, but not adversarial/buggy-firmware frame streams).
         async with (
             asyncio.timeout(DELIVERY_DEADLINE_S),
-            entry.runtime_data.ble_lock,
+            ble_connection(address, "service call (upload/drawcustom/LED/buzzer)"),
             OpenDisplayDevice(
                 mac_address=address,
                 ble_device=ble_device,

--- a/custom_components/opendisplay/services.yaml
+++ b/custom_components/opendisplay/services.yaml
@@ -208,6 +208,8 @@ activate_led:
           mode: slider
 
 activate_buzzer:
+  name: Activate buzzer
+  description: Plays a tone on an OpenDisplay device's buzzer.
   fields:
     device_id:
       required: true
@@ -215,6 +217,8 @@ activate_buzzer:
         device:
           integration: opendisplay
     instance:
+      name: Buzzer instance
+      description: Buzzer instance index (0-based) for devices with more than one buzzer.
       required: false
       default: 0
       selector:
@@ -223,6 +227,12 @@ activate_buzzer:
           max: 3
           mode: box
     frequency_hz:
+      name: Frequency
+      description: >
+        Tone frequency in Hz (0 = silence). Played as the nearest quarter-tone
+        note. The buzzer's playable range is roughly ~403 Hz to ~11840 Hz,
+        expressed in Hz for convenience; pitches outside that range are shifted
+        by whole octaves by the firmware to protect the speaker hardware.
       required: false
       default: 1000
       selector:
@@ -232,6 +242,8 @@ activate_buzzer:
           mode: box
           unit_of_measurement: Hz
     duration_ms:
+      name: Duration
+      description: Tone duration in milliseconds (5–1275, in 5 ms steps).
       required: false
       default: 100
       selector:
@@ -241,6 +253,8 @@ activate_buzzer:
           mode: box
           unit_of_measurement: ms
     repeats:
+      name: Repeats
+      description: Number of times to repeat the tone (1–255).
       required: false
       default: 1
       selector:

--- a/custom_components/opendisplay/strings.json
+++ b/custom_components/opendisplay/strings.json
@@ -5,6 +5,7 @@
       "already_in_progress": "[%key:common::config_flow::abort::already_in_progress%]",
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
       "no_devices_found": "[%key:common::config_flow::abort::no_devices_found%]",
+      "no_mac": "The discovered device did not advertise a MAC address and cannot be set up.",
       "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]",
       "unknown": "[%key:common::config_flow::error::unknown%]"
     },
@@ -18,6 +19,10 @@
     "step": {
       "bluetooth_confirm": {
         "description": "[%key:component::bluetooth::config::step::bluetooth_confirm::description%]"
+      },
+      "zeroconf_confirm": {
+        "description": "Do you want to set up {name}, discovered over WiFi?",
+        "title": "OpenDisplay device found"
       },
       "encryption_key": {
         "data": {

--- a/custom_components/opendisplay/strings.json
+++ b/custom_components/opendisplay/strings.json
@@ -81,6 +81,9 @@
     "binary_sensor": {
       "update_pending": {
         "name": "Update pending"
+      },
+      "wifi": {
+        "name": "WiFi"
       }
     },
     "image": {

--- a/custom_components/opendisplay/strings.json
+++ b/custom_components/opendisplay/strings.json
@@ -372,7 +372,7 @@
         },
         "frequency_hz": {
           "name": "Frequency",
-          "description": "Tone frequency in Hz (0 = silence, 400-12000)."
+          "description": "Tone frequency in Hz (0 = silence). Played as the nearest quarter-tone note; frequencies outside the buzzer's playable range are shifted by octaves to fit."
         },
         "duration_ms": {
           "name": "Duration",

--- a/custom_components/opendisplay/translations/en.json
+++ b/custom_components/opendisplay/translations/en.json
@@ -81,6 +81,9 @@
         "binary_sensor": {
             "update_pending": {
                 "name": "Update pending"
+            },
+            "wifi": {
+                "name": "WiFi"
             }
         },
         "image": {

--- a/custom_components/opendisplay/translations/en.json
+++ b/custom_components/opendisplay/translations/en.json
@@ -5,6 +5,7 @@
             "already_in_progress": "Configuration flow is already in progress",
             "cannot_connect": "Failed to connect",
             "no_devices_found": "No devices found on the network",
+            "no_mac": "The discovered device did not advertise a MAC address and cannot be set up.",
             "reauth_successful": "Re-authentication was successful",
             "unknown": "Unexpected error"
         },
@@ -47,6 +48,10 @@
                     "address": "Select the Bluetooth device to set up."
                 },
                 "description": "Choose a device to set up"
+            },
+            "zeroconf_confirm": {
+                "description": "Do you want to set up {name}, discovered over WiFi?",
+                "title": "OpenDisplay device found"
             }
         }
     },

--- a/custom_components/opendisplay/translations/en.json
+++ b/custom_components/opendisplay/translations/en.json
@@ -368,7 +368,7 @@
                 },
                 "frequency_hz": {
                     "name": "Frequency",
-                    "description": "Tone frequency in Hz (0 = silence, 400-12000)."
+                    "description": "Tone frequency in Hz (0 = silence). Played as the nearest quarter-tone note; frequencies outside the buzzer's playable range are shifted by octaves to fit."
                 },
                 "duration_ms": {
                     "name": "Duration",

--- a/custom_components/opendisplay/transport.py
+++ b/custom_components/opendisplay/transport.py
@@ -1,0 +1,196 @@
+"""Transport resolution for OpenDisplay deliveries (BLE vs WiFi/LAN).
+
+A single OpenDisplay tag exposes at most one BLE link *and*, when WiFi-enabled,
+a TCP/LAN endpoint discovered via mDNS (protocol 2.2 SECTION 9). Both transports
+address the same device by its BLE MAC (the config entry's ``unique_id``), so the
+process-global per-MAC lock in ``ble_lock.py`` serializes them transparently —
+this module never touches the lock; callers hold it around the whole delivery.
+
+Resolution rule (H3): prefer WiFi when the entry carries a ``CONF_HOST`` *and* the
+device was seen via mDNS within ``MDNS_FRESHNESS_WINDOW`` (fed by the zeroconf
+config-flow step, see ``note_mdns_seen``); otherwise use BLE. Any WiFi failure
+(unreachable / connect / TLS handshake / mid-transfer / stale port) falls back to
+BLE for that same delivery — a hard requirement — via ``async_run_with_fallback``.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+import logging
+import time
+from typing import TYPE_CHECKING, Any
+
+from opendisplay import (
+    OpenDisplayConnectionError,
+    OpenDisplayDevice,
+    OpenDisplayTimeoutError,
+)
+
+from homeassistant.components.bluetooth import async_ble_device_from_address
+from homeassistant.core import HomeAssistant
+
+from .const import (
+    CONF_HOST,
+    CONF_PORT,
+    CONF_TLS,
+    DEFAULT_LAN_PORT,
+    MDNS_FRESHNESS_WINDOW_S,
+)
+
+if TYPE_CHECKING:
+    from . import OpenDisplayConfigEntry
+
+_LOGGER = logging.getLogger(__name__)
+
+# Transport labels recorded on runtime data / surfaced in diagnostics.
+TRANSPORT_WIFI = "wifi"
+TRANSPORT_BLE = "ble"
+
+# Exceptions from a WiFi attempt that must trigger the BLE fallback. The neutral
+# py-opendisplay superclasses cover connect/read failures on any transport;
+# ``OSError`` (and its ``ssl.SSLError`` subclass) covers raw socket / TLS
+# handshake failures raised before the library wraps them. A genuine
+# ``ProtocolError`` is deliberately *not* here — it is a real device fault, not a
+# transport problem, and re-running it over BLE would just fail again.
+WIFI_FALLBACK_EXCEPTIONS: tuple[type[BaseException], ...] = (
+    OpenDisplayConnectionError,
+    OpenDisplayTimeoutError,
+    OSError,
+)
+
+
+@dataclass(frozen=True)
+class ResolvedTransport:
+    """The transport chosen for one delivery attempt."""
+
+    use_wifi: bool
+    host: str | None
+    port: int
+    tls: bool
+
+
+def resolve_transport(entry: OpenDisplayConfigEntry) -> ResolvedTransport:
+    """Decide which transport to use for the next connection to ``entry``.
+
+    WiFi is preferred only when the entry stores a host *and* the device has been
+    seen via mDNS recently (``MDNS_FRESHNESS_WINDOW``); otherwise BLE. An entry
+    with no ``CONF_HOST`` (every pre-WiFi entry) always resolves to BLE, so
+    existing installs need no migration.
+    """
+    data = entry.data
+    host = data.get(CONF_HOST)
+    port = int(data.get(CONF_PORT) or DEFAULT_LAN_PORT)
+    tls = bool(data.get(CONF_TLS))
+    if not host:
+        return ResolvedTransport(False, None, port, tls)
+
+    last_seen = _mdns_last_seen(entry)
+    fresh = last_seen is not None and (time.monotonic() - last_seen) <= MDNS_FRESHNESS_WINDOW_S
+    if not fresh:
+        _LOGGER.debug(
+            "%s: host %s known but mDNS presence stale/absent; using BLE",
+            entry.unique_id,
+            host,
+        )
+    return ResolvedTransport(fresh, host, port, tls)
+
+
+def _mdns_last_seen(entry: OpenDisplayConfigEntry) -> float | None:
+    """Return the monotonic timestamp of the last mDNS sighting, or None."""
+    runtime = getattr(entry, "runtime_data", None)
+    if runtime is None:
+        return None
+    return getattr(runtime, "mdns_last_seen", None)
+
+
+def note_mdns_seen(entry: OpenDisplayConfigEntry) -> None:
+    """Record that ``entry``'s device was just seen via mDNS.
+
+    Called from the zeroconf config-flow step for an already-configured entry so
+    the resolver can prefer WiFi, and so the delivery manager treats the mDNS
+    sighting as a wake (union of BLE-advert and mDNS presence).
+    """
+    runtime = getattr(entry, "runtime_data", None)
+    if runtime is None:
+        return
+    try:
+        runtime.mdns_last_seen = time.monotonic()
+    except AttributeError:  # pragma: no cover - runtime is always a mutable dataclass
+        return
+    delivery = getattr(runtime, "delivery", None)
+    if delivery is not None:
+        delivery.notify_device_seen("mdns")
+
+
+def record_last_transport(entry: OpenDisplayConfigEntry, transport: str) -> None:
+    """Store the transport a completed delivery used (surfaced in diagnostics)."""
+    runtime = getattr(entry, "runtime_data", None)
+    if runtime is None:
+        return
+    try:
+        runtime.last_transport = transport
+    except AttributeError:  # pragma: no cover
+        pass
+
+
+async def async_run_with_fallback(
+    hass: HomeAssistant,
+    entry: OpenDisplayConfigEntry,
+    action: Callable[[OpenDisplayDevice], Awaitable[None]],
+    *,
+    base_kwargs: dict[str, Any],
+    ble_unavailable: Callable[[], BaseException],
+) -> str:
+    """Open a device and run ``action`` over the resolved transport.
+
+    Tries WiFi first when :func:`resolve_transport` selects it; on any WiFi
+    transport failure (``WIFI_FALLBACK_EXCEPTIONS``) it falls back to BLE and
+    re-runs the *same* ``action`` over BLE before giving up. Returns the label of
+    the transport that completed the delivery.
+
+    Must be called inside the per-MAC ``ble_connection`` lock context (the lock is
+    MAC-keyed, hence transport-neutral). ``base_kwargs`` are the addressing-neutral
+    ``OpenDisplayDevice`` kwargs (config, encryption_key, tuning, timeouts); the
+    addressing kwargs (host/port/tls or ble_device/mac_address) are added here.
+    ``ble_unavailable`` builds the exception to raise when the BLE path is selected
+    (or fallen back to) but no connectable device exists — each caller supplies its
+    own (``_DeviceUnavailable`` / a translated ``device_not_found``).
+    """
+    address = entry.unique_id
+    assert address is not None
+    resolved = resolve_transport(entry)
+
+    if resolved.use_wifi:
+        try:
+            async with OpenDisplayDevice(
+                host=resolved.host,
+                port=resolved.port,
+                tls=resolved.tls,
+                **base_kwargs,
+            ) as device:
+                await action(device)
+        except WIFI_FALLBACK_EXCEPTIONS as err:
+            _LOGGER.warning(
+                "%s: WiFi delivery to %s:%s failed (%s); falling back to BLE",
+                address,
+                resolved.host,
+                resolved.port,
+                err,
+            )
+        else:
+            record_last_transport(entry, TRANSPORT_WIFI)
+            return TRANSPORT_WIFI
+
+    ble_device = async_ble_device_from_address(hass, address, connectable=True)
+    if ble_device is None:
+        raise ble_unavailable()
+
+    async with OpenDisplayDevice(
+        mac_address=address,
+        ble_device=ble_device,
+        **base_kwargs,
+    ) as device:
+        await action(device)
+    record_last_transport(entry, TRANSPORT_BLE)
+    return TRANSPORT_BLE

--- a/custom_components/opendisplay/update.py
+++ b/custom_components/opendisplay/update.py
@@ -32,6 +32,7 @@ from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from . import OpenDisplayConfigEntry, _get_encryption_key
+from .ble_lock import ble_connection
 from .const import DOMAIN
 from .entity import OpenDisplayEntity
 
@@ -253,7 +254,7 @@ class OpenDisplayFirmwareUpdateEntity(OpenDisplayEntity[UpdateEntityDescription]
             # half-connecting can't hold the lock forever (OTA_INSTALL_DEADLINE_S).
             async with (
                 asyncio.timeout(OTA_INSTALL_DEADLINE_S) as ota_deadline,
-                self._entry.runtime_data.ble_lock,
+                ble_connection(self._ble_address, "firmware update (OTA)"),
             ):
                 # Only EFR32BG22 (Silabs AppLoader) is flashed over BLE here — see
                 # _OTA_INSTALL_IC_TYPES. The device is either in app mode (and needs

--- a/tests/test_ble_lock.py
+++ b/tests/test_ble_lock.py
@@ -1,0 +1,128 @@
+"""Unit tests for the process-global per-MAC BLE connection lock.
+
+Exercises the registry keying (case-normalization, distinct MACs), the
+contention WARNING, holder bookkeeping, and the ``WeakValueDictionary``
+collection that keeps a lock from outliving the loop that bound it. These tests
+run on pytest-asyncio's per-test event loop while reusing one ``ADDRESS`` — the
+exact shape that would raise ``RuntimeError`` if the registry cached a
+loop-bound lock in a plain dict.
+"""
+
+import asyncio
+import gc
+import logging
+
+import pytest
+
+from homeassistant.helpers.device_registry import format_mac
+
+from custom_components.opendisplay.ble_lock import (
+    _HOLDERS,
+    _LOCKS,
+    async_get_ble_lock,
+    ble_connection,
+)
+
+ADDRESS = "AA:BB:CC:DD:EE:FF"
+_LOGGER_NAME = "custom_components.opendisplay.ble_lock"
+
+
+@pytest.mark.asyncio
+async def test_case_variant_addresses_share_one_lock():
+    """An upper- and lower-cased MAC resolve to the same lock object."""
+    upper = async_get_ble_lock("AA:BB:CC:DD:EE:FF")
+    lower = async_get_ble_lock("aa:bb:cc:dd:ee:ff")
+    assert upper is lower
+
+
+@pytest.mark.asyncio
+async def test_distinct_macs_get_distinct_locks():
+    """Different MACs are not serialized against each other."""
+    a = async_get_ble_lock("AA:BB:CC:DD:EE:FF")
+    b = async_get_ble_lock("11:22:33:44:55:66")
+    assert a is not b
+
+
+@pytest.mark.asyncio
+async def test_contended_connection_serializes_and_warns(caplog):
+    """A second connect on a held link warns (naming both ops) and waits."""
+    caplog.set_level(logging.WARNING, logger=_LOGGER_NAME)
+    order: list[str] = []
+    release_a = asyncio.Event()
+    a_holding = asyncio.Event()
+
+    async def op_a() -> None:
+        async with ble_connection(ADDRESS, "op-a"):
+            order.append("a-enter")
+            a_holding.set()
+            await release_a.wait()
+            order.append("a-exit")
+
+    async def op_b() -> None:
+        await a_holding.wait()
+        async with ble_connection(ADDRESS, "op-b"):
+            order.append("b-enter")
+
+    task_a = asyncio.create_task(op_a())
+    await a_holding.wait()
+    task_b = asyncio.create_task(op_b())
+    # Let B reach (and block on) the contended acquire while A still holds.
+    for _ in range(5):
+        await asyncio.sleep(0)
+    release_a.set()
+    await asyncio.gather(task_a, task_b)
+
+    # B's body runs only after A fully exits.
+    assert order == ["a-enter", "a-exit", "b-enter"]
+
+    warnings = [
+        r for r in caplog.records
+        if r.name == _LOGGER_NAME and r.levelno == logging.WARNING
+    ]
+    assert len(warnings) == 1
+    message = warnings[0].getMessage()
+    assert ADDRESS in message  # waiter's address
+    assert "op-b" in message   # the waiting purpose
+    assert "op-a" in message   # the current holder
+
+
+@pytest.mark.asyncio
+async def test_uncontended_connection_emits_no_warning(caplog):
+    """A connect on a free link logs nothing."""
+    caplog.set_level(logging.WARNING, logger=_LOGGER_NAME)
+    async with ble_connection(ADDRESS, "solo"):
+        pass
+
+    warnings = [
+        r for r in caplog.records
+        if r.name == _LOGGER_NAME and r.levelno == logging.WARNING
+    ]
+    assert warnings == []
+
+
+@pytest.mark.asyncio
+async def test_holder_cleared_after_exit():
+    """The holder entry is set while held and popped in the finally."""
+    key = format_mac(ADDRESS)
+    async with ble_connection(ADDRESS, "op"):
+        assert _HOLDERS[key] == "op"
+    assert key not in _HOLDERS
+
+
+@pytest.mark.asyncio
+async def test_unreferenced_lock_is_collected():
+    """Dropping the last reference lets the WeakValueDictionary evict the lock.
+
+    This is what lets the next test's first acquire mint a lock bound to that
+    test's live loop instead of resurrecting a dead-loop one.
+    """
+    key = format_mac(ADDRESS)
+    lock = async_get_ble_lock(ADDRESS)
+    assert _LOCKS.get(key) is lock
+    del lock
+    gc.collect()
+    assert key not in _LOCKS
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -5,17 +5,28 @@ exercised directly via ``_options_schema()`` — a plain voluptuous schema — s
 round-trip through it is exactly what the options flow persists.
 """
 
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
 import pytest
 import voluptuous as vol
 
-from custom_components.opendisplay.config_flow import _options_schema
+from homeassistant.data_entry_flow import AbortFlow
+
+from custom_components.opendisplay.config_flow import (
+    OpenDisplayConfigFlow,
+    _options_schema,
+)
 from custom_components.opendisplay.const import (
     CONF_BLOCKS_PER_ACK,
+    CONF_HOST,
     CONF_MAX_QUEUE_SIZE,
     CONF_MISSED_CYCLES,
+    CONF_PORT,
     CONF_PROBE_BEFORE_QUEUE,
     CONF_QUEUE_TIMEOUT_HOURS,
     CONF_SLEEP_MODE,
+    CONF_TLS,
     DEFAULT_BLOCKS_PER_ACK,
     DEFAULT_MAX_QUEUE_SIZE,
     DEFAULT_MISSED_CYCLES,
@@ -62,3 +73,158 @@ def test_options_schema_rejects_out_of_range(key, value):
     """Both options are bounded to the protocol's 1..32 window range."""
     with pytest.raises(vol.Invalid):
         _options_schema()({key: value})
+
+
+# -- zeroconf (WiFi/mDNS) discovery ----------------------------------------
+#
+# These drive the config-flow steps directly with the base-class HA touchpoints
+# mocked (no flow manager), mirroring the mocked-namespace style of the other
+# test modules. The unique_id is the uppercase-colon BLE MAC so a WiFi discovery
+# dedups onto an existing BLE entry.
+
+MAC_LOWER = "aa:bb:cc:dd:ee:ff"
+MAC_UPPER = "AA:BB:CC:DD:EE:FF"
+
+
+def _zeroconf_info(properties, *, host="1.2.3.4", port=2446, name=None):
+    """A ZeroconfServiceInfo stand-in (only the attributes the step reads)."""
+    return SimpleNamespace(
+        host=host,
+        port=port,
+        name=name if name is not None else "tag._opendisplay._tcp.local.",
+        properties=properties,
+    )
+
+
+def _flow(entries=()):
+    """A config flow with base-class HA methods mocked out."""
+    flow = OpenDisplayConfigFlow()
+    flow.hass = MagicMock()
+    flow.hass.config_entries.async_entries = MagicMock(return_value=list(entries))
+    flow.context = {}
+    flow.async_set_unique_id = AsyncMock()
+    flow._abort_if_unique_id_configured = MagicMock()
+    flow.async_abort = MagicMock(side_effect=lambda **kw: {"type": "abort", **kw})
+    flow.async_show_form = MagicMock(side_effect=lambda **kw: {"type": "form", **kw})
+    flow.async_create_entry = MagicMock(
+        side_effect=lambda **kw: {"type": "create_entry", **kw}
+    )
+    flow._set_confirm_only = MagicMock()
+    return flow
+
+
+@pytest.mark.asyncio
+async def test_zeroconf_missing_mac_aborts():
+    """A record without a mac TXT key cannot be correlated -> abort no_mac."""
+    flow = _flow()
+    result = await flow.async_step_zeroconf(_zeroconf_info({"tls": "0"}))
+
+    assert result["reason"] == "no_mac"
+    flow.async_set_unique_id.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_zeroconf_new_device_shows_confirm_and_uppercases_id():
+    """A never-configured device: unique_id uppercased, confirm form shown."""
+    flow = _flow(entries=[])
+    result = await flow.async_step_zeroconf(
+        _zeroconf_info({"mac": MAC_LOWER, "tls": "0"})
+    )
+
+    flow.async_set_unique_id.assert_awaited_once_with(MAC_UPPER)
+    flow._abort_if_unique_id_configured.assert_called_once()
+    assert result["type"] == "form"
+    assert result["step_id"] == "zeroconf_confirm"
+
+
+@pytest.mark.asyncio
+async def test_zeroconf_existing_ble_entry_gains_host_and_aborts():
+    """An existing (BLE) entry: merge host/port/tls, then abort already_configured."""
+    flow = _flow()
+    flow._abort_if_unique_id_configured.side_effect = AbortFlow("already_configured")
+
+    with pytest.raises(AbortFlow):
+        await flow.async_step_zeroconf(
+            _zeroconf_info(
+                {"mac": MAC_LOWER, "tls": "1"}, host="10.0.0.9", port=2447
+            )
+        )
+
+    # unique_id reconciled to uppercase, and the existing entry is updated with
+    # the live LAN endpoint (tls "1" -> True).
+    flow.async_set_unique_id.assert_awaited_once_with(MAC_UPPER)
+    updates = flow._abort_if_unique_id_configured.call_args.kwargs["updates"]
+    assert updates == {CONF_HOST: "10.0.0.9", CONF_PORT: 2447, CONF_TLS: True}
+
+
+@pytest.mark.asyncio
+async def test_zeroconf_feeds_mdns_presence_to_configured_entry():
+    """A sighting of a configured entry records mDNS presence + wakes delivery."""
+    delivery = MagicMock()
+    entry = SimpleNamespace(
+        unique_id=MAC_UPPER,
+        runtime_data=SimpleNamespace(mdns_last_seen=None, delivery=delivery),
+    )
+    flow = _flow(entries=[entry])
+    flow._abort_if_unique_id_configured.side_effect = AbortFlow("already_configured")
+
+    with pytest.raises(AbortFlow):
+        await flow.async_step_zeroconf(
+            _zeroconf_info({"mac": MAC_LOWER, "tls": "0"})
+        )
+
+    assert entry.runtime_data.mdns_last_seen is not None
+    delivery.notify_device_seen.assert_called_once_with("mdns")
+
+
+@pytest.mark.asyncio
+async def test_zeroconf_confirm_probes_tcp_and_creates_entry():
+    """Confirming a new WiFi device probes TCP then creates a host/port/tls entry."""
+    flow = _flow(entries=[])
+    await flow.async_step_zeroconf(
+        _zeroconf_info({"mac": MAC_LOWER, "tls": "0"}, host="1.2.3.4", port=2446)
+    )
+    flow._async_test_connection_tcp = AsyncMock()
+
+    result = await flow.async_step_zeroconf_confirm(user_input={})
+
+    flow._async_test_connection_tcp.assert_awaited_once_with("1.2.3.4", 2446)
+    assert result["type"] == "create_entry"
+    assert result["data"] == {
+        CONF_HOST: "1.2.3.4",
+        CONF_PORT: 2446,
+        CONF_TLS: False,
+    }
+
+
+@pytest.mark.asyncio
+async def test_zeroconf_confirm_tcp_unreachable_shows_error():
+    """A failed TCP probe re-shows the confirm form with cannot_connect."""
+    flow = _flow(entries=[])
+    await flow.async_step_zeroconf(
+        _zeroconf_info({"mac": MAC_LOWER, "tls": "0"})
+    )
+    flow._async_test_connection_tcp = AsyncMock(side_effect=OSError("refused"))
+
+    result = await flow.async_step_zeroconf_confirm(user_input={})
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "zeroconf_confirm"
+    assert result["errors"] == {"base": "cannot_connect"}
+    flow.async_create_entry.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_zeroconf_tls_port_default_when_port_absent():
+    """When the SRV record omits a port, tls TXT selects the derived TLS port."""
+    flow = _flow()
+    flow._abort_if_unique_id_configured.side_effect = AbortFlow("already_configured")
+
+    with pytest.raises(AbortFlow):
+        await flow.async_step_zeroconf(
+            _zeroconf_info({"mac": MAC_LOWER, "tls": "1"}, port=None)
+        )
+
+    updates = flow._abort_if_unique_id_configured.call_args.kwargs["updates"]
+    assert updates[CONF_PORT] == 2447
+    assert updates[CONF_TLS] is True

--- a/tests/test_delivery.py
+++ b/tests/test_delivery.py
@@ -6,6 +6,7 @@ and ``OpenDisplayDevice``) are patched in the delivery module namespace.
 """
 
 import asyncio
+import logging
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -15,6 +16,7 @@ import pytest
 from homeassistant.exceptions import HomeAssistantError
 
 from custom_components.opendisplay import delivery as delivery_mod
+from custom_components.opendisplay.ble_lock import async_get_ble_lock, ble_connection
 from custom_components.opendisplay.const import (
     CONF_BLOCKS_PER_ACK,
     CONF_MAX_QUEUE_SIZE,
@@ -52,7 +54,6 @@ def _make_env(profile=None, entry_data=None, last_seen=None, options=None):
         coordinator=coordinator,
         sleep_profile=profile,
         device_config=MagicMock(),
-        ble_lock=asyncio.Lock(),
         config_resync_pending=False,
         firmware=None,
         is_flex=False,
@@ -463,6 +464,94 @@ async def test_drain_passes_state_and_refresh_mode():
     call = device.upload_prepared_image.await_args
     assert call.kwargs["state"] is sentinel_state
     assert call.kwargs["refresh_mode"] is RefreshMode.PARTIAL
+
+
+@pytest.mark.asyncio
+async def test_drain_holds_registry_lock_during_connection():
+    """The drain body runs while the process-global per-MAC lock is held."""
+    hass, entry, _ = _make_env()
+    device = MagicMock()
+    device.upload_prepared_image = AsyncMock()
+    held: dict[str, bool] = {}
+
+    def _factory(**kwargs):
+        class _Ctx:
+            async def __aenter__(self):
+                held["locked"] = async_get_ble_lock(ADDRESS).locked()
+                return device
+
+            async def __aexit__(self, *exc):
+                return False
+
+        return _Ctx()
+
+    with (
+        patch.object(delivery_mod, "async_call_later", return_value=MagicMock()),
+        patch.object(delivery_mod, "async_dispatcher_send"),
+        patch.object(delivery_mod, "async_ble_device_from_address", return_value=MagicMock()),
+        patch.object(delivery_mod, "OpenDisplayDevice", side_effect=_factory),
+    ):
+        mgr = DeliveryManager(hass, entry)
+        _submit(mgr)
+        await mgr._deliver()
+
+    assert held["locked"] is True
+
+
+@pytest.mark.asyncio
+async def test_drain_waits_for_preheld_registry_lock(caplog):
+    """A drain queued behind a pre-held registry lock warns and waits."""
+    caplog.set_level(logging.WARNING, logger="custom_components.opendisplay.ble_lock")
+    hass, entry, _ = _make_env()
+    device = MagicMock()
+    device.upload_prepared_image = AsyncMock()
+    order: list[str] = []
+    release = asyncio.Event()
+
+    async def _hold() -> None:
+        async with ble_connection(ADDRESS, "external holder"):
+            order.append("holder-enter")
+            await release.wait()
+            order.append("holder-exit")
+
+    def _factory(**kwargs):
+        class _Ctx:
+            async def __aenter__(self):
+                order.append("drain-connect")
+                return device
+
+            async def __aexit__(self, *exc):
+                return False
+
+        return _Ctx()
+
+    with (
+        patch.object(delivery_mod, "async_call_later", return_value=MagicMock()),
+        patch.object(delivery_mod, "async_dispatcher_send"),
+        patch.object(delivery_mod, "async_ble_device_from_address", return_value=MagicMock()),
+        patch.object(delivery_mod, "OpenDisplayDevice", side_effect=_factory),
+    ):
+        mgr = DeliveryManager(hass, entry)
+        _submit(mgr)
+        holder = asyncio.create_task(_hold())
+        while "holder-enter" not in order:
+            await asyncio.sleep(0)
+        drain = asyncio.create_task(mgr._deliver())
+        # The drain must block on the held lock before it ever connects.
+        for _ in range(5):
+            await asyncio.sleep(0)
+        assert "drain-connect" not in order
+        release.set()
+        await asyncio.gather(holder, drain)
+
+    assert order == ["holder-enter", "holder-exit", "drain-connect"]
+    device.upload_prepared_image.assert_awaited_once()
+    warnings = [
+        r for r in caplog.records
+        if r.name == "custom_components.opendisplay.ble_lock"
+        and r.levelno == logging.WARNING
+    ]
+    assert len(warnings) == 1
 
 
 if __name__ == "__main__":

--- a/tests/test_delivery.py
+++ b/tests/test_delivery.py
@@ -1,8 +1,10 @@
 """Unit tests for DeliveryManager with mocked hass/coordinator/device.
 
 These avoid the full Home Assistant test harness: the manager's HA touchpoints
-(``async_call_later``, ``async_dispatcher_send``, ``async_ble_device_from_address``
-and ``OpenDisplayDevice``) are patched in the delivery module namespace.
+(``async_call_later``, ``async_dispatcher_send``) are patched in the delivery
+module namespace, while the connection touchpoints (``async_ble_device_from_address``
+and ``OpenDisplayDevice``) now live in — and are patched in — the transport module
+namespace, since the resolver owns the connect/fallback flow.
 """
 
 import asyncio
@@ -16,6 +18,7 @@ import pytest
 from homeassistant.exceptions import HomeAssistantError
 
 from custom_components.opendisplay import delivery as delivery_mod
+from custom_components.opendisplay import transport as transport_mod
 from custom_components.opendisplay.ble_lock import async_get_ble_lock, ble_connection
 from custom_components.opendisplay.const import (
     CONF_BLOCKS_PER_ACK,
@@ -204,8 +207,8 @@ async def test_drain_delivers_upload():
     with (
         patch.object(delivery_mod, "async_call_later", return_value=MagicMock()),
         patch.object(delivery_mod, "async_dispatcher_send"),
-        patch.object(delivery_mod, "async_ble_device_from_address", return_value=MagicMock()),
-        patch.object(delivery_mod, "OpenDisplayDevice", side_effect=_fake_device_ctx(device)),
+        patch.object(transport_mod, "async_ble_device_from_address", return_value=MagicMock()),
+        patch.object(transport_mod, "OpenDisplayDevice", side_effect=_fake_device_ctx(device)),
     ):
         mgr = DeliveryManager(hass, entry)
         _submit(mgr, device_id="dev1")
@@ -223,9 +226,9 @@ async def test_drain_ble_failure_keeps_slot_and_counts_attempt():
     with (
         patch.object(delivery_mod, "async_call_later", return_value=MagicMock()),
         patch.object(delivery_mod, "async_dispatcher_send"),
-        patch.object(delivery_mod, "async_ble_device_from_address", return_value=MagicMock()),
+        patch.object(transport_mod, "async_ble_device_from_address", return_value=MagicMock()),
         patch.object(
-            delivery_mod,
+            transport_mod,
             "OpenDisplayDevice",
             side_effect=_raising_device_ctx(BLEConnectionError("boom")),
         ),
@@ -245,9 +248,9 @@ async def test_drain_deadline_timeout_raises_and_counts_attempt():
     with (
         patch.object(delivery_mod, "async_call_later", return_value=MagicMock()),
         patch.object(delivery_mod, "async_dispatcher_send"),
-        patch.object(delivery_mod, "async_ble_device_from_address", return_value=MagicMock()),
+        patch.object(transport_mod, "async_ble_device_from_address", return_value=MagicMock()),
         patch.object(
-            delivery_mod,
+            transport_mod,
             "OpenDisplayDevice",
             side_effect=_raising_device_ctx(TimeoutError()),
         ),
@@ -274,9 +277,9 @@ async def test_drain_gives_up_after_max_attempts():
     with (
         patch.object(delivery_mod, "async_call_later", return_value=deadline_cancel),
         patch.object(delivery_mod, "async_dispatcher_send"),
-        patch.object(delivery_mod, "async_ble_device_from_address", return_value=MagicMock()),
+        patch.object(transport_mod, "async_ble_device_from_address", return_value=MagicMock()),
         patch.object(
-            delivery_mod,
+            transport_mod,
             "OpenDisplayDevice",
             side_effect=_raising_device_ctx(BLEConnectionError("boom")),
         ),
@@ -311,9 +314,9 @@ async def test_drain_auth_failure_pauses_and_starts_reauth():
     with (
         patch.object(delivery_mod, "async_call_later", return_value=MagicMock()),
         patch.object(delivery_mod, "async_dispatcher_send"),
-        patch.object(delivery_mod, "async_ble_device_from_address", return_value=MagicMock()),
+        patch.object(transport_mod, "async_ble_device_from_address", return_value=MagicMock()),
         patch.object(
-            delivery_mod,
+            transport_mod,
             "OpenDisplayDevice",
             side_effect=_raising_device_ctx(AuthenticationFailedError("bad key")),
         ),
@@ -343,8 +346,8 @@ async def test_drain_config_resync_updates_runtime_and_cache():
     with (
         patch.object(delivery_mod, "async_call_later", return_value=MagicMock()),
         patch.object(delivery_mod, "async_dispatcher_send"),
-        patch.object(delivery_mod, "async_ble_device_from_address", return_value=MagicMock()),
-        patch.object(delivery_mod, "OpenDisplayDevice", side_effect=_fake_device_ctx(device)),
+        patch.object(transport_mod, "async_ble_device_from_address", return_value=MagicMock()),
+        patch.object(transport_mod, "OpenDisplayDevice", side_effect=_fake_device_ctx(device)),
         patch("custom_components.opendisplay._write_cache") as write_cache,
     ):
         mgr = DeliveryManager(hass, entry)
@@ -385,9 +388,9 @@ async def test_drain_threads_pipe_kwargs_default():
     with (
         patch.object(delivery_mod, "async_call_later", return_value=MagicMock()),
         patch.object(delivery_mod, "async_dispatcher_send"),
-        patch.object(delivery_mod, "async_ble_device_from_address", return_value=MagicMock()),
+        patch.object(transport_mod, "async_ble_device_from_address", return_value=MagicMock()),
         patch.object(
-            delivery_mod, "OpenDisplayDevice", side_effect=_fake_device_ctx(device)
+            transport_mod, "OpenDisplayDevice", side_effect=_fake_device_ctx(device)
         ) as od,
     ):
         mgr = DeliveryManager(hass, entry)
@@ -411,9 +414,9 @@ async def test_drain_threads_pipe_kwargs_custom():
     with (
         patch.object(delivery_mod, "async_call_later", return_value=MagicMock()),
         patch.object(delivery_mod, "async_dispatcher_send"),
-        patch.object(delivery_mod, "async_ble_device_from_address", return_value=MagicMock()),
+        patch.object(transport_mod, "async_ble_device_from_address", return_value=MagicMock()),
         patch.object(
-            delivery_mod, "OpenDisplayDevice", side_effect=_fake_device_ctx(device)
+            transport_mod, "OpenDisplayDevice", side_effect=_fake_device_ctx(device)
         ) as od,
     ):
         mgr = DeliveryManager(hass, entry)
@@ -443,10 +446,10 @@ async def test_drain_passes_state_and_refresh_mode():
         patch.object(delivery_mod, "async_call_later", return_value=MagicMock()),
         patch.object(delivery_mod, "async_dispatcher_send"),
         patch.object(
-            delivery_mod, "async_ble_device_from_address", return_value=MagicMock()
+            transport_mod, "async_ble_device_from_address", return_value=MagicMock()
         ),
         patch.object(
-            delivery_mod, "OpenDisplayDevice", side_effect=_fake_device_ctx(device)
+            transport_mod, "OpenDisplayDevice", side_effect=_fake_device_ctx(device)
         ),
     ):
         mgr = DeliveryManager(hass, entry)
@@ -488,8 +491,8 @@ async def test_drain_holds_registry_lock_during_connection():
     with (
         patch.object(delivery_mod, "async_call_later", return_value=MagicMock()),
         patch.object(delivery_mod, "async_dispatcher_send"),
-        patch.object(delivery_mod, "async_ble_device_from_address", return_value=MagicMock()),
-        patch.object(delivery_mod, "OpenDisplayDevice", side_effect=_factory),
+        patch.object(transport_mod, "async_ble_device_from_address", return_value=MagicMock()),
+        patch.object(transport_mod, "OpenDisplayDevice", side_effect=_factory),
     ):
         mgr = DeliveryManager(hass, entry)
         _submit(mgr)
@@ -528,8 +531,8 @@ async def test_drain_waits_for_preheld_registry_lock(caplog):
     with (
         patch.object(delivery_mod, "async_call_later", return_value=MagicMock()),
         patch.object(delivery_mod, "async_dispatcher_send"),
-        patch.object(delivery_mod, "async_ble_device_from_address", return_value=MagicMock()),
-        patch.object(delivery_mod, "OpenDisplayDevice", side_effect=_factory),
+        patch.object(transport_mod, "async_ble_device_from_address", return_value=MagicMock()),
+        patch.object(transport_mod, "OpenDisplayDevice", side_effect=_factory),
     ):
         mgr = DeliveryManager(hass, entry)
         _submit(mgr)

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -7,6 +7,7 @@ service module's HA/BLE touchpoints (``prepare_image``, ``_pil_to_jpeg``,
 """
 
 import asyncio
+import logging
 import time
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -19,6 +20,7 @@ import voluptuous as vol
 from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 
 from custom_components.opendisplay import services as services_mod
+from custom_components.opendisplay.ble_lock import ble_connection
 from custom_components.opendisplay.const import (
     CONF_BLOCKS_PER_ACK,
     CONF_MAX_QUEUE_SIZE,
@@ -66,7 +68,6 @@ def _make_env(profile=None, last_seen=None, options=None):
         sleep_profile=profile,
         delivery=manager,
         device_config=None,
-        ble_lock=asyncio.Lock(),
         partial_state=MagicMock(),
     )
     entry = MagicMock()
@@ -499,6 +500,56 @@ def test_schema_play_melody_rejects_pipe():
     """The reserved multi-pattern separator is rejected at schema time."""
     with pytest.raises(vol.Invalid):
         SCHEMA_PLAY_MELODY({"device_id": "dev-1", "notes": "A4 | C5"})
+
+
+@pytest.mark.asyncio
+async def test_live_send_waits_for_preheld_registry_lock(caplog):
+    """A live send queued behind a pre-held per-MAC lock warns and waits."""
+    caplog.set_level(logging.WARNING, logger="custom_components.opendisplay.ble_lock")
+    hass, entry, _, _ = _make_env(profile=_profile(sleep_mode="off"), last_seen=None)
+    device = MagicMock()
+    device.upload_prepared_image = AsyncMock()
+    order: list[str] = []
+    release = asyncio.Event()
+
+    async def _hold() -> None:
+        async with ble_connection(ADDRESS, "external holder"):
+            order.append("holder-enter")
+            await release.wait()
+            order.append("holder-exit")
+
+    def _od_factory(**kwargs):
+        class _Ctx:
+            async def __aenter__(self):
+                order.append("send-connect")
+                return device
+
+            async def __aexit__(self, *exc):
+                return False
+
+        return _Ctx()
+
+    p1, p2, p3, p4, p5 = _patches(MagicMock(side_effect=_od_factory))
+    with p1, p2, p3, p4, p5:
+        holder = asyncio.create_task(_hold())
+        while "holder-enter" not in order:
+            await asyncio.sleep(0)
+        send = asyncio.create_task(_send(hass, entry))
+        # The send must block on the held lock before it ever connects.
+        for _ in range(5):
+            await asyncio.sleep(0)
+        assert "send-connect" not in order
+        release.set()
+        receipt, _ = await asyncio.gather(send, holder)
+
+    assert order == ["holder-enter", "holder-exit", "send-connect"]
+    assert receipt.status == "delivered"
+    warnings = [
+        r for r in caplog.records
+        if r.name == "custom_components.opendisplay.ble_lock"
+        and r.levelno == logging.WARNING
+    ]
+    assert len(warnings) == 1
 
 
 if __name__ == "__main__":

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -1,9 +1,10 @@
 """Unit tests for the _async_send_image sleep gate and probe-before-queue.
 
 Mirrors the test_delivery.py approach: no Home Assistant test harness; the
-service module's HA/BLE touchpoints (``prepare_image``, ``_pil_to_jpeg``,
-``async_dispatcher_send``, ``async_ble_device_from_address`` and
-``OpenDisplayDevice``) are patched in the services module namespace.
+service module's HA touchpoints (``prepare_image``, ``_pil_to_jpeg``,
+``async_dispatcher_send``) are patched in the services module namespace, while the
+connection touchpoints (``async_ble_device_from_address`` and ``OpenDisplayDevice``)
+are patched in the transport module namespace, where the resolver now calls them.
 """
 
 import asyncio
@@ -20,6 +21,7 @@ import voluptuous as vol
 from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 
 from custom_components.opendisplay import services as services_mod
+from custom_components.opendisplay import transport as transport_mod
 from custom_components.opendisplay.ble_lock import ble_connection
 from custom_components.opendisplay.const import (
     CONF_BLOCKS_PER_ACK,
@@ -125,9 +127,9 @@ def _patches(od_factory, ble_device="ble-device"):
         patch.object(services_mod, "_pil_to_jpeg", return_value=b"jpeg"),
         patch.object(services_mod, "async_dispatcher_send"),
         patch.object(
-            services_mod, "async_ble_device_from_address", return_value=ble_device
+            transport_mod, "async_ble_device_from_address", return_value=ble_device
         ),
-        patch.object(services_mod, "OpenDisplayDevice", od_factory),
+        patch.object(transport_mod, "OpenDisplayDevice", od_factory),
     )
 
 

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -1,0 +1,302 @@
+"""Unit tests for the WiFi/BLE transport resolver.
+
+No Home Assistant test harness: the resolver's connection touchpoints
+(``async_ble_device_from_address`` and ``OpenDisplayDevice``) are patched in the
+transport module namespace, and the config entry is a plain ``MagicMock`` with a
+``SimpleNamespace`` runtime — matching the other test modules' style.
+"""
+
+import time
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from opendisplay import OpenDisplayConnectionError, OpenDisplayTimeoutError
+import pytest
+
+from custom_components.opendisplay import transport as transport_mod
+from custom_components.opendisplay.const import (
+    CONF_HOST,
+    CONF_PORT,
+    CONF_TLS,
+    DEFAULT_LAN_PORT,
+    MDNS_FRESHNESS_WINDOW_S,
+)
+from custom_components.opendisplay.transport import (
+    TRANSPORT_BLE,
+    TRANSPORT_WIFI,
+    async_run_with_fallback,
+    note_mdns_seen,
+    resolve_transport,
+)
+
+ADDRESS = "AA:BB:CC:DD:EE:FF"
+
+
+def _entry(data=None, mdns_last_seen=None, delivery=None):
+    """Build a fake config entry with a mutable SimpleNamespace runtime."""
+    runtime = SimpleNamespace(
+        mdns_last_seen=mdns_last_seen,
+        delivery=delivery,
+        last_transport=None,
+    )
+    entry = MagicMock()
+    entry.unique_id = ADDRESS
+    entry.data = data if data is not None else {}
+    entry.runtime_data = runtime
+    return entry
+
+
+def _device_ctx(device):
+    """Async context manager yielding ``device`` (mirrors OpenDisplayDevice())."""
+
+    class _Ctx:
+        async def __aenter__(self):
+            return device
+
+        async def __aexit__(self, *exc):
+            return False
+
+    return _Ctx()
+
+
+# -- resolve_transport ------------------------------------------------------
+
+
+def test_resolve_no_host_is_ble():
+    """An entry with no CONF_HOST (every pre-WiFi entry) resolves to BLE."""
+    resolved = resolve_transport(_entry(data={}))
+    assert resolved.use_wifi is False
+    assert resolved.host is None
+
+
+def test_resolve_host_fresh_mdns_prefers_wifi():
+    """Host present + a recent mDNS sighting -> WiFi, carrying host/port/tls."""
+    entry = _entry(
+        data={CONF_HOST: "1.2.3.4", CONF_PORT: 2447, CONF_TLS: True},
+        mdns_last_seen=time.monotonic(),
+    )
+    resolved = resolve_transport(entry)
+    assert resolved.use_wifi is True
+    assert resolved.host == "1.2.3.4"
+    assert resolved.port == 2447
+    assert resolved.tls is True
+
+
+def test_resolve_host_stale_mdns_falls_back_to_ble():
+    """A host known but not seen via mDNS within the window -> BLE."""
+    entry = _entry(
+        data={CONF_HOST: "1.2.3.4"},
+        mdns_last_seen=time.monotonic() - MDNS_FRESHNESS_WINDOW_S - 60,
+    )
+    resolved = resolve_transport(entry)
+    assert resolved.use_wifi is False
+    # host is still carried (a caller may log it) but WiFi is not chosen.
+    assert resolved.host == "1.2.3.4"
+    assert resolved.port == DEFAULT_LAN_PORT
+
+
+def test_resolve_host_never_seen_is_ble():
+    """A host with no mDNS sighting yet -> BLE (no premature WiFi)."""
+    entry = _entry(data={CONF_HOST: "1.2.3.4"}, mdns_last_seen=None)
+    assert resolve_transport(entry).use_wifi is False
+
+
+# -- note_mdns_seen ---------------------------------------------------------
+
+
+def test_note_mdns_seen_records_timestamp_and_wakes_delivery():
+    """A sighting stamps the freshness timestamp and triggers a wake."""
+    delivery = MagicMock()
+    entry = _entry(data={CONF_HOST: "1.2.3.4"}, delivery=delivery)
+    assert entry.runtime_data.mdns_last_seen is None
+
+    note_mdns_seen(entry)
+
+    assert entry.runtime_data.mdns_last_seen is not None
+    delivery.notify_device_seen.assert_called_once_with("mdns")
+
+
+def test_note_mdns_seen_without_runtime_is_noop():
+    """An unloaded entry (no runtime_data) is tolerated silently."""
+    entry = MagicMock()
+    entry.runtime_data = None
+    note_mdns_seen(entry)  # must not raise
+
+
+# -- async_run_with_fallback ------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_wifi_preferred_when_fresh():
+    """A fresh mDNS host connects over WiFi; BLE is never touched."""
+    entry = _entry(
+        data={CONF_HOST: "1.2.3.4", CONF_PORT: 2446, CONF_TLS: False},
+        mdns_last_seen=time.monotonic(),
+    )
+    device = MagicMock()
+    action = AsyncMock()
+    calls: list[dict] = []
+
+    def _factory(**kwargs):
+        calls.append(kwargs)
+        return _device_ctx(device)
+
+    with (
+        patch.object(transport_mod, "OpenDisplayDevice", side_effect=_factory),
+        patch.object(transport_mod, "async_ble_device_from_address") as ble,
+    ):
+        result = await async_run_with_fallback(
+            MagicMock(),
+            entry,
+            action,
+            base_kwargs={"config": None},
+            ble_unavailable=lambda: AssertionError("BLE must not be reached"),
+        )
+
+    assert result == TRANSPORT_WIFI
+    action.assert_awaited_once_with(device)
+    assert "host" in calls[0] and "mac_address" not in calls[0]
+    ble.assert_not_called()
+    assert entry.runtime_data.last_transport == TRANSPORT_WIFI
+
+
+@pytest.mark.asyncio
+async def test_wifi_failure_falls_back_to_ble_same_delivery():
+    """A WiFi connection failure retries the same action over BLE."""
+    entry = _entry(
+        data={CONF_HOST: "1.2.3.4", CONF_PORT: 2446, CONF_TLS: False},
+        mdns_last_seen=time.monotonic(),
+    )
+    device = MagicMock()
+    action = AsyncMock()
+
+    def _factory(**kwargs):
+        if "host" in kwargs:  # the WiFi attempt
+            raise OpenDisplayConnectionError("unreachable")
+        return _device_ctx(device)  # the BLE fallback
+
+    with (
+        patch.object(transport_mod, "OpenDisplayDevice", side_effect=_factory),
+        patch.object(
+            transport_mod, "async_ble_device_from_address", return_value=MagicMock()
+        ),
+    ):
+        result = await async_run_with_fallback(
+            MagicMock(),
+            entry,
+            action,
+            base_kwargs={"config": None},
+            ble_unavailable=lambda: AssertionError("BLE device was available"),
+        )
+
+    assert result == TRANSPORT_BLE
+    # The same action ran once — over BLE, after the WiFi attempt raised.
+    action.assert_awaited_once_with(device)
+    assert entry.runtime_data.last_transport == TRANSPORT_BLE
+
+
+@pytest.mark.asyncio
+async def test_wifi_tls_oserror_falls_back_to_ble():
+    """A raw socket/TLS error (OSError) also triggers the BLE fallback."""
+    entry = _entry(
+        data={CONF_HOST: "1.2.3.4", CONF_TLS: True},
+        mdns_last_seen=time.monotonic(),
+    )
+    device = MagicMock()
+    action = AsyncMock()
+
+    def _factory(**kwargs):
+        if "host" in kwargs:
+            raise OSError("TLS handshake failed")
+        return _device_ctx(device)
+
+    with (
+        patch.object(transport_mod, "OpenDisplayDevice", side_effect=_factory),
+        patch.object(
+            transport_mod, "async_ble_device_from_address", return_value=MagicMock()
+        ),
+    ):
+        result = await async_run_with_fallback(
+            MagicMock(), entry, action, base_kwargs={}, ble_unavailable=RuntimeError
+        )
+
+    assert result == TRANSPORT_BLE
+
+
+@pytest.mark.asyncio
+async def test_stale_host_uses_ble_directly():
+    """No fresh mDNS -> BLE with no WiFi attempt at all."""
+    entry = _entry(data={CONF_HOST: "1.2.3.4"}, mdns_last_seen=None)
+    device = MagicMock()
+    action = AsyncMock()
+    calls: list[dict] = []
+
+    def _factory(**kwargs):
+        calls.append(kwargs)
+        return _device_ctx(device)
+
+    with (
+        patch.object(transport_mod, "OpenDisplayDevice", side_effect=_factory),
+        patch.object(
+            transport_mod, "async_ble_device_from_address", return_value=MagicMock()
+        ),
+    ):
+        result = await async_run_with_fallback(
+            MagicMock(), entry, action, base_kwargs={}, ble_unavailable=RuntimeError
+        )
+
+    assert result == TRANSPORT_BLE
+    assert len(calls) == 1 and "mac_address" in calls[0] and "host" not in calls[0]
+
+
+@pytest.mark.asyncio
+async def test_ble_unavailable_raises_supplied_exception():
+    """When BLE is selected but no connectable device exists, the caller's
+    exception factory decides the outcome (e.g. _DeviceUnavailable)."""
+    entry = _entry(data={}, mdns_last_seen=None)  # no host -> BLE
+    action = AsyncMock()
+
+    class _Sentinel(Exception):
+        pass
+
+    with (
+        patch.object(transport_mod, "OpenDisplayDevice"),
+        patch.object(
+            transport_mod, "async_ble_device_from_address", return_value=None
+        ),
+    ):
+        with pytest.raises(_Sentinel):
+            await async_run_with_fallback(
+                MagicMock(),
+                entry,
+                action,
+                base_kwargs={},
+                ble_unavailable=_Sentinel,
+            )
+
+    action.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_wifi_timeout_falls_back_to_ble():
+    """A neutral OpenDisplayTimeoutError from WiFi also falls back to BLE."""
+    entry = _entry(data={CONF_HOST: "1.2.3.4"}, mdns_last_seen=time.monotonic())
+    device = MagicMock()
+    action = AsyncMock()
+
+    def _factory(**kwargs):
+        if "host" in kwargs:
+            raise OpenDisplayTimeoutError("read timeout")
+        return _device_ctx(device)
+
+    with (
+        patch.object(transport_mod, "OpenDisplayDevice", side_effect=_factory),
+        patch.object(
+            transport_mod, "async_ble_device_from_address", return_value=MagicMock()
+        ),
+    ):
+        result = await async_run_with_fallback(
+            MagicMock(), entry, action, base_kwargs={}, ble_unavailable=RuntimeError
+        )
+
+    assert result == TRANSPORT_BLE


### PR DESCRIPTION
## Summary

Adds **WiFi/LAN as a transport** alongside BLE, with mDNS discovery and automatic BLE fallback. Built on a new process-global per-MAC connection lock, and surfaced with a WiFi-status binary sensor.

Three related pieces, kept as separate commits for review:

1. **`feat(ble)` — per-MAC connection lock.** A process-global, MAC-keyed `asyncio.Lock` (`ble_lock.py`) serializes all connect sites to a given tag, logging a WARNING on contention. Transport-neutral, so it also covers the WiFi path.
2. **`feat(wifi)` — WiFi/LAN transport.** Registers zeroconf `_opendisplay._tcp.local.`; `async_step_zeroconf` reads the MAC TXT record and dedups a WiFi-discovered tag onto its existing BLE config entry (merging host/port/tls). `resolve_transport` prefers WiFi when the entry has a host and a fresh mDNS sighting, else BLE; `async_run_with_fallback` falls back to BLE on any WiFi connect/TLS/timeout/OSError failure. Diagnostics surface host/port/tls, last-used transport, and mDNS last-seen. Existing BLE-only entries have no host and resolve to BLE unchanged.
3. **`feat(binary_sensor)` — WiFi (LAN) status sensor** with the device IP as an attribute.

## Dependency

`py-opendisplay` is pinned to the released **`==7.14.2`**, which carries the WiFi transport support this PR needs. (Earlier revisions temporarily pinned the fork's `feat/wifi-transport` branch while that work was unpublished; that draft pin has been dropped.)

## Notes

- Targets `feat/clean-port`.
- `translations/en.json` change is only the 4 new keys (no reformatting churn).
- New tests: `test_ble_lock.py`, `test_transport.py`, plus zeroconf config-flow cases and delivery/services transport-fallback coverage.
- Also carries a docs-only commit correcting `activate_buzzer` `frequency_hz` wording for the firmware's quarter-tone/nearest-note mapping (cherry-picked from #5, across `services.yaml`, `strings.json`, and `translations/en.json`).
