### PR TITLE
feat: add AI-generated translations for 9 languages

### DIFF
--- a/.github/translation-state.json
+++ b/.github/translation-state.json
@@ -1,5808 +1,5808 @@
 {
   "cs": {
-    "config.abort.already_configured": {
+    "config\u0000abort\u0000already_configured": {
       "out": "cfebe6abdf22",
       "src": "c2936e02a0d2"
     },
-    "config.abort.already_in_progress": {
+    "config\u0000abort\u0000already_in_progress": {
       "out": "6ebbfd9173a4",
       "src": "985a72ad93a3"
     },
-    "config.abort.cannot_connect": {
+    "config\u0000abort\u0000cannot_connect": {
       "out": "9a1dc8859d5e",
       "src": "46c9f3b7520f"
     },
-    "config.abort.no_devices_found": {
+    "config\u0000abort\u0000no_devices_found": {
       "out": "2b75b2bd2d47",
       "src": "b8f28e84cf0b"
     },
-    "config.abort.reauth_successful": {
+    "config\u0000abort\u0000reauth_successful": {
       "out": "e0c7a53681ca",
       "src": "e5b83989735c"
     },
-    "config.abort.unknown": {
+    "config\u0000abort\u0000unknown": {
       "out": "05aa2a2eef83",
       "src": "d24c41ae530a"
     },
-    "config.error.cannot_connect": {
+    "config\u0000error\u0000cannot_connect": {
       "out": "9a1dc8859d5e",
       "src": "46c9f3b7520f"
     },
-    "config.error.invalid_auth": {
+    "config\u0000error\u0000invalid_auth": {
       "out": "4aeb94da6f2e",
       "src": "4ca089878c5f"
     },
-    "config.error.invalid_key_format": {
+    "config\u0000error\u0000invalid_key_format": {
       "out": "cbc799d354b8",
       "src": "f7b03dd699df"
     },
-    "config.error.unknown": {
+    "config\u0000error\u0000unknown": {
       "out": "05aa2a2eef83",
       "src": "d24c41ae530a"
     },
-    "config.flow_title": {
+    "config\u0000flow_title": {
       "out": "5e291d7bcb2d",
       "src": "5e291d7bcb2d"
     },
-    "config.step.bluetooth_confirm.description": {
+    "config\u0000step\u0000bluetooth_confirm\u0000description": {
       "out": "0f66fd954120",
       "src": "bcfd5a24b7d7"
     },
-    "config.step.encryption_key.data.encryption_key": {
+    "config\u0000step\u0000encryption_key\u0000data\u0000encryption_key": {
       "out": "c357a59fb745",
       "src": "16b3c9d5573d"
     },
-    "config.step.encryption_key.data_description.encryption_key": {
+    "config\u0000step\u0000encryption_key\u0000data_description\u0000encryption_key": {
       "out": "46053a9ce60b",
       "src": "e64cd2e7e647"
     },
-    "config.step.encryption_key.description": {
+    "config\u0000step\u0000encryption_key\u0000description": {
       "out": "b126b2ba8ac7",
       "src": "664d3f12bfe6"
     },
-    "config.step.encryption_key.title": {
+    "config\u0000step\u0000encryption_key\u0000title": {
       "out": "51ff494c9466",
       "src": "c30d1ca158a3"
     },
-    "config.step.reauth_confirm.data.encryption_key": {
+    "config\u0000step\u0000reauth_confirm\u0000data\u0000encryption_key": {
       "out": "c357a59fb745",
       "src": "16b3c9d5573d"
     },
-    "config.step.reauth_confirm.data_description.encryption_key": {
+    "config\u0000step\u0000reauth_confirm\u0000data_description\u0000encryption_key": {
       "out": "46053a9ce60b",
       "src": "e64cd2e7e647"
     },
-    "config.step.reauth_confirm.description": {
+    "config\u0000step\u0000reauth_confirm\u0000description": {
       "out": "f5965a3ea787",
       "src": "f53b69d3be84"
     },
-    "config.step.reauth_confirm.title": {
+    "config\u0000step\u0000reauth_confirm\u0000title": {
       "out": "c4a20af90fb5",
       "src": "7e22a752572f"
     },
-    "config.step.user.data.address": {
+    "config\u0000step\u0000user\u0000data\u0000address": {
       "out": "e1363fae54dc",
       "src": "6ba0bdeccb42"
     },
-    "config.step.user.data_description.address": {
+    "config\u0000step\u0000user\u0000data_description\u0000address": {
       "out": "47cb83a900b6",
       "src": "a083a457cfb1"
     },
-    "config.step.user.description": {
+    "config\u0000step\u0000user\u0000description": {
       "out": "1d2972ba825f",
       "src": "109135454652"
     },
-    "entity.binary_sensor.update_pending.name": {
+    "entity\u0000binary_sensor\u0000update_pending\u0000name": {
       "out": "1662dbb14ec4",
       "src": "8e0a4b18ae75"
     },
-    "entity.event.button.name": {
+    "entity\u0000event\u0000button\u0000name": {
       "out": "1fe4b52f1a66",
       "src": "2dcae43716c2"
     },
-    "entity.event.button.state_attributes.event_type.state.button_down": {
+    "entity\u0000event\u0000button\u0000state_attributes\u0000event_type\u0000state\u0000button_down": {
       "out": "bcd890b7d63c",
       "src": "8352c89d20b4"
     },
-    "entity.event.button.state_attributes.event_type.state.button_up": {
+    "entity\u0000event\u0000button\u0000state_attributes\u0000event_type\u0000state\u0000button_up": {
       "out": "70621e79373a",
       "src": "7f18b4912929"
     },
-    "entity.event.touch.name": {
+    "entity\u0000event\u0000touch\u0000name": {
       "out": "b415304a8343",
       "src": "c915d14278fc"
     },
-    "entity.event.touch.state_attributes.event_type.state.touch_down": {
+    "entity\u0000event\u0000touch\u0000state_attributes\u0000event_type\u0000state\u0000touch_down": {
       "out": "5bdaf56856ad",
       "src": "0234a9576230"
     },
-    "entity.event.touch.state_attributes.event_type.state.touch_move": {
+    "entity\u0000event\u0000touch\u0000state_attributes\u0000event_type\u0000state\u0000touch_move": {
       "out": "9ae4a3a42e2c",
       "src": "67aeac815e94"
     },
-    "entity.event.touch.state_attributes.event_type.state.touch_up": {
+    "entity\u0000event\u0000touch\u0000state_attributes\u0000event_type\u0000state\u0000touch_up": {
       "out": "a5a11748360a",
       "src": "7c65519d3bb3"
     },
-    "entity.image.content.name": {
+    "entity\u0000image\u0000content\u0000name": {
       "out": "99187c3ed5a1",
       "src": "047c6db3382a"
     },
-    "entity.sensor.battery_voltage.name": {
+    "entity\u0000sensor\u0000battery_voltage\u0000name": {
       "out": "1035f4b7fc64",
       "src": "39d6c91b57ce"
     },
-    "entity.sensor.last_seen.name": {
+    "entity\u0000sensor\u0000last_seen\u0000name": {
       "out": "64d7ab22fd32",
       "src": "21fd79c7de52"
     },
-    "entity.sensor.rssi.name": {
+    "entity\u0000sensor\u0000rssi\u0000name": {
       "out": "0def3420aa7a",
       "src": "2604d15c1187"
     },
-    "entity.update.firmware.name": {
+    "entity\u0000update\u0000firmware\u0000name": {
       "out": "c2a314c3b32b",
       "src": "c2a314c3b32b"
     },
-    "exceptions.authentication_error.message": {
+    "exceptions\u0000authentication_error\u0000message": {
       "out": "451ec0042a3e",
       "src": "3d9f7c0c6d80"
     },
-    "exceptions.device_not_found.message": {
+    "exceptions\u0000device_not_found\u0000message": {
       "out": "e469310c63c6",
       "src": "f244d0d2db8d"
     },
-    "exceptions.device_sleeping.message": {
+    "exceptions\u0000device_sleeping\u0000message": {
       "out": "faf083e36325",
       "src": "e95d25bd6fc7"
     },
-    "exceptions.device_sleeping_ota.message": {
+    "exceptions\u0000device_sleeping_ota\u0000message": {
       "out": "2aab933151b7",
       "src": "430e3a1baa6a"
     },
-    "exceptions.invalid_device_id.message": {
+    "exceptions\u0000invalid_device_id\u0000message": {
       "out": "2ede118246db",
       "src": "cc64cc29ceeb"
     },
-    "exceptions.media_download_error.message": {
+    "exceptions\u0000media_download_error\u0000message": {
       "out": "f737579995ff",
       "src": "5852129dd920"
     },
-    "exceptions.mime_type_not_applicable.message": {
+    "exceptions\u0000mime_type_not_applicable\u0000message": {
       "out": "990faf3da728",
       "src": "de700f02fbd5"
     },
-    "exceptions.multiple_errors.message": {
+    "exceptions\u0000multiple_errors\u0000message": {
       "out": "e0151482bbbb",
       "src": "f17c68e0a848"
     },
-    "exceptions.nfc_content_empty.message": {
+    "exceptions\u0000nfc_content_empty\u0000message": {
       "out": "2694884c2464",
       "src": "b93a1a6ebdc0"
     },
-    "exceptions.nfc_content_too_long.message": {
+    "exceptions\u0000nfc_content_too_long\u0000message": {
       "out": "d42c574e4c8a",
       "src": "8f580b9c6c76"
     },
-    "exceptions.nfc_mime_type_invalid.message": {
+    "exceptions\u0000nfc_mime_type_invalid\u0000message": {
       "out": "db70a8ea32bc",
       "src": "5a5f44fe332f"
     },
-    "exceptions.nfc_not_supported.message": {
+    "exceptions\u0000nfc_not_supported\u0000message": {
       "out": "89124d492c32",
       "src": "8fdcd0e2bd17"
     },
-    "exceptions.nfc_write_failed.message": {
+    "exceptions\u0000nfc_write_failed\u0000message": {
       "out": "bcfba9a035a1",
       "src": "e8186303a52e"
     },
-    "exceptions.no_buzzers.message": {
+    "exceptions\u0000no_buzzers\u0000message": {
       "out": "ba1f84e9b306",
       "src": "9c014dfeac91"
     },
-    "exceptions.no_leds.message": {
+    "exceptions\u0000no_leds\u0000message": {
       "out": "0fc1bf821d13",
       "src": "6a302f8f22ee"
     },
-    "exceptions.no_nfc.message": {
+    "exceptions\u0000no_nfc\u0000message": {
       "out": "7e12bbb18870",
       "src": "abb1917ad57e"
     },
-    "exceptions.no_targets_specified.message": {
+    "exceptions\u0000no_targets_specified\u0000message": {
       "out": "5e2456ad2a50",
       "src": "80c472afefe6"
     },
-    "exceptions.upload_error.message": {
+    "exceptions\u0000upload_error\u0000message": {
       "out": "946a74a36d9a",
       "src": "75561a03be6e"
     },
-    "exceptions.url_not_allowed.message": {
+    "exceptions\u0000url_not_allowed\u0000message": {
       "out": "4f1612b673a0",
       "src": "33ffb9a9f2c4"
     },
-    "options.step.init.data.blocks_per_ack": {
+    "options\u0000step\u0000init\u0000data\u0000blocks_per_ack": {
       "out": "f4064970f630",
       "src": "3e2a554e69a4"
     },
-    "options.step.init.data.max_queue_size": {
+    "options\u0000step\u0000init\u0000data\u0000max_queue_size": {
       "out": "9984405cecb9",
       "src": "297af7027dd0"
     },
-    "options.step.init.data.missed_cycles": {
+    "options\u0000step\u0000init\u0000data\u0000missed_cycles": {
       "out": "fa60491af79d",
       "src": "59b78644491a"
     },
-    "options.step.init.data.probe_before_queue": {
+    "options\u0000step\u0000init\u0000data\u0000probe_before_queue": {
       "out": "20b0c0f9b40f",
       "src": "02c4211a58b2"
     },
-    "options.step.init.data.queue_timeout_hours": {
+    "options\u0000step\u0000init\u0000data\u0000queue_timeout_hours": {
       "out": "580423afef62",
       "src": "be70fc5cca79"
     },
-    "options.step.init.data.sleep_mode": {
+    "options\u0000step\u0000init\u0000data\u0000sleep_mode": {
       "out": "58f710c3ec6c",
       "src": "f925c0e541ce"
     },
-    "options.step.init.data_description.blocks_per_ack": {
+    "options\u0000step\u0000init\u0000data_description\u0000blocks_per_ack": {
       "out": "cfffaab8d04a",
       "src": "3a693b19d3c6"
     },
-    "options.step.init.data_description.max_queue_size": {
+    "options\u0000step\u0000init\u0000data_description\u0000max_queue_size": {
       "out": "25377f83bfe4",
       "src": "50260959ee56"
     },
-    "options.step.init.data_description.missed_cycles": {
+    "options\u0000step\u0000init\u0000data_description\u0000missed_cycles": {
       "out": "7b08ce81fbe9",
       "src": "6ce493f4c44d"
     },
-    "options.step.init.data_description.probe_before_queue": {
+    "options\u0000step\u0000init\u0000data_description\u0000probe_before_queue": {
       "out": "c5a7e5c67a64",
       "src": "5d0f2985ffdf"
     },
-    "options.step.init.data_description.queue_timeout_hours": {
+    "options\u0000step\u0000init\u0000data_description\u0000queue_timeout_hours": {
       "out": "c4f34e43c09f",
       "src": "34895000b491"
     },
-    "options.step.init.data_description.sleep_mode": {
+    "options\u0000step\u0000init\u0000data_description\u0000sleep_mode": {
       "out": "ab4c59deeb76",
       "src": "4acfeb65d10d"
     },
-    "selector.dither_mode.options.atkinson": {
+    "selector\u0000dither_mode\u0000options\u0000atkinson": {
       "out": "7a8fe6d47b5b",
       "src": "7a8fe6d47b5b"
     },
-    "selector.dither_mode.options.burkes": {
+    "selector\u0000dither_mode\u0000options\u0000burkes": {
       "out": "1b75087201fb",
       "src": "1b75087201fb"
     },
-    "selector.dither_mode.options.floyd_steinberg": {
+    "selector\u0000dither_mode\u0000options\u0000floyd_steinberg": {
       "out": "37969811a3cf",
       "src": "37969811a3cf"
     },
-    "selector.dither_mode.options.jarvis_judice_ninke": {
+    "selector\u0000dither_mode\u0000options\u0000jarvis_judice_ninke": {
       "out": "7020241adf78",
       "src": "7020241adf78"
     },
-    "selector.dither_mode.options.none": {
+    "selector\u0000dither_mode\u0000options\u0000none": {
       "out": "e4a313af66a4",
       "src": "dc937b598926"
     },
-    "selector.dither_mode.options.ordered": {
+    "selector\u0000dither_mode\u0000options\u0000ordered": {
       "out": "73292ad4ebb1",
       "src": "007877479e21"
     },
-    "selector.dither_mode.options.sierra": {
+    "selector\u0000dither_mode\u0000options\u0000sierra": {
       "out": "d5eef8ad210c",
       "src": "d5eef8ad210c"
     },
-    "selector.dither_mode.options.sierra_lite": {
+    "selector\u0000dither_mode\u0000options\u0000sierra_lite": {
       "out": "20da8cc85f38",
       "src": "20da8cc85f38"
     },
-    "selector.dither_mode.options.stucki": {
+    "selector\u0000dither_mode\u0000options\u0000stucki": {
       "out": "a17d2b13b6f9",
       "src": "a17d2b13b6f9"
     },
-    "selector.fit_mode.options.contain": {
+    "selector\u0000fit_mode\u0000options\u0000contain": {
       "out": "da805da4ef64",
       "src": "e534a2c2b456"
     },
-    "selector.fit_mode.options.cover": {
+    "selector\u0000fit_mode\u0000options\u0000cover": {
       "out": "48c7c7dbd8ef",
       "src": "fa8d84566676"
     },
-    "selector.fit_mode.options.crop": {
+    "selector\u0000fit_mode\u0000options\u0000crop": {
       "out": "299c5826ed0b",
       "src": "98caf7c43c6f"
     },
-    "selector.fit_mode.options.stretch": {
+    "selector\u0000fit_mode\u0000options\u0000stretch": {
       "out": "279e56f5fabf",
       "src": "a33fbcf83f7b"
     },
-    "selector.nfc_record_type.options.ha_tag": {
+    "selector\u0000nfc_record_type\u0000options\u0000ha_tag": {
       "out": "d1d47a8fa544",
       "src": "d1d47a8fa544"
     },
-    "selector.nfc_record_type.options.mime": {
+    "selector\u0000nfc_record_type\u0000options\u0000mime": {
       "out": "c9a55c719e07",
       "src": "f98d7539e627"
     },
-    "selector.nfc_record_type.options.text": {
+    "selector\u0000nfc_record_type\u0000options\u0000text": {
       "out": "71988c4d8e08",
       "src": "71988c4d8e08"
     },
-    "selector.nfc_record_type.options.url": {
+    "selector\u0000nfc_record_type\u0000options\u0000url": {
       "out": "e7a241debad5",
       "src": "e7a241debad5"
     },
-    "selector.refresh_mode.options.fast": {
+    "selector\u0000refresh_mode\u0000options\u0000fast": {
       "out": "466ff56b59b2",
       "src": "6c582b62e0e5"
     },
-    "selector.refresh_mode.options.full": {
+    "selector\u0000refresh_mode\u0000options\u0000full": {
       "out": "a2b95a053c53",
       "src": "008dacb6d1e8"
     },
-    "selector.refresh_mode.options.partial": {
+    "selector\u0000refresh_mode\u0000options\u0000partial": {
       "out": "269582aff3f4",
       "src": "a4d50fb85403"
     },
-    "selector.sleep_mode.options.auto": {
+    "selector\u0000sleep_mode\u0000options\u0000auto": {
       "out": "35727d4fb111",
       "src": "132990bd8ef7"
     },
-    "selector.sleep_mode.options.off": {
+    "selector\u0000sleep_mode\u0000options\u0000off": {
       "out": "10740875f5b8",
       "src": "34598efe7b90"
     },
-    "selector.sleep_mode.options.on": {
+    "selector\u0000sleep_mode\u0000options\u0000on": {
       "out": "d94c08d8165a",
       "src": "bde131e31c9e"
     },
-    "services.activate_buzzer.description": {
+    "services\u0000activate_buzzer\u0000description": {
       "out": "37b20ddf2753",
       "src": "1898784614cb"
     },
-    "services.activate_buzzer.fields.device_id.description": {
+    "services\u0000activate_buzzer\u0000fields\u0000device_id\u0000description": {
       "out": "082aa38abb33",
       "src": "7dec980cb238"
     },
-    "services.activate_buzzer.fields.device_id.name": {
+    "services\u0000activate_buzzer\u0000fields\u0000device_id\u0000name": {
       "out": "e1363fae54dc",
       "src": "6ba0bdeccb42"
     },
-    "services.activate_buzzer.fields.duration_ms.description": {
+    "services\u0000activate_buzzer\u0000fields\u0000duration_ms\u0000description": {
       "out": "c4c224c6bbe6",
       "src": "cd1bc75ca60c"
     },
-    "services.activate_buzzer.fields.duration_ms.name": {
+    "services\u0000activate_buzzer\u0000fields\u0000duration_ms\u0000name": {
       "out": "e2ebfffce3d1",
       "src": "4fc52a3c4c55"
     },
-    "services.activate_buzzer.fields.frequency_hz.description": {
+    "services\u0000activate_buzzer\u0000fields\u0000frequency_hz\u0000description": {
       "out": "efd5b116bd7b",
       "src": "510fc20311e3"
     },
-    "services.activate_buzzer.fields.frequency_hz.name": {
+    "services\u0000activate_buzzer\u0000fields\u0000frequency_hz\u0000name": {
       "out": "18e0c4322b87",
       "src": "16b6668d9831"
     },
-    "services.activate_buzzer.fields.instance.description": {
+    "services\u0000activate_buzzer\u0000fields\u0000instance\u0000description": {
       "out": "1dfe53f07145",
       "src": "f39fa742d55c"
     },
-    "services.activate_buzzer.fields.instance.name": {
+    "services\u0000activate_buzzer\u0000fields\u0000instance\u0000name": {
       "out": "7a641c371be6",
       "src": "1f671ddded9e"
     },
-    "services.activate_buzzer.fields.repeats.description": {
+    "services\u0000activate_buzzer\u0000fields\u0000repeats\u0000description": {
       "out": "1d1a01d8a595",
       "src": "1f88b0fe23ea"
     },
-    "services.activate_buzzer.fields.repeats.name": {
+    "services\u0000activate_buzzer\u0000fields\u0000repeats\u0000name": {
       "out": "57db92bda9a5",
       "src": "92ee0233f013"
     },
-    "services.activate_buzzer.name": {
+    "services\u0000activate_buzzer\u0000name": {
       "out": "5a7492da70ee",
       "src": "0b80285753b7"
     },
-    "services.activate_led.description": {
+    "services\u0000activate_led\u0000description": {
       "out": "8f1501d74247",
       "src": "6cbd645597cc"
     },
-    "services.activate_led.fields.brightness.description": {
+    "services\u0000activate_led\u0000fields\u0000brightness\u0000description": {
       "out": "e20dd7ae15e5",
       "src": "6ad88a28230d"
     },
-    "services.activate_led.fields.brightness.name": {
+    "services\u0000activate_led\u0000fields\u0000brightness\u0000name": {
       "out": "92fb5f5d87e9",
       "src": "ec811d30a89c"
     },
-    "services.activate_led.fields.color1.description": {
+    "services\u0000activate_led\u0000fields\u0000color1\u0000description": {
       "out": "8d7b32f32c8a",
       "src": "17f145013241"
     },
-    "services.activate_led.fields.color1.name": {
+    "services\u0000activate_led\u0000fields\u0000color1\u0000name": {
       "out": "5c3a7978a694",
       "src": "571461f36f3a"
     },
-    "services.activate_led.fields.color2.description": {
+    "services\u0000activate_led\u0000fields\u0000color2\u0000description": {
       "out": "cf13c4f8927c",
       "src": "f2680a4bbe85"
     },
-    "services.activate_led.fields.color2.name": {
+    "services\u0000activate_led\u0000fields\u0000color2\u0000name": {
       "out": "949ea85f5b37",
       "src": "ef792d287872"
     },
-    "services.activate_led.fields.color3.description": {
+    "services\u0000activate_led\u0000fields\u0000color3\u0000description": {
       "out": "203a3870bafb",
       "src": "b8ecd353b426"
     },
-    "services.activate_led.fields.color3.name": {
+    "services\u0000activate_led\u0000fields\u0000color3\u0000name": {
       "out": "b0ff9ce9cc3f",
       "src": "48d54e046d29"
     },
-    "services.activate_led.fields.device_id.description": {
+    "services\u0000activate_led\u0000fields\u0000device_id\u0000description": {
       "out": "082aa38abb33",
       "src": "7dec980cb238"
     },
-    "services.activate_led.fields.device_id.name": {
+    "services\u0000activate_led\u0000fields\u0000device_id\u0000name": {
       "out": "e1363fae54dc",
       "src": "6ba0bdeccb42"
     },
-    "services.activate_led.fields.flash_count1.description": {
+    "services\u0000activate_led\u0000fields\u0000flash_count1\u0000description": {
       "out": "350002775c00",
       "src": "4ffdadde31c2"
     },
-    "services.activate_led.fields.flash_count1.name": {
+    "services\u0000activate_led\u0000fields\u0000flash_count1\u0000name": {
       "out": "022cd1537b90",
       "src": "13c6a2e5c22e"
     },
-    "services.activate_led.fields.flash_count2.description": {
+    "services\u0000activate_led\u0000fields\u0000flash_count2\u0000description": {
       "out": "7d9657597aae",
       "src": "86dc999a3915"
     },
-    "services.activate_led.fields.flash_count2.name": {
+    "services\u0000activate_led\u0000fields\u0000flash_count2\u0000name": {
       "out": "ad031bf6de32",
       "src": "2be36d8449dc"
     },
-    "services.activate_led.fields.flash_count3.description": {
+    "services\u0000activate_led\u0000fields\u0000flash_count3\u0000description": {
       "out": "884c08260a1d",
       "src": "aa40c396a9a4"
     },
-    "services.activate_led.fields.flash_count3.name": {
+    "services\u0000activate_led\u0000fields\u0000flash_count3\u0000name": {
       "out": "74a7c7895831",
       "src": "7978910dc6b2"
     },
-    "services.activate_led.fields.instance.description": {
+    "services\u0000activate_led\u0000fields\u0000instance\u0000description": {
       "out": "705fc5dde0fd",
       "src": "0531b37de90a"
     },
-    "services.activate_led.fields.instance.name": {
+    "services\u0000activate_led\u0000fields\u0000instance\u0000name": {
       "out": "b3aa884776b0",
       "src": "f942926204c7"
     },
-    "services.activate_led.fields.inter_delay1.description": {
+    "services\u0000activate_led\u0000fields\u0000inter_delay1\u0000description": {
       "out": "83facb388e1d",
       "src": "1b65dcfcea95"
     },
-    "services.activate_led.fields.inter_delay1.name": {
+    "services\u0000activate_led\u0000fields\u0000inter_delay1\u0000name": {
       "out": "b17882b9b4e0",
       "src": "71452f436c33"
     },
-    "services.activate_led.fields.inter_delay2.description": {
+    "services\u0000activate_led\u0000fields\u0000inter_delay2\u0000description": {
       "out": "e1e2dd642684",
       "src": "181e03f33cbf"
     },
-    "services.activate_led.fields.inter_delay2.name": {
+    "services\u0000activate_led\u0000fields\u0000inter_delay2\u0000name": {
       "out": "5c1101644dbb",
       "src": "6a50551e5355"
     },
-    "services.activate_led.fields.inter_delay3.description": {
+    "services\u0000activate_led\u0000fields\u0000inter_delay3\u0000description": {
       "out": "db2759a1495c",
       "src": "5c5973b586df"
     },
-    "services.activate_led.fields.inter_delay3.name": {
+    "services\u0000activate_led\u0000fields\u0000inter_delay3\u0000name": {
       "out": "656f06132f4f",
       "src": "b0f72903777e"
     },
-    "services.activate_led.fields.loop_delay1.description": {
+    "services\u0000activate_led\u0000fields\u0000loop_delay1\u0000description": {
       "out": "22fabf9e8658",
       "src": "2139915c35bc"
     },
-    "services.activate_led.fields.loop_delay1.name": {
+    "services\u0000activate_led\u0000fields\u0000loop_delay1\u0000name": {
       "out": "cf0342b33575",
       "src": "2fb02375bae0"
     },
-    "services.activate_led.fields.loop_delay2.description": {
+    "services\u0000activate_led\u0000fields\u0000loop_delay2\u0000description": {
       "out": "b893b4c35f01",
       "src": "9a3a8cccb3bb"
     },
-    "services.activate_led.fields.loop_delay2.name": {
+    "services\u0000activate_led\u0000fields\u0000loop_delay2\u0000name": {
       "out": "886b24677799",
       "src": "597cbe87a7ec"
     },
-    "services.activate_led.fields.loop_delay3.description": {
+    "services\u0000activate_led\u0000fields\u0000loop_delay3\u0000description": {
       "out": "f9a5da863e9b",
       "src": "8a965100226c"
     },
-    "services.activate_led.fields.loop_delay3.name": {
+    "services\u0000activate_led\u0000fields\u0000loop_delay3\u0000name": {
       "out": "589b4807f8a3",
       "src": "66d787aa1bad"
     },
-    "services.activate_led.fields.repeats.description": {
+    "services\u0000activate_led\u0000fields\u0000repeats\u0000description": {
       "out": "ffec2e7fc70c",
       "src": "e40e956e3762"
     },
-    "services.activate_led.fields.repeats.name": {
+    "services\u0000activate_led\u0000fields\u0000repeats\u0000name": {
       "out": "57db92bda9a5",
       "src": "92ee0233f013"
     },
-    "services.activate_led.name": {
+    "services\u0000activate_led\u0000name": {
       "out": "0457442a4a9a",
       "src": "91933e94cc57"
     },
-    "services.drawcustom.description": {
+    "services\u0000drawcustom\u0000description": {
       "out": "c41ec5a1e657",
       "src": "55f9f3333fc0"
     },
-    "services.drawcustom.fields.background.description": {
+    "services\u0000drawcustom\u0000fields\u0000background\u0000description": {
       "out": "ea091067cfa8",
       "src": "f5858405d78a"
     },
-    "services.drawcustom.fields.background.name": {
+    "services\u0000drawcustom\u0000fields\u0000background\u0000name": {
       "out": "957e64d35fd3",
       "src": "3e314dafdf7c"
     },
-    "services.drawcustom.fields.dither.description": {
+    "services\u0000drawcustom\u0000fields\u0000dither\u0000description": {
       "out": "92b10f6b069c",
       "src": "d7c737e5d01e"
     },
-    "services.drawcustom.fields.dither.name": {
+    "services\u0000drawcustom\u0000fields\u0000dither\u0000name": {
       "out": "0fa65914f534",
       "src": "35fb13830002"
     },
-    "services.drawcustom.fields.dry-run.description": {
+    "services\u0000drawcustom\u0000fields\u0000dry-run\u0000description": {
       "out": "0913d7609357",
       "src": "54f5f06db00c"
     },
-    "services.drawcustom.fields.dry-run.name": {
+    "services\u0000drawcustom\u0000fields\u0000dry-run\u0000name": {
       "out": "cd9c1744785c",
       "src": "d5da154d9f00"
     },
-    "services.drawcustom.fields.measured_palette.description": {
+    "services\u0000drawcustom\u0000fields\u0000measured_palette\u0000description": {
       "out": "b637e22adff7",
       "src": "53842124c7af"
     },
-    "services.drawcustom.fields.measured_palette.name": {
+    "services\u0000drawcustom\u0000fields\u0000measured_palette\u0000name": {
       "out": "0466eb8ca82b",
       "src": "672d38bdeb19"
     },
-    "services.drawcustom.fields.payload.description": {
+    "services\u0000drawcustom\u0000fields\u0000payload\u0000description": {
       "out": "e687b78d71f1",
       "src": "a72e3d514ead"
     },
-    "services.drawcustom.fields.payload.name": {
+    "services\u0000drawcustom\u0000fields\u0000payload\u0000name": {
       "out": "cec8c2eed133",
       "src": "99733344956d"
     },
-    "services.drawcustom.fields.refresh_type.description": {
+    "services\u0000drawcustom\u0000fields\u0000refresh_type\u0000description": {
       "out": "aec55315bee1",
       "src": "d87a3d5c4d06"
     },
-    "services.drawcustom.fields.refresh_type.name": {
+    "services\u0000drawcustom\u0000fields\u0000refresh_type\u0000name": {
       "out": "df798e91afea",
       "src": "201b25b874bb"
     },
-    "services.drawcustom.fields.rotate.description": {
+    "services\u0000drawcustom\u0000fields\u0000rotate\u0000description": {
       "out": "67334075f5c1",
       "src": "21e39f93db71"
     },
-    "services.drawcustom.fields.rotate.name": {
+    "services\u0000drawcustom\u0000fields\u0000rotate\u0000name": {
       "out": "a607297da2aa",
       "src": "57b5e2fc1bba"
     },
-    "services.drawcustom.name": {
+    "services\u0000drawcustom\u0000name": {
       "out": "e258d0bbfad9",
       "src": "d0df7a6244ea"
     },
-    "services.upload_image.description": {
+    "services\u0000upload_image\u0000description": {
       "out": "d0a115fc3148",
       "src": "24e19354eaa4"
     },
-    "services.upload_image.fields.device_id.description": {
+    "services\u0000upload_image\u0000fields\u0000device_id\u0000description": {
       "out": "2e3bc6c204bc",
       "src": "ee157333391e"
     },
-    "services.upload_image.fields.device_id.name": {
+    "services\u0000upload_image\u0000fields\u0000device_id\u0000name": {
       "out": "e1363fae54dc",
       "src": "6ba0bdeccb42"
     },
-    "services.upload_image.fields.dither_mode.description": {
+    "services\u0000upload_image\u0000fields\u0000dither_mode\u0000description": {
       "out": "6370658d6970",
       "src": "70483fdfe7ec"
     },
-    "services.upload_image.fields.dither_mode.name": {
+    "services\u0000upload_image\u0000fields\u0000dither_mode\u0000name": {
       "out": "0fa65914f534",
       "src": "35fb13830002"
     },
-    "services.upload_image.fields.fit_mode.description": {
+    "services\u0000upload_image\u0000fields\u0000fit_mode\u0000description": {
       "out": "9db7c9fc40cd",
       "src": "8d2c8735a962"
     },
-    "services.upload_image.fields.fit_mode.name": {
+    "services\u0000upload_image\u0000fields\u0000fit_mode\u0000name": {
       "out": "dc6f12db12ac",
       "src": "8a59790c9187"
     },
-    "services.upload_image.fields.image.description": {
+    "services\u0000upload_image\u0000fields\u0000image\u0000description": {
       "out": "7fff4af997f1",
       "src": "ba6d9fb759b0"
     },
-    "services.upload_image.fields.image.name": {
+    "services\u0000upload_image\u0000fields\u0000image\u0000name": {
       "out": "61f1115604e3",
       "src": "1aa4cb0bcca7"
     },
-    "services.upload_image.fields.measured_palette.description": {
+    "services\u0000upload_image\u0000fields\u0000measured_palette\u0000description": {
       "out": "489976f9cc3f",
       "src": "53842124c7af"
     },
-    "services.upload_image.fields.measured_palette.name": {
+    "services\u0000upload_image\u0000fields\u0000measured_palette\u0000name": {
       "out": "0466eb8ca82b",
       "src": "672d38bdeb19"
     },
-    "services.upload_image.fields.refresh_mode.description": {
+    "services\u0000upload_image\u0000fields\u0000refresh_mode\u0000description": {
       "out": "b9e70315e14a",
       "src": "0fe957da240a"
     },
-    "services.upload_image.fields.refresh_mode.name": {
+    "services\u0000upload_image\u0000fields\u0000refresh_mode\u0000name": {
       "out": "c41e76bb7993",
       "src": "c72fd253298c"
     },
-    "services.upload_image.fields.rotation.description": {
+    "services\u0000upload_image\u0000fields\u0000rotation\u0000description": {
       "out": "0670ee63d178",
       "src": "b639ab27209e"
     },
-    "services.upload_image.fields.rotation.name": {
+    "services\u0000upload_image\u0000fields\u0000rotation\u0000name": {
       "out": "dca80c8604f0",
       "src": "57b5e2fc1bba"
     },
-    "services.upload_image.fields.tone_compression.description": {
+    "services\u0000upload_image\u0000fields\u0000tone_compression\u0000description": {
       "out": "43814e4235b6",
       "src": "6453b45ae0cc"
     },
-    "services.upload_image.fields.tone_compression.name": {
+    "services\u0000upload_image\u0000fields\u0000tone_compression\u0000name": {
       "out": "7d3542453da5",
       "src": "ffaed65f03fa"
     },
-    "services.upload_image.name": {
+    "services\u0000upload_image\u0000name": {
       "out": "803d97e4739e",
       "src": "ffe4df6c7ca6"
     },
-    "services.upload_image.sections.additional_fields.name": {
+    "services\u0000upload_image\u0000sections\u0000additional_fields\u0000name": {
       "out": "a127f78dbb07",
       "src": "092170b2408b"
     },
-    "services.write_nfc.description": {
+    "services\u0000write_nfc\u0000description": {
       "out": "a503a1d01e8b",
       "src": "3c1f6a6d643e"
     },
-    "services.write_nfc.fields.content.description": {
+    "services\u0000write_nfc\u0000fields\u0000content\u0000description": {
       "out": "6eb3a3b98a3a",
       "src": "857d1cf0bf90"
     },
-    "services.write_nfc.fields.content.name": {
+    "services\u0000write_nfc\u0000fields\u0000content\u0000name": {
       "out": "cec8c2eed133",
       "src": "47bd29075f8b"
     },
-    "services.write_nfc.fields.device_id.description": {
+    "services\u0000write_nfc\u0000fields\u0000device_id\u0000description": {
       "out": "082aa38abb33",
       "src": "7dec980cb238"
     },
-    "services.write_nfc.fields.device_id.name": {
+    "services\u0000write_nfc\u0000fields\u0000device_id\u0000name": {
       "out": "e1363fae54dc",
       "src": "6ba0bdeccb42"
     },
-    "services.write_nfc.fields.mime_type.description": {
+    "services\u0000write_nfc\u0000fields\u0000mime_type\u0000description": {
       "out": "317edf3902f2",
       "src": "4eb2b40ec666"
     },
-    "services.write_nfc.fields.mime_type.name": {
+    "services\u0000write_nfc\u0000fields\u0000mime_type\u0000name": {
       "out": "a6175133210c",
       "src": "849e8a810960"
     },
-    "services.write_nfc.fields.record_type.description": {
+    "services\u0000write_nfc\u0000fields\u0000record_type\u0000description": {
       "out": "e1274dbe5fd7",
       "src": "936cf634012f"
     },
-    "services.write_nfc.fields.record_type.name": {
+    "services\u0000write_nfc\u0000fields\u0000record_type\u0000name": {
       "out": "f6b062c049e9",
       "src": "91cf117b1d70"
     },
-    "services.write_nfc.name": {
+    "services\u0000write_nfc\u0000name": {
       "out": "045d72869ebd",
       "src": "96ea14b97cf7"
     }
   },
   "de": {
-    "config.abort.already_configured": {
+    "config\u0000abort\u0000already_configured": {
       "out": "c9b4894d2c0a",
       "src": "c2936e02a0d2"
     },
-    "config.abort.already_in_progress": {
+    "config\u0000abort\u0000already_in_progress": {
       "out": "4133b45916fd",
       "src": "985a72ad93a3"
     },
-    "config.abort.cannot_connect": {
+    "config\u0000abort\u0000cannot_connect": {
       "out": "9f5c81a587e0",
       "src": "46c9f3b7520f"
     },
-    "config.abort.no_devices_found": {
+    "config\u0000abort\u0000no_devices_found": {
       "out": "8733c1f43375",
       "src": "b8f28e84cf0b"
     },
-    "config.abort.reauth_successful": {
+    "config\u0000abort\u0000reauth_successful": {
       "out": "6abfbf86672f",
       "src": "e5b83989735c"
     },
-    "config.abort.unknown": {
+    "config\u0000abort\u0000unknown": {
       "out": "1bb6bb85adff",
       "src": "d24c41ae530a"
     },
-    "config.error.cannot_connect": {
+    "config\u0000error\u0000cannot_connect": {
       "out": "9f5c81a587e0",
       "src": "46c9f3b7520f"
     },
-    "config.error.invalid_auth": {
+    "config\u0000error\u0000invalid_auth": {
       "out": "0c1e9f96ab73",
       "src": "4ca089878c5f"
     },
-    "config.error.invalid_key_format": {
+    "config\u0000error\u0000invalid_key_format": {
       "out": "51a4db5b6494",
       "src": "f7b03dd699df"
     },
-    "config.error.unknown": {
+    "config\u0000error\u0000unknown": {
       "out": "1bb6bb85adff",
       "src": "d24c41ae530a"
     },
-    "config.flow_title": {
+    "config\u0000flow_title": {
       "out": "5e291d7bcb2d",
       "src": "5e291d7bcb2d"
     },
-    "config.step.bluetooth_confirm.description": {
+    "config\u0000step\u0000bluetooth_confirm\u0000description": {
       "out": "ecff72aba247",
       "src": "bcfd5a24b7d7"
     },
-    "config.step.encryption_key.data.encryption_key": {
+    "config\u0000step\u0000encryption_key\u0000data\u0000encryption_key": {
       "out": "b60d860c061b",
       "src": "16b3c9d5573d"
     },
-    "config.step.encryption_key.data_description.encryption_key": {
+    "config\u0000step\u0000encryption_key\u0000data_description\u0000encryption_key": {
       "out": "14c2dc6bdbf9",
       "src": "e64cd2e7e647"
     },
-    "config.step.encryption_key.description": {
+    "config\u0000step\u0000encryption_key\u0000description": {
       "out": "8b7e9493d7b5",
       "src": "664d3f12bfe6"
     },
-    "config.step.encryption_key.title": {
+    "config\u0000step\u0000encryption_key\u0000title": {
       "out": "e64cc8c774de",
       "src": "c30d1ca158a3"
     },
-    "config.step.reauth_confirm.data.encryption_key": {
+    "config\u0000step\u0000reauth_confirm\u0000data\u0000encryption_key": {
       "out": "b60d860c061b",
       "src": "16b3c9d5573d"
     },
-    "config.step.reauth_confirm.data_description.encryption_key": {
+    "config\u0000step\u0000reauth_confirm\u0000data_description\u0000encryption_key": {
       "out": "14c2dc6bdbf9",
       "src": "e64cd2e7e647"
     },
-    "config.step.reauth_confirm.description": {
+    "config\u0000step\u0000reauth_confirm\u0000description": {
       "out": "b8118ea64501",
       "src": "f53b69d3be84"
     },
-    "config.step.reauth_confirm.title": {
+    "config\u0000step\u0000reauth_confirm\u0000title": {
       "out": "4a8707a38e51",
       "src": "7e22a752572f"
     },
-    "config.step.user.data.address": {
+    "config\u0000step\u0000user\u0000data\u0000address": {
       "out": "b32db78620d9",
       "src": "6ba0bdeccb42"
     },
-    "config.step.user.data_description.address": {
+    "config\u0000step\u0000user\u0000data_description\u0000address": {
       "out": "2c8fea906f6e",
       "src": "a083a457cfb1"
     },
-    "config.step.user.description": {
+    "config\u0000step\u0000user\u0000description": {
       "out": "557f8f83b684",
       "src": "109135454652"
     },
-    "entity.binary_sensor.update_pending.name": {
+    "entity\u0000binary_sensor\u0000update_pending\u0000name": {
       "out": "f891020eff67",
       "src": "8e0a4b18ae75"
     },
-    "entity.event.button.name": {
+    "entity\u0000event\u0000button\u0000name": {
       "out": "76cf838efac6",
       "src": "2dcae43716c2"
     },
-    "entity.event.button.state_attributes.event_type.state.button_down": {
+    "entity\u0000event\u0000button\u0000state_attributes\u0000event_type\u0000state\u0000button_down": {
       "out": "1d47b9367e9b",
       "src": "8352c89d20b4"
     },
-    "entity.event.button.state_attributes.event_type.state.button_up": {
+    "entity\u0000event\u0000button\u0000state_attributes\u0000event_type\u0000state\u0000button_up": {
       "out": "8c2301b474ea",
       "src": "7f18b4912929"
     },
-    "entity.event.touch.name": {
+    "entity\u0000event\u0000touch\u0000name": {
       "out": "32bb934a90a5",
       "src": "c915d14278fc"
     },
-    "entity.event.touch.state_attributes.event_type.state.touch_down": {
+    "entity\u0000event\u0000touch\u0000state_attributes\u0000event_type\u0000state\u0000touch_down": {
       "out": "fc293df02339",
       "src": "0234a9576230"
     },
-    "entity.event.touch.state_attributes.event_type.state.touch_move": {
+    "entity\u0000event\u0000touch\u0000state_attributes\u0000event_type\u0000state\u0000touch_move": {
       "out": "ff7d5231d9a8",
       "src": "67aeac815e94"
     },
-    "entity.event.touch.state_attributes.event_type.state.touch_up": {
+    "entity\u0000event\u0000touch\u0000state_attributes\u0000event_type\u0000state\u0000touch_up": {
       "out": "3b8887e21536",
       "src": "7c65519d3bb3"
     },
-    "entity.image.content.name": {
+    "entity\u0000image\u0000content\u0000name": {
       "out": "c38ca3f0b649",
       "src": "047c6db3382a"
     },
-    "entity.sensor.battery_voltage.name": {
+    "entity\u0000sensor\u0000battery_voltage\u0000name": {
       "out": "beeb8ebab924",
       "src": "39d6c91b57ce"
     },
-    "entity.sensor.last_seen.name": {
+    "entity\u0000sensor\u0000last_seen\u0000name": {
       "out": "32522f222b66",
       "src": "21fd79c7de52"
     },
-    "entity.sensor.rssi.name": {
+    "entity\u0000sensor\u0000rssi\u0000name": {
       "out": "26a29a7b13f7",
       "src": "2604d15c1187"
     },
-    "entity.update.firmware.name": {
+    "entity\u0000update\u0000firmware\u0000name": {
       "out": "c2a314c3b32b",
       "src": "c2a314c3b32b"
     },
-    "exceptions.authentication_error.message": {
+    "exceptions\u0000authentication_error\u0000message": {
       "out": "9e507db4cc0f",
       "src": "3d9f7c0c6d80"
     },
-    "exceptions.device_not_found.message": {
+    "exceptions\u0000device_not_found\u0000message": {
       "out": "5c1f9c1134fc",
       "src": "f244d0d2db8d"
     },
-    "exceptions.device_sleeping.message": {
+    "exceptions\u0000device_sleeping\u0000message": {
       "out": "61fe3775a645",
       "src": "e95d25bd6fc7"
     },
-    "exceptions.device_sleeping_ota.message": {
+    "exceptions\u0000device_sleeping_ota\u0000message": {
       "out": "5b60bade6dcc",
       "src": "430e3a1baa6a"
     },
-    "exceptions.invalid_device_id.message": {
+    "exceptions\u0000invalid_device_id\u0000message": {
       "out": "9c06ec0618e4",
       "src": "cc64cc29ceeb"
     },
-    "exceptions.media_download_error.message": {
+    "exceptions\u0000media_download_error\u0000message": {
       "out": "55b588a0733a",
       "src": "5852129dd920"
     },
-    "exceptions.mime_type_not_applicable.message": {
+    "exceptions\u0000mime_type_not_applicable\u0000message": {
       "out": "3c2db98f77c2",
       "src": "de700f02fbd5"
     },
-    "exceptions.multiple_errors.message": {
+    "exceptions\u0000multiple_errors\u0000message": {
       "out": "b35c4f55b78e",
       "src": "f17c68e0a848"
     },
-    "exceptions.nfc_content_empty.message": {
+    "exceptions\u0000nfc_content_empty\u0000message": {
       "out": "3d9b3519fd41",
       "src": "b93a1a6ebdc0"
     },
-    "exceptions.nfc_content_too_long.message": {
+    "exceptions\u0000nfc_content_too_long\u0000message": {
       "out": "9d31c9e46595",
       "src": "8f580b9c6c76"
     },
-    "exceptions.nfc_mime_type_invalid.message": {
+    "exceptions\u0000nfc_mime_type_invalid\u0000message": {
       "out": "617172c5484f",
       "src": "5a5f44fe332f"
     },
-    "exceptions.nfc_not_supported.message": {
+    "exceptions\u0000nfc_not_supported\u0000message": {
       "out": "3e0390544aec",
       "src": "8fdcd0e2bd17"
     },
-    "exceptions.nfc_write_failed.message": {
+    "exceptions\u0000nfc_write_failed\u0000message": {
       "out": "76c221e2e752",
       "src": "e8186303a52e"
     },
-    "exceptions.no_buzzers.message": {
+    "exceptions\u0000no_buzzers\u0000message": {
       "out": "76d6204ff6bc",
       "src": "9c014dfeac91"
     },
-    "exceptions.no_leds.message": {
+    "exceptions\u0000no_leds\u0000message": {
       "out": "d5a8382fb1a5",
       "src": "6a302f8f22ee"
     },
-    "exceptions.no_nfc.message": {
+    "exceptions\u0000no_nfc\u0000message": {
       "out": "5c539dd0cc41",
       "src": "abb1917ad57e"
     },
-    "exceptions.no_targets_specified.message": {
+    "exceptions\u0000no_targets_specified\u0000message": {
       "out": "1937c120929b",
       "src": "80c472afefe6"
     },
-    "exceptions.upload_error.message": {
+    "exceptions\u0000upload_error\u0000message": {
       "out": "a0d49d0ede2c",
       "src": "75561a03be6e"
     },
-    "exceptions.url_not_allowed.message": {
+    "exceptions\u0000url_not_allowed\u0000message": {
       "out": "fbd45bf5d464",
       "src": "33ffb9a9f2c4"
     },
-    "options.step.init.data.blocks_per_ack": {
+    "options\u0000step\u0000init\u0000data\u0000blocks_per_ack": {
       "out": "f407ac69b8bd",
       "src": "3e2a554e69a4"
     },
-    "options.step.init.data.max_queue_size": {
+    "options\u0000step\u0000init\u0000data\u0000max_queue_size": {
       "out": "5d89bbe0c4ff",
       "src": "297af7027dd0"
     },
-    "options.step.init.data.missed_cycles": {
+    "options\u0000step\u0000init\u0000data\u0000missed_cycles": {
       "out": "5615dc03f7cf",
       "src": "59b78644491a"
     },
-    "options.step.init.data.probe_before_queue": {
+    "options\u0000step\u0000init\u0000data\u0000probe_before_queue": {
       "out": "e3543b3b4739",
       "src": "02c4211a58b2"
     },
-    "options.step.init.data.queue_timeout_hours": {
+    "options\u0000step\u0000init\u0000data\u0000queue_timeout_hours": {
       "out": "638bc53d3ee0",
       "src": "be70fc5cca79"
     },
-    "options.step.init.data.sleep_mode": {
+    "options\u0000step\u0000init\u0000data\u0000sleep_mode": {
       "out": "f5eca6790b6e",
       "src": "f925c0e541ce"
     },
-    "options.step.init.data_description.blocks_per_ack": {
+    "options\u0000step\u0000init\u0000data_description\u0000blocks_per_ack": {
       "out": "88a9bf326be4",
       "src": "3a693b19d3c6"
     },
-    "options.step.init.data_description.max_queue_size": {
+    "options\u0000step\u0000init\u0000data_description\u0000max_queue_size": {
       "out": "3ab2a26606e1",
       "src": "50260959ee56"
     },
-    "options.step.init.data_description.missed_cycles": {
+    "options\u0000step\u0000init\u0000data_description\u0000missed_cycles": {
       "out": "88826c48d3e3",
       "src": "6ce493f4c44d"
     },
-    "options.step.init.data_description.probe_before_queue": {
+    "options\u0000step\u0000init\u0000data_description\u0000probe_before_queue": {
       "out": "5246b4eabf36",
       "src": "5d0f2985ffdf"
     },
-    "options.step.init.data_description.queue_timeout_hours": {
+    "options\u0000step\u0000init\u0000data_description\u0000queue_timeout_hours": {
       "out": "e748b489eecb",
       "src": "34895000b491"
     },
-    "options.step.init.data_description.sleep_mode": {
+    "options\u0000step\u0000init\u0000data_description\u0000sleep_mode": {
       "out": "adcf41634e3b",
       "src": "4acfeb65d10d"
     },
-    "selector.dither_mode.options.atkinson": {
+    "selector\u0000dither_mode\u0000options\u0000atkinson": {
       "out": "7a8fe6d47b5b",
       "src": "7a8fe6d47b5b"
     },
-    "selector.dither_mode.options.burkes": {
+    "selector\u0000dither_mode\u0000options\u0000burkes": {
       "out": "1b75087201fb",
       "src": "1b75087201fb"
     },
-    "selector.dither_mode.options.floyd_steinberg": {
+    "selector\u0000dither_mode\u0000options\u0000floyd_steinberg": {
       "out": "37969811a3cf",
       "src": "37969811a3cf"
     },
-    "selector.dither_mode.options.jarvis_judice_ninke": {
+    "selector\u0000dither_mode\u0000options\u0000jarvis_judice_ninke": {
       "out": "7020241adf78",
       "src": "7020241adf78"
     },
-    "selector.dither_mode.options.none": {
+    "selector\u0000dither_mode\u0000options\u0000none": {
       "out": "8a572015c49b",
       "src": "dc937b598926"
     },
-    "selector.dither_mode.options.ordered": {
+    "selector\u0000dither_mode\u0000options\u0000ordered": {
       "out": "f496918f9be6",
       "src": "007877479e21"
     },
-    "selector.dither_mode.options.sierra": {
+    "selector\u0000dither_mode\u0000options\u0000sierra": {
       "out": "d5eef8ad210c",
       "src": "d5eef8ad210c"
     },
-    "selector.dither_mode.options.sierra_lite": {
+    "selector\u0000dither_mode\u0000options\u0000sierra_lite": {
       "out": "20da8cc85f38",
       "src": "20da8cc85f38"
     },
-    "selector.dither_mode.options.stucki": {
+    "selector\u0000dither_mode\u0000options\u0000stucki": {
       "out": "a17d2b13b6f9",
       "src": "a17d2b13b6f9"
     },
-    "selector.fit_mode.options.contain": {
+    "selector\u0000fit_mode\u0000options\u0000contain": {
       "out": "56743fb5d71a",
       "src": "e534a2c2b456"
     },
-    "selector.fit_mode.options.cover": {
+    "selector\u0000fit_mode\u0000options\u0000cover": {
       "out": "03a2eb101be5",
       "src": "fa8d84566676"
     },
-    "selector.fit_mode.options.crop": {
+    "selector\u0000fit_mode\u0000options\u0000crop": {
       "out": "a7ee0740f7f1",
       "src": "98caf7c43c6f"
     },
-    "selector.fit_mode.options.stretch": {
+    "selector\u0000fit_mode\u0000options\u0000stretch": {
       "out": "88a2b24c1ce0",
       "src": "a33fbcf83f7b"
     },
-    "selector.nfc_record_type.options.ha_tag": {
+    "selector\u0000nfc_record_type\u0000options\u0000ha_tag": {
       "out": "1f919f97794b",
       "src": "d1d47a8fa544"
     },
-    "selector.nfc_record_type.options.mime": {
+    "selector\u0000nfc_record_type\u0000options\u0000mime": {
       "out": "620341f3ccc0",
       "src": "f98d7539e627"
     },
-    "selector.nfc_record_type.options.text": {
+    "selector\u0000nfc_record_type\u0000options\u0000text": {
       "out": "71988c4d8e08",
       "src": "71988c4d8e08"
     },
-    "selector.nfc_record_type.options.url": {
+    "selector\u0000nfc_record_type\u0000options\u0000url": {
       "out": "e7a241debad5",
       "src": "e7a241debad5"
     },
-    "selector.refresh_mode.options.fast": {
+    "selector\u0000refresh_mode\u0000options\u0000fast": {
       "out": "4d1272d42b9b",
       "src": "6c582b62e0e5"
     },
-    "selector.refresh_mode.options.full": {
+    "selector\u0000refresh_mode\u0000options\u0000full": {
       "out": "9eae8e7efb47",
       "src": "008dacb6d1e8"
     },
-    "selector.refresh_mode.options.partial": {
+    "selector\u0000refresh_mode\u0000options\u0000partial": {
       "out": "296f1fe2c06d",
       "src": "a4d50fb85403"
     },
-    "selector.sleep_mode.options.auto": {
+    "selector\u0000sleep_mode\u0000options\u0000auto": {
       "out": "0a99ee8281a3",
       "src": "132990bd8ef7"
     },
-    "selector.sleep_mode.options.off": {
+    "selector\u0000sleep_mode\u0000options\u0000off": {
       "out": "a150b5702aff",
       "src": "34598efe7b90"
     },
-    "selector.sleep_mode.options.on": {
+    "selector\u0000sleep_mode\u0000options\u0000on": {
       "out": "b7d0f2c29d4e",
       "src": "bde131e31c9e"
     },
-    "services.activate_buzzer.description": {
+    "services\u0000activate_buzzer\u0000description": {
       "out": "b67a5314e9bc",
       "src": "1898784614cb"
     },
-    "services.activate_buzzer.fields.device_id.description": {
+    "services\u0000activate_buzzer\u0000fields\u0000device_id\u0000description": {
       "out": "c9d3248db546",
       "src": "7dec980cb238"
     },
-    "services.activate_buzzer.fields.device_id.name": {
+    "services\u0000activate_buzzer\u0000fields\u0000device_id\u0000name": {
       "out": "b32db78620d9",
       "src": "6ba0bdeccb42"
     },
-    "services.activate_buzzer.fields.duration_ms.description": {
+    "services\u0000activate_buzzer\u0000fields\u0000duration_ms\u0000description": {
       "out": "51ea736fee20",
       "src": "cd1bc75ca60c"
     },
-    "services.activate_buzzer.fields.duration_ms.name": {
+    "services\u0000activate_buzzer\u0000fields\u0000duration_ms\u0000name": {
       "out": "668cbe316167",
       "src": "4fc52a3c4c55"
     },
-    "services.activate_buzzer.fields.frequency_hz.description": {
+    "services\u0000activate_buzzer\u0000fields\u0000frequency_hz\u0000description": {
       "out": "ac4bba206ebd",
       "src": "510fc20311e3"
     },
-    "services.activate_buzzer.fields.frequency_hz.name": {
+    "services\u0000activate_buzzer\u0000fields\u0000frequency_hz\u0000name": {
       "out": "68b6fcc1ea1b",
       "src": "16b6668d9831"
     },
-    "services.activate_buzzer.fields.instance.description": {
+    "services\u0000activate_buzzer\u0000fields\u0000instance\u0000description": {
       "out": "adc1a6c3c436",
       "src": "f39fa742d55c"
     },
-    "services.activate_buzzer.fields.instance.name": {
+    "services\u0000activate_buzzer\u0000fields\u0000instance\u0000name": {
       "out": "9280d2bb03e2",
       "src": "1f671ddded9e"
     },
-    "services.activate_buzzer.fields.repeats.description": {
+    "services\u0000activate_buzzer\u0000fields\u0000repeats\u0000description": {
       "out": "39741bdba44d",
       "src": "1f88b0fe23ea"
     },
-    "services.activate_buzzer.fields.repeats.name": {
+    "services\u0000activate_buzzer\u0000fields\u0000repeats\u0000name": {
       "out": "b93838e6408f",
       "src": "92ee0233f013"
     },
-    "services.activate_buzzer.name": {
+    "services\u0000activate_buzzer\u0000name": {
       "out": "949c6996af70",
       "src": "0b80285753b7"
     },
-    "services.activate_led.description": {
+    "services\u0000activate_led\u0000description": {
       "out": "bf1feaf64630",
       "src": "6cbd645597cc"
     },
-    "services.activate_led.fields.brightness.description": {
+    "services\u0000activate_led\u0000fields\u0000brightness\u0000description": {
       "out": "a2a49c5e243a",
       "src": "6ad88a28230d"
     },
-    "services.activate_led.fields.brightness.name": {
+    "services\u0000activate_led\u0000fields\u0000brightness\u0000name": {
       "out": "00b737a90a4a",
       "src": "ec811d30a89c"
     },
-    "services.activate_led.fields.color1.description": {
+    "services\u0000activate_led\u0000fields\u0000color1\u0000description": {
       "out": "528ef41884fd",
       "src": "17f145013241"
     },
-    "services.activate_led.fields.color1.name": {
+    "services\u0000activate_led\u0000fields\u0000color1\u0000name": {
       "out": "0539eb2c084a",
       "src": "571461f36f3a"
     },
-    "services.activate_led.fields.color2.description": {
+    "services\u0000activate_led\u0000fields\u0000color2\u0000description": {
       "out": "b03d5b89f419",
       "src": "f2680a4bbe85"
     },
-    "services.activate_led.fields.color2.name": {
+    "services\u0000activate_led\u0000fields\u0000color2\u0000name": {
       "out": "5da9bac05b38",
       "src": "ef792d287872"
     },
-    "services.activate_led.fields.color3.description": {
+    "services\u0000activate_led\u0000fields\u0000color3\u0000description": {
       "out": "f35b1e471369",
       "src": "b8ecd353b426"
     },
-    "services.activate_led.fields.color3.name": {
+    "services\u0000activate_led\u0000fields\u0000color3\u0000name": {
       "out": "4dfaa7e17220",
       "src": "48d54e046d29"
     },
-    "services.activate_led.fields.device_id.description": {
+    "services\u0000activate_led\u0000fields\u0000device_id\u0000description": {
       "out": "c9d3248db546",
       "src": "7dec980cb238"
     },
-    "services.activate_led.fields.device_id.name": {
+    "services\u0000activate_led\u0000fields\u0000device_id\u0000name": {
       "out": "b32db78620d9",
       "src": "6ba0bdeccb42"
     },
-    "services.activate_led.fields.flash_count1.description": {
+    "services\u0000activate_led\u0000fields\u0000flash_count1\u0000description": {
       "out": "510b9dbf8c6b",
       "src": "4ffdadde31c2"
     },
-    "services.activate_led.fields.flash_count1.name": {
+    "services\u0000activate_led\u0000fields\u0000flash_count1\u0000name": {
       "out": "e8b4d938c9cd",
       "src": "13c6a2e5c22e"
     },
-    "services.activate_led.fields.flash_count2.description": {
+    "services\u0000activate_led\u0000fields\u0000flash_count2\u0000description": {
       "out": "fb78d61d9443",
       "src": "86dc999a3915"
     },
-    "services.activate_led.fields.flash_count2.name": {
+    "services\u0000activate_led\u0000fields\u0000flash_count2\u0000name": {
       "out": "5fdb5ef0ab6c",
       "src": "2be36d8449dc"
     },
-    "services.activate_led.fields.flash_count3.description": {
+    "services\u0000activate_led\u0000fields\u0000flash_count3\u0000description": {
       "out": "0e460c43a75c",
       "src": "aa40c396a9a4"
     },
-    "services.activate_led.fields.flash_count3.name": {
+    "services\u0000activate_led\u0000fields\u0000flash_count3\u0000name": {
       "out": "ddef8b74eb45",
       "src": "7978910dc6b2"
     },
-    "services.activate_led.fields.instance.description": {
+    "services\u0000activate_led\u0000fields\u0000instance\u0000description": {
       "out": "488e61e0b007",
       "src": "0531b37de90a"
     },
-    "services.activate_led.fields.instance.name": {
+    "services\u0000activate_led\u0000fields\u0000instance\u0000name": {
       "out": "d45911100f53",
       "src": "f942926204c7"
     },
-    "services.activate_led.fields.inter_delay1.description": {
+    "services\u0000activate_led\u0000fields\u0000inter_delay1\u0000description": {
       "out": "d6b3493aefae",
       "src": "1b65dcfcea95"
     },
-    "services.activate_led.fields.inter_delay1.name": {
+    "services\u0000activate_led\u0000fields\u0000inter_delay1\u0000name": {
       "out": "15d328411824",
       "src": "71452f436c33"
     },
-    "services.activate_led.fields.inter_delay2.description": {
+    "services\u0000activate_led\u0000fields\u0000inter_delay2\u0000description": {
       "out": "c472b1cbd40b",
       "src": "181e03f33cbf"
     },
-    "services.activate_led.fields.inter_delay2.name": {
+    "services\u0000activate_led\u0000fields\u0000inter_delay2\u0000name": {
       "out": "a21f401e77a6",
       "src": "6a50551e5355"
     },
-    "services.activate_led.fields.inter_delay3.description": {
+    "services\u0000activate_led\u0000fields\u0000inter_delay3\u0000description": {
       "out": "4c0f68b1894a",
       "src": "5c5973b586df"
     },
-    "services.activate_led.fields.inter_delay3.name": {
+    "services\u0000activate_led\u0000fields\u0000inter_delay3\u0000name": {
       "out": "ee390ed0822c",
       "src": "b0f72903777e"
     },
-    "services.activate_led.fields.loop_delay1.description": {
+    "services\u0000activate_led\u0000fields\u0000loop_delay1\u0000description": {
       "out": "6c65dd5b1d5e",
       "src": "2139915c35bc"
     },
-    "services.activate_led.fields.loop_delay1.name": {
+    "services\u0000activate_led\u0000fields\u0000loop_delay1\u0000name": {
       "out": "f231caca47fd",
       "src": "2fb02375bae0"
     },
-    "services.activate_led.fields.loop_delay2.description": {
+    "services\u0000activate_led\u0000fields\u0000loop_delay2\u0000description": {
       "out": "0d6ad5afb805",
       "src": "9a3a8cccb3bb"
     },
-    "services.activate_led.fields.loop_delay2.name": {
+    "services\u0000activate_led\u0000fields\u0000loop_delay2\u0000name": {
       "out": "31824443e583",
       "src": "597cbe87a7ec"
     },
-    "services.activate_led.fields.loop_delay3.description": {
+    "services\u0000activate_led\u0000fields\u0000loop_delay3\u0000description": {
       "out": "bc62fd7f23ed",
       "src": "8a965100226c"
     },
-    "services.activate_led.fields.loop_delay3.name": {
+    "services\u0000activate_led\u0000fields\u0000loop_delay3\u0000name": {
       "out": "8d76ef9731fb",
       "src": "66d787aa1bad"
     },
-    "services.activate_led.fields.repeats.description": {
+    "services\u0000activate_led\u0000fields\u0000repeats\u0000description": {
       "out": "e2e8578f3089",
       "src": "e40e956e3762"
     },
-    "services.activate_led.fields.repeats.name": {
+    "services\u0000activate_led\u0000fields\u0000repeats\u0000name": {
       "out": "b93838e6408f",
       "src": "92ee0233f013"
     },
-    "services.activate_led.name": {
+    "services\u0000activate_led\u0000name": {
       "out": "695c29fa44b0",
       "src": "91933e94cc57"
     },
-    "services.drawcustom.description": {
+    "services\u0000drawcustom\u0000description": {
       "out": "76a8ef04c1a6",
       "src": "55f9f3333fc0"
     },
-    "services.drawcustom.fields.background.description": {
+    "services\u0000drawcustom\u0000fields\u0000background\u0000description": {
       "out": "449e352f699b",
       "src": "f5858405d78a"
     },
-    "services.drawcustom.fields.background.name": {
+    "services\u0000drawcustom\u0000fields\u0000background\u0000name": {
       "out": "ac31c0c1c7e7",
       "src": "3e314dafdf7c"
     },
-    "services.drawcustom.fields.dither.description": {
+    "services\u0000drawcustom\u0000fields\u0000dither\u0000description": {
       "out": "cacbd413daf9",
       "src": "d7c737e5d01e"
     },
-    "services.drawcustom.fields.dither.name": {
+    "services\u0000drawcustom\u0000fields\u0000dither\u0000name": {
       "out": "ed8bce595a2d",
       "src": "35fb13830002"
     },
-    "services.drawcustom.fields.dry-run.description": {
+    "services\u0000drawcustom\u0000fields\u0000dry-run\u0000description": {
       "out": "3211c4927a10",
       "src": "54f5f06db00c"
     },
-    "services.drawcustom.fields.dry-run.name": {
+    "services\u0000drawcustom\u0000fields\u0000dry-run\u0000name": {
       "out": "e6a47af0d12e",
       "src": "d5da154d9f00"
     },
-    "services.drawcustom.fields.measured_palette.description": {
+    "services\u0000drawcustom\u0000fields\u0000measured_palette\u0000description": {
       "out": "3f08436f9451",
       "src": "53842124c7af"
     },
-    "services.drawcustom.fields.measured_palette.name": {
+    "services\u0000drawcustom\u0000fields\u0000measured_palette\u0000name": {
       "out": "708f2b8f834d",
       "src": "672d38bdeb19"
     },
-    "services.drawcustom.fields.payload.description": {
+    "services\u0000drawcustom\u0000fields\u0000payload\u0000description": {
       "out": "b7f39b62bb92",
       "src": "a72e3d514ead"
     },
-    "services.drawcustom.fields.payload.name": {
+    "services\u0000drawcustom\u0000fields\u0000payload\u0000name": {
       "out": "ccc72cfa3a65",
       "src": "99733344956d"
     },
-    "services.drawcustom.fields.refresh_type.description": {
+    "services\u0000drawcustom\u0000fields\u0000refresh_type\u0000description": {
       "out": "0738ab314ced",
       "src": "d87a3d5c4d06"
     },
-    "services.drawcustom.fields.refresh_type.name": {
+    "services\u0000drawcustom\u0000fields\u0000refresh_type\u0000name": {
       "out": "fd61a7155b28",
       "src": "201b25b874bb"
     },
-    "services.drawcustom.fields.rotate.description": {
+    "services\u0000drawcustom\u0000fields\u0000rotate\u0000description": {
       "out": "773fcdf3be50",
       "src": "21e39f93db71"
     },
-    "services.drawcustom.fields.rotate.name": {
+    "services\u0000drawcustom\u0000fields\u0000rotate\u0000name": {
       "out": "212c09d28b0c",
       "src": "57b5e2fc1bba"
     },
-    "services.drawcustom.name": {
+    "services\u0000drawcustom\u0000name": {
       "out": "8d49c980745b",
       "src": "d0df7a6244ea"
     },
-    "services.upload_image.description": {
+    "services\u0000upload_image\u0000description": {
       "out": "c2473cdf6eaa",
       "src": "24e19354eaa4"
     },
-    "services.upload_image.fields.device_id.description": {
+    "services\u0000upload_image\u0000fields\u0000device_id\u0000description": {
       "out": "215db5502603",
       "src": "ee157333391e"
     },
-    "services.upload_image.fields.device_id.name": {
+    "services\u0000upload_image\u0000fields\u0000device_id\u0000name": {
       "out": "b32db78620d9",
       "src": "6ba0bdeccb42"
     },
-    "services.upload_image.fields.dither_mode.description": {
+    "services\u0000upload_image\u0000fields\u0000dither_mode\u0000description": {
       "out": "8e4f53567201",
       "src": "70483fdfe7ec"
     },
-    "services.upload_image.fields.dither_mode.name": {
+    "services\u0000upload_image\u0000fields\u0000dither_mode\u0000name": {
       "out": "ed8bce595a2d",
       "src": "35fb13830002"
     },
-    "services.upload_image.fields.fit_mode.description": {
+    "services\u0000upload_image\u0000fields\u0000fit_mode\u0000description": {
       "out": "43bfe09eec5c",
       "src": "8d2c8735a962"
     },
-    "services.upload_image.fields.fit_mode.name": {
+    "services\u0000upload_image\u0000fields\u0000fit_mode\u0000name": {
       "out": "2eac0bac98fc",
       "src": "8a59790c9187"
     },
-    "services.upload_image.fields.image.description": {
+    "services\u0000upload_image\u0000fields\u0000image\u0000description": {
       "out": "3a51963f6e02",
       "src": "ba6d9fb759b0"
     },
-    "services.upload_image.fields.image.name": {
+    "services\u0000upload_image\u0000fields\u0000image\u0000name": {
       "out": "375e84034b8f",
       "src": "1aa4cb0bcca7"
     },
-    "services.upload_image.fields.measured_palette.description": {
+    "services\u0000upload_image\u0000fields\u0000measured_palette\u0000description": {
       "out": "025f11aa9800",
       "src": "53842124c7af"
     },
-    "services.upload_image.fields.measured_palette.name": {
+    "services\u0000upload_image\u0000fields\u0000measured_palette\u0000name": {
       "out": "708f2b8f834d",
       "src": "672d38bdeb19"
     },
-    "services.upload_image.fields.refresh_mode.description": {
+    "services\u0000upload_image\u0000fields\u0000refresh_mode\u0000description": {
       "out": "af677ca92e0c",
       "src": "0fe957da240a"
     },
-    "services.upload_image.fields.refresh_mode.name": {
+    "services\u0000upload_image\u0000fields\u0000refresh_mode\u0000name": {
       "out": "97584ab5521b",
       "src": "c72fd253298c"
     },
-    "services.upload_image.fields.rotation.description": {
+    "services\u0000upload_image\u0000fields\u0000rotation\u0000description": {
       "out": "f58b8d4fb11e",
       "src": "b639ab27209e"
     },
-    "services.upload_image.fields.rotation.name": {
+    "services\u0000upload_image\u0000fields\u0000rotation\u0000name": {
       "out": "57b5e2fc1bba",
       "src": "57b5e2fc1bba"
     },
-    "services.upload_image.fields.tone_compression.description": {
+    "services\u0000upload_image\u0000fields\u0000tone_compression\u0000description": {
       "out": "6be7b829aaa4",
       "src": "6453b45ae0cc"
     },
-    "services.upload_image.fields.tone_compression.name": {
+    "services\u0000upload_image\u0000fields\u0000tone_compression\u0000name": {
       "out": "91bc0fc58b48",
       "src": "ffaed65f03fa"
     },
-    "services.upload_image.name": {
+    "services\u0000upload_image\u0000name": {
       "out": "3c66c01e1539",
       "src": "ffe4df6c7ca6"
     },
-    "services.upload_image.sections.additional_fields.name": {
+    "services\u0000upload_image\u0000sections\u0000additional_fields\u0000name": {
       "out": "75b8b3d83662",
       "src": "092170b2408b"
     },
-    "services.write_nfc.description": {
+    "services\u0000write_nfc\u0000description": {
       "out": "2c3f5d1d2105",
       "src": "3c1f6a6d643e"
     },
-    "services.write_nfc.fields.content.description": {
+    "services\u0000write_nfc\u0000fields\u0000content\u0000description": {
       "out": "17d81bf1d44b",
       "src": "857d1cf0bf90"
     },
-    "services.write_nfc.fields.content.name": {
+    "services\u0000write_nfc\u0000fields\u0000content\u0000name": {
       "out": "3cc46559245d",
       "src": "47bd29075f8b"
     },
-    "services.write_nfc.fields.device_id.description": {
+    "services\u0000write_nfc\u0000fields\u0000device_id\u0000description": {
       "out": "c9d3248db546",
       "src": "7dec980cb238"
     },
-    "services.write_nfc.fields.device_id.name": {
+    "services\u0000write_nfc\u0000fields\u0000device_id\u0000name": {
       "out": "b32db78620d9",
       "src": "6ba0bdeccb42"
     },
-    "services.write_nfc.fields.mime_type.description": {
+    "services\u0000write_nfc\u0000fields\u0000mime_type\u0000description": {
       "out": "d5b1dd414bee",
       "src": "4eb2b40ec666"
     },
-    "services.write_nfc.fields.mime_type.name": {
+    "services\u0000write_nfc\u0000fields\u0000mime_type\u0000name": {
       "out": "5d5e7aa3f6ee",
       "src": "849e8a810960"
     },
-    "services.write_nfc.fields.record_type.description": {
+    "services\u0000write_nfc\u0000fields\u0000record_type\u0000description": {
       "out": "dad34c14e3bc",
       "src": "936cf634012f"
     },
-    "services.write_nfc.fields.record_type.name": {
+    "services\u0000write_nfc\u0000fields\u0000record_type\u0000name": {
       "out": "2cb82579c833",
       "src": "91cf117b1d70"
     },
-    "services.write_nfc.name": {
+    "services\u0000write_nfc\u0000name": {
       "out": "c9c85a560a98",
       "src": "96ea14b97cf7"
     }
   },
   "es": {
-    "config.abort.already_configured": {
+    "config\u0000abort\u0000already_configured": {
       "out": "dd16eb9b2a75",
       "src": "c2936e02a0d2"
     },
-    "config.abort.already_in_progress": {
+    "config\u0000abort\u0000already_in_progress": {
       "out": "c2f93a25217c",
       "src": "985a72ad93a3"
     },
-    "config.abort.cannot_connect": {
+    "config\u0000abort\u0000cannot_connect": {
       "out": "1e70a9f3dc49",
       "src": "46c9f3b7520f"
     },
-    "config.abort.no_devices_found": {
+    "config\u0000abort\u0000no_devices_found": {
       "out": "937384f4f174",
       "src": "b8f28e84cf0b"
     },
-    "config.abort.reauth_successful": {
+    "config\u0000abort\u0000reauth_successful": {
       "out": "cb0be5c2d01f",
       "src": "e5b83989735c"
     },
-    "config.abort.unknown": {
+    "config\u0000abort\u0000unknown": {
       "out": "52f98b7958d0",
       "src": "d24c41ae530a"
     },
-    "config.error.cannot_connect": {
+    "config\u0000error\u0000cannot_connect": {
       "out": "1e70a9f3dc49",
       "src": "46c9f3b7520f"
     },
-    "config.error.invalid_auth": {
+    "config\u0000error\u0000invalid_auth": {
       "out": "3b1fcaaaaaf0",
       "src": "4ca089878c5f"
     },
-    "config.error.invalid_key_format": {
+    "config\u0000error\u0000invalid_key_format": {
       "out": "33cfd75d440f",
       "src": "f7b03dd699df"
     },
-    "config.error.unknown": {
+    "config\u0000error\u0000unknown": {
       "out": "52f98b7958d0",
       "src": "d24c41ae530a"
     },
-    "config.flow_title": {
+    "config\u0000flow_title": {
       "out": "5e291d7bcb2d",
       "src": "5e291d7bcb2d"
     },
-    "config.step.bluetooth_confirm.description": {
+    "config\u0000step\u0000bluetooth_confirm\u0000description": {
       "out": "9e758bdb4d0a",
       "src": "bcfd5a24b7d7"
     },
-    "config.step.encryption_key.data.encryption_key": {
+    "config\u0000step\u0000encryption_key\u0000data\u0000encryption_key": {
       "out": "7b8e165b5050",
       "src": "16b3c9d5573d"
     },
-    "config.step.encryption_key.data_description.encryption_key": {
+    "config\u0000step\u0000encryption_key\u0000data_description\u0000encryption_key": {
       "out": "7658bd7644c9",
       "src": "e64cd2e7e647"
     },
-    "config.step.encryption_key.description": {
+    "config\u0000step\u0000encryption_key\u0000description": {
       "out": "150036380590",
       "src": "664d3f12bfe6"
     },
-    "config.step.encryption_key.title": {
+    "config\u0000step\u0000encryption_key\u0000title": {
       "out": "c11abaf0036c",
       "src": "c30d1ca158a3"
     },
-    "config.step.reauth_confirm.data.encryption_key": {
+    "config\u0000step\u0000reauth_confirm\u0000data\u0000encryption_key": {
       "out": "7b8e165b5050",
       "src": "16b3c9d5573d"
     },
-    "config.step.reauth_confirm.data_description.encryption_key": {
+    "config\u0000step\u0000reauth_confirm\u0000data_description\u0000encryption_key": {
       "out": "7658bd7644c9",
       "src": "e64cd2e7e647"
     },
-    "config.step.reauth_confirm.description": {
+    "config\u0000step\u0000reauth_confirm\u0000description": {
       "out": "8a24fca49c56",
       "src": "f53b69d3be84"
     },
-    "config.step.reauth_confirm.title": {
+    "config\u0000step\u0000reauth_confirm\u0000title": {
       "out": "d7300d1550af",
       "src": "7e22a752572f"
     },
-    "config.step.user.data.address": {
+    "config\u0000step\u0000user\u0000data\u0000address": {
       "out": "1c555eb7f1c0",
       "src": "6ba0bdeccb42"
     },
-    "config.step.user.data_description.address": {
+    "config\u0000step\u0000user\u0000data_description\u0000address": {
       "out": "e49a18e28bbe",
       "src": "a083a457cfb1"
     },
-    "config.step.user.description": {
+    "config\u0000step\u0000user\u0000description": {
       "out": "d5c6d20003a2",
       "src": "109135454652"
     },
-    "entity.binary_sensor.update_pending.name": {
+    "entity\u0000binary_sensor\u0000update_pending\u0000name": {
       "out": "770d7498552f",
       "src": "8e0a4b18ae75"
     },
-    "entity.event.button.name": {
+    "entity\u0000event\u0000button\u0000name": {
       "out": "5c620d69f4ec",
       "src": "2dcae43716c2"
     },
-    "entity.event.button.state_attributes.event_type.state.button_down": {
+    "entity\u0000event\u0000button\u0000state_attributes\u0000event_type\u0000state\u0000button_down": {
       "out": "45313946a254",
       "src": "8352c89d20b4"
     },
-    "entity.event.button.state_attributes.event_type.state.button_up": {
+    "entity\u0000event\u0000button\u0000state_attributes\u0000event_type\u0000state\u0000button_up": {
       "out": "d16271a00fab",
       "src": "7f18b4912929"
     },
-    "entity.event.touch.name": {
+    "entity\u0000event\u0000touch\u0000name": {
       "out": "837842a1ac38",
       "src": "c915d14278fc"
     },
-    "entity.event.touch.state_attributes.event_type.state.touch_down": {
+    "entity\u0000event\u0000touch\u0000state_attributes\u0000event_type\u0000state\u0000touch_down": {
       "out": "6ae5f5d15da9",
       "src": "0234a9576230"
     },
-    "entity.event.touch.state_attributes.event_type.state.touch_move": {
+    "entity\u0000event\u0000touch\u0000state_attributes\u0000event_type\u0000state\u0000touch_move": {
       "out": "971b5268e9f4",
       "src": "67aeac815e94"
     },
-    "entity.event.touch.state_attributes.event_type.state.touch_up": {
+    "entity\u0000event\u0000touch\u0000state_attributes\u0000event_type\u0000state\u0000touch_up": {
       "out": "15dacc8e94d6",
       "src": "7c65519d3bb3"
     },
-    "entity.image.content.name": {
+    "entity\u0000image\u0000content\u0000name": {
       "out": "72294391b47e",
       "src": "047c6db3382a"
     },
-    "entity.sensor.battery_voltage.name": {
+    "entity\u0000sensor\u0000battery_voltage\u0000name": {
       "out": "3c077f56f37d",
       "src": "39d6c91b57ce"
     },
-    "entity.sensor.last_seen.name": {
+    "entity\u0000sensor\u0000last_seen\u0000name": {
       "out": "a060c6768208",
       "src": "21fd79c7de52"
     },
-    "entity.sensor.rssi.name": {
+    "entity\u0000sensor\u0000rssi\u0000name": {
       "out": "5bb6ab8219af",
       "src": "2604d15c1187"
     },
-    "entity.update.firmware.name": {
+    "entity\u0000update\u0000firmware\u0000name": {
       "out": "c2a314c3b32b",
       "src": "c2a314c3b32b"
     },
-    "exceptions.authentication_error.message": {
+    "exceptions\u0000authentication_error\u0000message": {
       "out": "5b02c9b5bc26",
       "src": "3d9f7c0c6d80"
     },
-    "exceptions.device_not_found.message": {
+    "exceptions\u0000device_not_found\u0000message": {
       "out": "429a0d6f8a18",
       "src": "f244d0d2db8d"
     },
-    "exceptions.device_sleeping.message": {
+    "exceptions\u0000device_sleeping\u0000message": {
       "out": "fde6d0c5b622",
       "src": "e95d25bd6fc7"
     },
-    "exceptions.device_sleeping_ota.message": {
+    "exceptions\u0000device_sleeping_ota\u0000message": {
       "out": "7e66b9304d9a",
       "src": "430e3a1baa6a"
     },
-    "exceptions.invalid_device_id.message": {
+    "exceptions\u0000invalid_device_id\u0000message": {
       "out": "bd59236488fd",
       "src": "cc64cc29ceeb"
     },
-    "exceptions.media_download_error.message": {
+    "exceptions\u0000media_download_error\u0000message": {
       "out": "afbf6cb62c7e",
       "src": "5852129dd920"
     },
-    "exceptions.mime_type_not_applicable.message": {
+    "exceptions\u0000mime_type_not_applicable\u0000message": {
       "out": "02b2528c1eb9",
       "src": "de700f02fbd5"
     },
-    "exceptions.multiple_errors.message": {
+    "exceptions\u0000multiple_errors\u0000message": {
       "out": "e8f50cf5816c",
       "src": "f17c68e0a848"
     },
-    "exceptions.nfc_content_empty.message": {
+    "exceptions\u0000nfc_content_empty\u0000message": {
       "out": "389e03d6cb91",
       "src": "b93a1a6ebdc0"
     },
-    "exceptions.nfc_content_too_long.message": {
+    "exceptions\u0000nfc_content_too_long\u0000message": {
       "out": "0f561eaef7da",
       "src": "8f580b9c6c76"
     },
-    "exceptions.nfc_mime_type_invalid.message": {
+    "exceptions\u0000nfc_mime_type_invalid\u0000message": {
       "out": "aa8eb3a440ee",
       "src": "5a5f44fe332f"
     },
-    "exceptions.nfc_not_supported.message": {
+    "exceptions\u0000nfc_not_supported\u0000message": {
       "out": "01a1efefe4ad",
       "src": "8fdcd0e2bd17"
     },
-    "exceptions.nfc_write_failed.message": {
+    "exceptions\u0000nfc_write_failed\u0000message": {
       "out": "1874bbf4736b",
       "src": "e8186303a52e"
     },
-    "exceptions.no_buzzers.message": {
+    "exceptions\u0000no_buzzers\u0000message": {
       "out": "3ca4a205bb3a",
       "src": "9c014dfeac91"
     },
-    "exceptions.no_leds.message": {
+    "exceptions\u0000no_leds\u0000message": {
       "out": "d9efe35eff01",
       "src": "6a302f8f22ee"
     },
-    "exceptions.no_nfc.message": {
+    "exceptions\u0000no_nfc\u0000message": {
       "out": "be8e2893f1a2",
       "src": "abb1917ad57e"
     },
-    "exceptions.no_targets_specified.message": {
+    "exceptions\u0000no_targets_specified\u0000message": {
       "out": "6e6821bc84e0",
       "src": "80c472afefe6"
     },
-    "exceptions.upload_error.message": {
+    "exceptions\u0000upload_error\u0000message": {
       "out": "d063ac6d2b60",
       "src": "75561a03be6e"
     },
-    "exceptions.url_not_allowed.message": {
+    "exceptions\u0000url_not_allowed\u0000message": {
       "out": "fdebaa8d51f1",
       "src": "33ffb9a9f2c4"
     },
-    "options.step.init.data.blocks_per_ack": {
+    "options\u0000step\u0000init\u0000data\u0000blocks_per_ack": {
       "out": "b91e673e4faf",
       "src": "3e2a554e69a4"
     },
-    "options.step.init.data.max_queue_size": {
+    "options\u0000step\u0000init\u0000data\u0000max_queue_size": {
       "out": "1671be9585ae",
       "src": "297af7027dd0"
     },
-    "options.step.init.data.missed_cycles": {
+    "options\u0000step\u0000init\u0000data\u0000missed_cycles": {
       "out": "bc59bb521ef0",
       "src": "59b78644491a"
     },
-    "options.step.init.data.probe_before_queue": {
+    "options\u0000step\u0000init\u0000data\u0000probe_before_queue": {
       "out": "d405f26fdc62",
       "src": "02c4211a58b2"
     },
-    "options.step.init.data.queue_timeout_hours": {
+    "options\u0000step\u0000init\u0000data\u0000queue_timeout_hours": {
       "out": "3e8f0ba214cd",
       "src": "be70fc5cca79"
     },
-    "options.step.init.data.sleep_mode": {
+    "options\u0000step\u0000init\u0000data\u0000sleep_mode": {
       "out": "f3cf6e015b6a",
       "src": "f925c0e541ce"
     },
-    "options.step.init.data_description.blocks_per_ack": {
+    "options\u0000step\u0000init\u0000data_description\u0000blocks_per_ack": {
       "out": "6889f1dbf50f",
       "src": "3a693b19d3c6"
     },
-    "options.step.init.data_description.max_queue_size": {
+    "options\u0000step\u0000init\u0000data_description\u0000max_queue_size": {
       "out": "f881059664b0",
       "src": "50260959ee56"
     },
-    "options.step.init.data_description.missed_cycles": {
+    "options\u0000step\u0000init\u0000data_description\u0000missed_cycles": {
       "out": "7e06bb92b5e6",
       "src": "6ce493f4c44d"
     },
-    "options.step.init.data_description.probe_before_queue": {
+    "options\u0000step\u0000init\u0000data_description\u0000probe_before_queue": {
       "out": "3ebce5e98b85",
       "src": "5d0f2985ffdf"
     },
-    "options.step.init.data_description.queue_timeout_hours": {
+    "options\u0000step\u0000init\u0000data_description\u0000queue_timeout_hours": {
       "out": "e1654af72ec8",
       "src": "34895000b491"
     },
-    "options.step.init.data_description.sleep_mode": {
+    "options\u0000step\u0000init\u0000data_description\u0000sleep_mode": {
       "out": "2a5cd5643b95",
       "src": "4acfeb65d10d"
     },
-    "selector.dither_mode.options.atkinson": {
+    "selector\u0000dither_mode\u0000options\u0000atkinson": {
       "out": "7a8fe6d47b5b",
       "src": "7a8fe6d47b5b"
     },
-    "selector.dither_mode.options.burkes": {
+    "selector\u0000dither_mode\u0000options\u0000burkes": {
       "out": "1b75087201fb",
       "src": "1b75087201fb"
     },
-    "selector.dither_mode.options.floyd_steinberg": {
+    "selector\u0000dither_mode\u0000options\u0000floyd_steinberg": {
       "out": "37969811a3cf",
       "src": "37969811a3cf"
     },
-    "selector.dither_mode.options.jarvis_judice_ninke": {
+    "selector\u0000dither_mode\u0000options\u0000jarvis_judice_ninke": {
       "out": "7020241adf78",
       "src": "7020241adf78"
     },
-    "selector.dither_mode.options.none": {
+    "selector\u0000dither_mode\u0000options\u0000none": {
       "out": "9e3fc69d0d9c",
       "src": "dc937b598926"
     },
-    "selector.dither_mode.options.ordered": {
+    "selector\u0000dither_mode\u0000options\u0000ordered": {
       "out": "d2aba6849adb",
       "src": "007877479e21"
     },
-    "selector.dither_mode.options.sierra": {
+    "selector\u0000dither_mode\u0000options\u0000sierra": {
       "out": "d5eef8ad210c",
       "src": "d5eef8ad210c"
     },
-    "selector.dither_mode.options.sierra_lite": {
+    "selector\u0000dither_mode\u0000options\u0000sierra_lite": {
       "out": "20da8cc85f38",
       "src": "20da8cc85f38"
     },
-    "selector.dither_mode.options.stucki": {
+    "selector\u0000dither_mode\u0000options\u0000stucki": {
       "out": "a17d2b13b6f9",
       "src": "a17d2b13b6f9"
     },
-    "selector.fit_mode.options.contain": {
+    "selector\u0000fit_mode\u0000options\u0000contain": {
       "out": "851222f34c5f",
       "src": "e534a2c2b456"
     },
-    "selector.fit_mode.options.cover": {
+    "selector\u0000fit_mode\u0000options\u0000cover": {
       "out": "35412ce9814f",
       "src": "fa8d84566676"
     },
-    "selector.fit_mode.options.crop": {
+    "selector\u0000fit_mode\u0000options\u0000crop": {
       "out": "b659da7fa50d",
       "src": "98caf7c43c6f"
     },
-    "selector.fit_mode.options.stretch": {
+    "selector\u0000fit_mode\u0000options\u0000stretch": {
       "out": "28200ccf7067",
       "src": "a33fbcf83f7b"
     },
-    "selector.nfc_record_type.options.ha_tag": {
+    "selector\u0000nfc_record_type\u0000options\u0000ha_tag": {
       "out": "2e30ed3e033c",
       "src": "d1d47a8fa544"
     },
-    "selector.nfc_record_type.options.mime": {
+    "selector\u0000nfc_record_type\u0000options\u0000mime": {
       "out": "675a2649dd2c",
       "src": "f98d7539e627"
     },
-    "selector.nfc_record_type.options.text": {
+    "selector\u0000nfc_record_type\u0000options\u0000text": {
       "out": "6df3d6661c09",
       "src": "71988c4d8e08"
     },
-    "selector.nfc_record_type.options.url": {
+    "selector\u0000nfc_record_type\u0000options\u0000url": {
       "out": "e7a241debad5",
       "src": "e7a241debad5"
     },
-    "selector.refresh_mode.options.fast": {
+    "selector\u0000refresh_mode\u0000options\u0000fast": {
       "out": "76495f26e6c5",
       "src": "6c582b62e0e5"
     },
-    "selector.refresh_mode.options.full": {
+    "selector\u0000refresh_mode\u0000options\u0000full": {
       "out": "23e3685fbe6c",
       "src": "008dacb6d1e8"
     },
-    "selector.refresh_mode.options.partial": {
+    "selector\u0000refresh_mode\u0000options\u0000partial": {
       "out": "154b61b1e9da",
       "src": "a4d50fb85403"
     },
-    "selector.sleep_mode.options.auto": {
+    "selector\u0000sleep_mode\u0000options\u0000auto": {
       "out": "7557cb15b0a8",
       "src": "132990bd8ef7"
     },
-    "selector.sleep_mode.options.off": {
+    "selector\u0000sleep_mode\u0000options\u0000off": {
       "out": "17e645e9a836",
       "src": "34598efe7b90"
     },
-    "selector.sleep_mode.options.on": {
+    "selector\u0000sleep_mode\u0000options\u0000on": {
       "out": "a8d3c0a8fea3",
       "src": "bde131e31c9e"
     },
-    "services.activate_buzzer.description": {
+    "services\u0000activate_buzzer\u0000description": {
       "out": "cc0fc0af56e3",
       "src": "1898784614cb"
     },
-    "services.activate_buzzer.fields.device_id.description": {
+    "services\u0000activate_buzzer\u0000fields\u0000device_id\u0000description": {
       "out": "1abb38711bf0",
       "src": "7dec980cb238"
     },
-    "services.activate_buzzer.fields.device_id.name": {
+    "services\u0000activate_buzzer\u0000fields\u0000device_id\u0000name": {
       "out": "1c555eb7f1c0",
       "src": "6ba0bdeccb42"
     },
-    "services.activate_buzzer.fields.duration_ms.description": {
+    "services\u0000activate_buzzer\u0000fields\u0000duration_ms\u0000description": {
       "out": "55829e4c8ec4",
       "src": "cd1bc75ca60c"
     },
-    "services.activate_buzzer.fields.duration_ms.name": {
+    "services\u0000activate_buzzer\u0000fields\u0000duration_ms\u0000name": {
       "out": "d5a804455b33",
       "src": "4fc52a3c4c55"
     },
-    "services.activate_buzzer.fields.frequency_hz.description": {
+    "services\u0000activate_buzzer\u0000fields\u0000frequency_hz\u0000description": {
       "out": "dd6565014d9f",
       "src": "510fc20311e3"
     },
-    "services.activate_buzzer.fields.frequency_hz.name": {
+    "services\u0000activate_buzzer\u0000fields\u0000frequency_hz\u0000name": {
       "out": "e1867c7f9bb3",
       "src": "16b6668d9831"
     },
-    "services.activate_buzzer.fields.instance.description": {
+    "services\u0000activate_buzzer\u0000fields\u0000instance\u0000description": {
       "out": "a4c148743acd",
       "src": "f39fa742d55c"
     },
-    "services.activate_buzzer.fields.instance.name": {
+    "services\u0000activate_buzzer\u0000fields\u0000instance\u0000name": {
       "out": "1fcf4383db04",
       "src": "1f671ddded9e"
     },
-    "services.activate_buzzer.fields.repeats.description": {
+    "services\u0000activate_buzzer\u0000fields\u0000repeats\u0000description": {
       "out": "b31ad43cd3ad",
       "src": "1f88b0fe23ea"
     },
-    "services.activate_buzzer.fields.repeats.name": {
+    "services\u0000activate_buzzer\u0000fields\u0000repeats\u0000name": {
       "out": "f79916caa78b",
       "src": "92ee0233f013"
     },
-    "services.activate_buzzer.name": {
+    "services\u0000activate_buzzer\u0000name": {
       "out": "f4a96e4ec649",
       "src": "0b80285753b7"
     },
-    "services.activate_led.description": {
+    "services\u0000activate_led\u0000description": {
       "out": "0774a9448d1d",
       "src": "6cbd645597cc"
     },
-    "services.activate_led.fields.brightness.description": {
+    "services\u0000activate_led\u0000fields\u0000brightness\u0000description": {
       "out": "9765bddfe191",
       "src": "6ad88a28230d"
     },
-    "services.activate_led.fields.brightness.name": {
+    "services\u0000activate_led\u0000fields\u0000brightness\u0000name": {
       "out": "97eba63984ea",
       "src": "ec811d30a89c"
     },
-    "services.activate_led.fields.color1.description": {
+    "services\u0000activate_led\u0000fields\u0000color1\u0000description": {
       "out": "a59a193a8c40",
       "src": "17f145013241"
     },
-    "services.activate_led.fields.color1.name": {
+    "services\u0000activate_led\u0000fields\u0000color1\u0000name": {
       "out": "571461f36f3a",
       "src": "571461f36f3a"
     },
-    "services.activate_led.fields.color2.description": {
+    "services\u0000activate_led\u0000fields\u0000color2\u0000description": {
       "out": "07f8706b6fd1",
       "src": "f2680a4bbe85"
     },
-    "services.activate_led.fields.color2.name": {
+    "services\u0000activate_led\u0000fields\u0000color2\u0000name": {
       "out": "ef792d287872",
       "src": "ef792d287872"
     },
-    "services.activate_led.fields.color3.description": {
+    "services\u0000activate_led\u0000fields\u0000color3\u0000description": {
       "out": "751df2cbe30a",
       "src": "b8ecd353b426"
     },
-    "services.activate_led.fields.color3.name": {
+    "services\u0000activate_led\u0000fields\u0000color3\u0000name": {
       "out": "48d54e046d29",
       "src": "48d54e046d29"
     },
-    "services.activate_led.fields.device_id.description": {
+    "services\u0000activate_led\u0000fields\u0000device_id\u0000description": {
       "out": "1abb38711bf0",
       "src": "7dec980cb238"
     },
-    "services.activate_led.fields.device_id.name": {
+    "services\u0000activate_led\u0000fields\u0000device_id\u0000name": {
       "out": "1c555eb7f1c0",
       "src": "6ba0bdeccb42"
     },
-    "services.activate_led.fields.flash_count1.description": {
+    "services\u0000activate_led\u0000fields\u0000flash_count1\u0000description": {
       "out": "62b7188fc74a",
       "src": "4ffdadde31c2"
     },
-    "services.activate_led.fields.flash_count1.name": {
+    "services\u0000activate_led\u0000fields\u0000flash_count1\u0000name": {
       "out": "e4eb946b1e4b",
       "src": "13c6a2e5c22e"
     },
-    "services.activate_led.fields.flash_count2.description": {
+    "services\u0000activate_led\u0000fields\u0000flash_count2\u0000description": {
       "out": "50bba8936ba7",
       "src": "86dc999a3915"
     },
-    "services.activate_led.fields.flash_count2.name": {
+    "services\u0000activate_led\u0000fields\u0000flash_count2\u0000name": {
       "out": "91cea4d40186",
       "src": "2be36d8449dc"
     },
-    "services.activate_led.fields.flash_count3.description": {
+    "services\u0000activate_led\u0000fields\u0000flash_count3\u0000description": {
       "out": "26e686815172",
       "src": "aa40c396a9a4"
     },
-    "services.activate_led.fields.flash_count3.name": {
+    "services\u0000activate_led\u0000fields\u0000flash_count3\u0000name": {
       "out": "65100acca399",
       "src": "7978910dc6b2"
     },
-    "services.activate_led.fields.instance.description": {
+    "services\u0000activate_led\u0000fields\u0000instance\u0000description": {
       "out": "7bd1d7fc1ee5",
       "src": "0531b37de90a"
     },
-    "services.activate_led.fields.instance.name": {
+    "services\u0000activate_led\u0000fields\u0000instance\u0000name": {
       "out": "1409af6d11c1",
       "src": "f942926204c7"
     },
-    "services.activate_led.fields.inter_delay1.description": {
+    "services\u0000activate_led\u0000fields\u0000inter_delay1\u0000description": {
       "out": "2598f2131a5c",
       "src": "1b65dcfcea95"
     },
-    "services.activate_led.fields.inter_delay1.name": {
+    "services\u0000activate_led\u0000fields\u0000inter_delay1\u0000name": {
       "out": "aa8a66be3b10",
       "src": "71452f436c33"
     },
-    "services.activate_led.fields.inter_delay2.description": {
+    "services\u0000activate_led\u0000fields\u0000inter_delay2\u0000description": {
       "out": "5b690d8dba57",
       "src": "181e03f33cbf"
     },
-    "services.activate_led.fields.inter_delay2.name": {
+    "services\u0000activate_led\u0000fields\u0000inter_delay2\u0000name": {
       "out": "94408e5f0772",
       "src": "6a50551e5355"
     },
-    "services.activate_led.fields.inter_delay3.description": {
+    "services\u0000activate_led\u0000fields\u0000inter_delay3\u0000description": {
       "out": "740c2cea3a13",
       "src": "5c5973b586df"
     },
-    "services.activate_led.fields.inter_delay3.name": {
+    "services\u0000activate_led\u0000fields\u0000inter_delay3\u0000name": {
       "out": "66c0832efea2",
       "src": "b0f72903777e"
     },
-    "services.activate_led.fields.loop_delay1.description": {
+    "services\u0000activate_led\u0000fields\u0000loop_delay1\u0000description": {
       "out": "6239f73e6493",
       "src": "2139915c35bc"
     },
-    "services.activate_led.fields.loop_delay1.name": {
+    "services\u0000activate_led\u0000fields\u0000loop_delay1\u0000name": {
       "out": "2c2051517f08",
       "src": "2fb02375bae0"
     },
-    "services.activate_led.fields.loop_delay2.description": {
+    "services\u0000activate_led\u0000fields\u0000loop_delay2\u0000description": {
       "out": "5e55d865cd9c",
       "src": "9a3a8cccb3bb"
     },
-    "services.activate_led.fields.loop_delay2.name": {
+    "services\u0000activate_led\u0000fields\u0000loop_delay2\u0000name": {
       "out": "6bcf605e9726",
       "src": "597cbe87a7ec"
     },
-    "services.activate_led.fields.loop_delay3.description": {
+    "services\u0000activate_led\u0000fields\u0000loop_delay3\u0000description": {
       "out": "550e5d5d2e23",
       "src": "8a965100226c"
     },
-    "services.activate_led.fields.loop_delay3.name": {
+    "services\u0000activate_led\u0000fields\u0000loop_delay3\u0000name": {
       "out": "03e6783a3374",
       "src": "66d787aa1bad"
     },
-    "services.activate_led.fields.repeats.description": {
+    "services\u0000activate_led\u0000fields\u0000repeats\u0000description": {
       "out": "04c389babea3",
       "src": "e40e956e3762"
     },
-    "services.activate_led.fields.repeats.name": {
+    "services\u0000activate_led\u0000fields\u0000repeats\u0000name": {
       "out": "f79916caa78b",
       "src": "92ee0233f013"
     },
-    "services.activate_led.name": {
+    "services\u0000activate_led\u0000name": {
       "out": "6ab28c868c2c",
       "src": "91933e94cc57"
     },
-    "services.drawcustom.description": {
+    "services\u0000drawcustom\u0000description": {
       "out": "ff11d43a9de1",
       "src": "55f9f3333fc0"
     },
-    "services.drawcustom.fields.background.description": {
+    "services\u0000drawcustom\u0000fields\u0000background\u0000description": {
       "out": "93c03d5777ac",
       "src": "f5858405d78a"
     },
-    "services.drawcustom.fields.background.name": {
+    "services\u0000drawcustom\u0000fields\u0000background\u0000name": {
       "out": "f0aa9f5d3189",
       "src": "3e314dafdf7c"
     },
-    "services.drawcustom.fields.dither.description": {
+    "services\u0000drawcustom\u0000fields\u0000dither\u0000description": {
       "out": "182bfe9a390d",
       "src": "d7c737e5d01e"
     },
-    "services.drawcustom.fields.dither.name": {
+    "services\u0000drawcustom\u0000fields\u0000dither\u0000name": {
       "out": "4c79b79008bf",
       "src": "35fb13830002"
     },
-    "services.drawcustom.fields.dry-run.description": {
+    "services\u0000drawcustom\u0000fields\u0000dry-run\u0000description": {
       "out": "71e228b60201",
       "src": "54f5f06db00c"
     },
-    "services.drawcustom.fields.dry-run.name": {
+    "services\u0000drawcustom\u0000fields\u0000dry-run\u0000name": {
       "out": "23b48c51e67e",
       "src": "d5da154d9f00"
     },
-    "services.drawcustom.fields.measured_palette.description": {
+    "services\u0000drawcustom\u0000fields\u0000measured_palette\u0000description": {
       "out": "7c4bf4976978",
       "src": "53842124c7af"
     },
-    "services.drawcustom.fields.measured_palette.name": {
+    "services\u0000drawcustom\u0000fields\u0000measured_palette\u0000name": {
       "out": "2e8f0e046ee9",
       "src": "672d38bdeb19"
     },
-    "services.drawcustom.fields.payload.description": {
+    "services\u0000drawcustom\u0000fields\u0000payload\u0000description": {
       "out": "1f277869a66c",
       "src": "a72e3d514ead"
     },
-    "services.drawcustom.fields.payload.name": {
+    "services\u0000drawcustom\u0000fields\u0000payload\u0000name": {
       "out": "197c7a8551b9",
       "src": "99733344956d"
     },
-    "services.drawcustom.fields.refresh_type.description": {
+    "services\u0000drawcustom\u0000fields\u0000refresh_type\u0000description": {
       "out": "1c236fb206cb",
       "src": "d87a3d5c4d06"
     },
-    "services.drawcustom.fields.refresh_type.name": {
+    "services\u0000drawcustom\u0000fields\u0000refresh_type\u0000name": {
       "out": "d7e535a49776",
       "src": "201b25b874bb"
     },
-    "services.drawcustom.fields.rotate.description": {
+    "services\u0000drawcustom\u0000fields\u0000rotate\u0000description": {
       "out": "1b7401e22dc3",
       "src": "21e39f93db71"
     },
-    "services.drawcustom.fields.rotate.name": {
+    "services\u0000drawcustom\u0000fields\u0000rotate\u0000name": {
       "out": "f56c9e94479b",
       "src": "57b5e2fc1bba"
     },
-    "services.drawcustom.name": {
+    "services\u0000drawcustom\u0000name": {
       "out": "9d9d1493716c",
       "src": "d0df7a6244ea"
     },
-    "services.upload_image.description": {
+    "services\u0000upload_image\u0000description": {
       "out": "5c90f31d0b7a",
       "src": "24e19354eaa4"
     },
-    "services.upload_image.fields.device_id.description": {
+    "services\u0000upload_image\u0000fields\u0000device_id\u0000description": {
       "out": "7142f7889872",
       "src": "ee157333391e"
     },
-    "services.upload_image.fields.device_id.name": {
+    "services\u0000upload_image\u0000fields\u0000device_id\u0000name": {
       "out": "1c555eb7f1c0",
       "src": "6ba0bdeccb42"
     },
-    "services.upload_image.fields.dither_mode.description": {
+    "services\u0000upload_image\u0000fields\u0000dither_mode\u0000description": {
       "out": "2ff1f6714137",
       "src": "70483fdfe7ec"
     },
-    "services.upload_image.fields.dither_mode.name": {
+    "services\u0000upload_image\u0000fields\u0000dither_mode\u0000name": {
       "out": "4c79b79008bf",
       "src": "35fb13830002"
     },
-    "services.upload_image.fields.fit_mode.description": {
+    "services\u0000upload_image\u0000fields\u0000fit_mode\u0000description": {
       "out": "4bcb27af868d",
       "src": "8d2c8735a962"
     },
-    "services.upload_image.fields.fit_mode.name": {
+    "services\u0000upload_image\u0000fields\u0000fit_mode\u0000name": {
       "out": "66d2c4bb0197",
       "src": "8a59790c9187"
     },
-    "services.upload_image.fields.image.description": {
+    "services\u0000upload_image\u0000fields\u0000image\u0000description": {
       "out": "8c4b63c8533f",
       "src": "ba6d9fb759b0"
     },
-    "services.upload_image.fields.image.name": {
+    "services\u0000upload_image\u0000fields\u0000image\u0000name": {
       "out": "58d6f29b0633",
       "src": "1aa4cb0bcca7"
     },
-    "services.upload_image.fields.measured_palette.description": {
+    "services\u0000upload_image\u0000fields\u0000measured_palette\u0000description": {
       "out": "923de416cd8b",
       "src": "53842124c7af"
     },
-    "services.upload_image.fields.measured_palette.name": {
+    "services\u0000upload_image\u0000fields\u0000measured_palette\u0000name": {
       "out": "2e8f0e046ee9",
       "src": "672d38bdeb19"
     },
-    "services.upload_image.fields.refresh_mode.description": {
+    "services\u0000upload_image\u0000fields\u0000refresh_mode\u0000description": {
       "out": "ed81e0545ff2",
       "src": "0fe957da240a"
     },
-    "services.upload_image.fields.refresh_mode.name": {
+    "services\u0000upload_image\u0000fields\u0000refresh_mode\u0000name": {
       "out": "61221d25a7e7",
       "src": "c72fd253298c"
     },
-    "services.upload_image.fields.rotation.description": {
+    "services\u0000upload_image\u0000fields\u0000rotation\u0000description": {
       "out": "2312f865f3eb",
       "src": "b639ab27209e"
     },
-    "services.upload_image.fields.rotation.name": {
+    "services\u0000upload_image\u0000fields\u0000rotation\u0000name": {
       "out": "f56c9e94479b",
       "src": "57b5e2fc1bba"
     },
-    "services.upload_image.fields.tone_compression.description": {
+    "services\u0000upload_image\u0000fields\u0000tone_compression\u0000description": {
       "out": "2c98409c9bcf",
       "src": "6453b45ae0cc"
     },
-    "services.upload_image.fields.tone_compression.name": {
+    "services\u0000upload_image\u0000fields\u0000tone_compression\u0000name": {
       "out": "b3c4094e9866",
       "src": "ffaed65f03fa"
     },
-    "services.upload_image.name": {
+    "services\u0000upload_image\u0000name": {
       "out": "251f0755f51e",
       "src": "ffe4df6c7ca6"
     },
-    "services.upload_image.sections.additional_fields.name": {
+    "services\u0000upload_image\u0000sections\u0000additional_fields\u0000name": {
       "out": "952d9c9c77ef",
       "src": "092170b2408b"
     },
-    "services.write_nfc.description": {
+    "services\u0000write_nfc\u0000description": {
       "out": "1206225cdf06",
       "src": "3c1f6a6d643e"
     },
-    "services.write_nfc.fields.content.description": {
+    "services\u0000write_nfc\u0000fields\u0000content\u0000description": {
       "out": "a62ea9447049",
       "src": "857d1cf0bf90"
     },
-    "services.write_nfc.fields.content.name": {
+    "services\u0000write_nfc\u0000fields\u0000content\u0000name": {
       "out": "197c7a8551b9",
       "src": "47bd29075f8b"
     },
-    "services.write_nfc.fields.device_id.description": {
+    "services\u0000write_nfc\u0000fields\u0000device_id\u0000description": {
       "out": "1abb38711bf0",
       "src": "7dec980cb238"
     },
-    "services.write_nfc.fields.device_id.name": {
+    "services\u0000write_nfc\u0000fields\u0000device_id\u0000name": {
       "out": "1c555eb7f1c0",
       "src": "6ba0bdeccb42"
     },
-    "services.write_nfc.fields.mime_type.description": {
+    "services\u0000write_nfc\u0000fields\u0000mime_type\u0000description": {
       "out": "1812c5bb0384",
       "src": "4eb2b40ec666"
     },
-    "services.write_nfc.fields.mime_type.name": {
+    "services\u0000write_nfc\u0000fields\u0000mime_type\u0000name": {
       "out": "899f5b786081",
       "src": "849e8a810960"
     },
-    "services.write_nfc.fields.record_type.description": {
+    "services\u0000write_nfc\u0000fields\u0000record_type\u0000description": {
       "out": "b33b53833622",
       "src": "936cf634012f"
     },
-    "services.write_nfc.fields.record_type.name": {
+    "services\u0000write_nfc\u0000fields\u0000record_type\u0000name": {
       "out": "ffc69bba602f",
       "src": "91cf117b1d70"
     },
-    "services.write_nfc.name": {
+    "services\u0000write_nfc\u0000name": {
       "out": "a1c857ba57fc",
       "src": "96ea14b97cf7"
     }
   },
   "fr": {
-    "config.abort.already_configured": {
+    "config\u0000abort\u0000already_configured": {
       "out": "ddcf916e028b",
       "src": "c2936e02a0d2"
     },
-    "config.abort.already_in_progress": {
+    "config\u0000abort\u0000already_in_progress": {
       "out": "7c2816cd6d80",
       "src": "985a72ad93a3"
     },
-    "config.abort.cannot_connect": {
+    "config\u0000abort\u0000cannot_connect": {
       "out": "17170dfd78ae",
       "src": "46c9f3b7520f"
     },
-    "config.abort.no_devices_found": {
+    "config\u0000abort\u0000no_devices_found": {
       "out": "a74e2b5f5a8c",
       "src": "b8f28e84cf0b"
     },
-    "config.abort.reauth_successful": {
+    "config\u0000abort\u0000reauth_successful": {
       "out": "66f6fc1dae36",
       "src": "e5b83989735c"
     },
-    "config.abort.unknown": {
+    "config\u0000abort\u0000unknown": {
       "out": "081fa1eabc25",
       "src": "d24c41ae530a"
     },
-    "config.error.cannot_connect": {
+    "config\u0000error\u0000cannot_connect": {
       "out": "17170dfd78ae",
       "src": "46c9f3b7520f"
     },
-    "config.error.invalid_auth": {
+    "config\u0000error\u0000invalid_auth": {
       "out": "197d22a8b406",
       "src": "4ca089878c5f"
     },
-    "config.error.invalid_key_format": {
+    "config\u0000error\u0000invalid_key_format": {
       "out": "5649b04c07f4",
       "src": "f7b03dd699df"
     },
-    "config.error.unknown": {
+    "config\u0000error\u0000unknown": {
       "out": "081fa1eabc25",
       "src": "d24c41ae530a"
     },
-    "config.flow_title": {
+    "config\u0000flow_title": {
       "out": "5e291d7bcb2d",
       "src": "5e291d7bcb2d"
     },
-    "config.step.bluetooth_confirm.description": {
+    "config\u0000step\u0000bluetooth_confirm\u0000description": {
       "out": "8383206ea254",
       "src": "bcfd5a24b7d7"
     },
-    "config.step.encryption_key.data.encryption_key": {
+    "config\u0000step\u0000encryption_key\u0000data\u0000encryption_key": {
       "out": "17e907e85e0b",
       "src": "16b3c9d5573d"
     },
-    "config.step.encryption_key.data_description.encryption_key": {
+    "config\u0000step\u0000encryption_key\u0000data_description\u0000encryption_key": {
       "out": "fe0b56099a97",
       "src": "e64cd2e7e647"
     },
-    "config.step.encryption_key.description": {
+    "config\u0000step\u0000encryption_key\u0000description": {
       "out": "0df36bba6c56",
       "src": "664d3f12bfe6"
     },
-    "config.step.encryption_key.title": {
+    "config\u0000step\u0000encryption_key\u0000title": {
       "out": "3edac433f3d0",
       "src": "c30d1ca158a3"
     },
-    "config.step.reauth_confirm.data.encryption_key": {
+    "config\u0000step\u0000reauth_confirm\u0000data\u0000encryption_key": {
       "out": "17e907e85e0b",
       "src": "16b3c9d5573d"
     },
-    "config.step.reauth_confirm.data_description.encryption_key": {
+    "config\u0000step\u0000reauth_confirm\u0000data_description\u0000encryption_key": {
       "out": "fe0b56099a97",
       "src": "e64cd2e7e647"
     },
-    "config.step.reauth_confirm.description": {
+    "config\u0000step\u0000reauth_confirm\u0000description": {
       "out": "d1e5f2e357ce",
       "src": "f53b69d3be84"
     },
-    "config.step.reauth_confirm.title": {
+    "config\u0000step\u0000reauth_confirm\u0000title": {
       "out": "e8d8fd1d16bd",
       "src": "7e22a752572f"
     },
-    "config.step.user.data.address": {
+    "config\u0000step\u0000user\u0000data\u0000address": {
       "out": "0944613acb42",
       "src": "6ba0bdeccb42"
     },
-    "config.step.user.data_description.address": {
+    "config\u0000step\u0000user\u0000data_description\u0000address": {
       "out": "43c23b9cad0e",
       "src": "a083a457cfb1"
     },
-    "config.step.user.description": {
+    "config\u0000step\u0000user\u0000description": {
       "out": "dbe5232de45c",
       "src": "109135454652"
     },
-    "entity.binary_sensor.update_pending.name": {
+    "entity\u0000binary_sensor\u0000update_pending\u0000name": {
       "out": "664c4836055e",
       "src": "8e0a4b18ae75"
     },
-    "entity.event.button.name": {
+    "entity\u0000event\u0000button\u0000name": {
       "out": "26ed1f392213",
       "src": "2dcae43716c2"
     },
-    "entity.event.button.state_attributes.event_type.state.button_down": {
+    "entity\u0000event\u0000button\u0000state_attributes\u0000event_type\u0000state\u0000button_down": {
       "out": "bace38079c90",
       "src": "8352c89d20b4"
     },
-    "entity.event.button.state_attributes.event_type.state.button_up": {
+    "entity\u0000event\u0000button\u0000state_attributes\u0000event_type\u0000state\u0000button_up": {
       "out": "4ca6cfa38863",
       "src": "7f18b4912929"
     },
-    "entity.event.touch.name": {
+    "entity\u0000event\u0000touch\u0000name": {
       "out": "3aad1d2fe736",
       "src": "c915d14278fc"
     },
-    "entity.event.touch.state_attributes.event_type.state.touch_down": {
+    "entity\u0000event\u0000touch\u0000state_attributes\u0000event_type\u0000state\u0000touch_down": {
       "out": "80075b7a2494",
       "src": "0234a9576230"
     },
-    "entity.event.touch.state_attributes.event_type.state.touch_move": {
+    "entity\u0000event\u0000touch\u0000state_attributes\u0000event_type\u0000state\u0000touch_move": {
       "out": "5c9d355e128f",
       "src": "67aeac815e94"
     },
-    "entity.event.touch.state_attributes.event_type.state.touch_up": {
+    "entity\u0000event\u0000touch\u0000state_attributes\u0000event_type\u0000state\u0000touch_up": {
       "out": "196cd58bed8c",
       "src": "7c65519d3bb3"
     },
-    "entity.image.content.name": {
+    "entity\u0000image\u0000content\u0000name": {
       "out": "3011d34c82c6",
       "src": "047c6db3382a"
     },
-    "entity.sensor.battery_voltage.name": {
+    "entity\u0000sensor\u0000battery_voltage\u0000name": {
       "out": "72df7d138a1b",
       "src": "39d6c91b57ce"
     },
-    "entity.sensor.last_seen.name": {
+    "entity\u0000sensor\u0000last_seen\u0000name": {
       "out": "fceee0a4da07",
       "src": "21fd79c7de52"
     },
-    "entity.sensor.rssi.name": {
+    "entity\u0000sensor\u0000rssi\u0000name": {
       "out": "a92896600aad",
       "src": "2604d15c1187"
     },
-    "entity.update.firmware.name": {
+    "entity\u0000update\u0000firmware\u0000name": {
       "out": "c2a314c3b32b",
       "src": "c2a314c3b32b"
     },
-    "exceptions.authentication_error.message": {
+    "exceptions\u0000authentication_error\u0000message": {
       "out": "b4c0bb1725b5",
       "src": "3d9f7c0c6d80"
     },
-    "exceptions.device_not_found.message": {
+    "exceptions\u0000device_not_found\u0000message": {
       "out": "d749244c1514",
       "src": "f244d0d2db8d"
     },
-    "exceptions.device_sleeping.message": {
+    "exceptions\u0000device_sleeping\u0000message": {
       "out": "889ea0aa7ffc",
       "src": "e95d25bd6fc7"
     },
-    "exceptions.device_sleeping_ota.message": {
+    "exceptions\u0000device_sleeping_ota\u0000message": {
       "out": "05d2ec6a3e74",
       "src": "430e3a1baa6a"
     },
-    "exceptions.invalid_device_id.message": {
+    "exceptions\u0000invalid_device_id\u0000message": {
       "out": "4bf835acb87c",
       "src": "cc64cc29ceeb"
     },
-    "exceptions.media_download_error.message": {
+    "exceptions\u0000media_download_error\u0000message": {
       "out": "7d55b66d49f3",
       "src": "5852129dd920"
     },
-    "exceptions.mime_type_not_applicable.message": {
+    "exceptions\u0000mime_type_not_applicable\u0000message": {
       "out": "a5316efa502d",
       "src": "de700f02fbd5"
     },
-    "exceptions.multiple_errors.message": {
+    "exceptions\u0000multiple_errors\u0000message": {
       "out": "2f8e69a4d79e",
       "src": "f17c68e0a848"
     },
-    "exceptions.nfc_content_empty.message": {
+    "exceptions\u0000nfc_content_empty\u0000message": {
       "out": "850fac77feb5",
       "src": "b93a1a6ebdc0"
     },
-    "exceptions.nfc_content_too_long.message": {
+    "exceptions\u0000nfc_content_too_long\u0000message": {
       "out": "dd3690534c8a",
       "src": "8f580b9c6c76"
     },
-    "exceptions.nfc_mime_type_invalid.message": {
+    "exceptions\u0000nfc_mime_type_invalid\u0000message": {
       "out": "74b56e4a452f",
       "src": "5a5f44fe332f"
     },
-    "exceptions.nfc_not_supported.message": {
+    "exceptions\u0000nfc_not_supported\u0000message": {
       "out": "293b2ad78093",
       "src": "8fdcd0e2bd17"
     },
-    "exceptions.nfc_write_failed.message": {
+    "exceptions\u0000nfc_write_failed\u0000message": {
       "out": "63a5192b8da9",
       "src": "e8186303a52e"
     },
-    "exceptions.no_buzzers.message": {
+    "exceptions\u0000no_buzzers\u0000message": {
       "out": "56d1132c4d37",
       "src": "9c014dfeac91"
     },
-    "exceptions.no_leds.message": {
+    "exceptions\u0000no_leds\u0000message": {
       "out": "d1f16357f872",
       "src": "6a302f8f22ee"
     },
-    "exceptions.no_nfc.message": {
+    "exceptions\u0000no_nfc\u0000message": {
       "out": "f8e4904c0963",
       "src": "abb1917ad57e"
     },
-    "exceptions.no_targets_specified.message": {
+    "exceptions\u0000no_targets_specified\u0000message": {
       "out": "1fb3bf9319c3",
       "src": "80c472afefe6"
     },
-    "exceptions.upload_error.message": {
+    "exceptions\u0000upload_error\u0000message": {
       "out": "e9e642fc50a4",
       "src": "75561a03be6e"
     },
-    "exceptions.url_not_allowed.message": {
+    "exceptions\u0000url_not_allowed\u0000message": {
       "out": "b1f7216a69d7",
       "src": "33ffb9a9f2c4"
     },
-    "options.step.init.data.blocks_per_ack": {
+    "options\u0000step\u0000init\u0000data\u0000blocks_per_ack": {
       "out": "3300b9e0cebf",
       "src": "3e2a554e69a4"
     },
-    "options.step.init.data.max_queue_size": {
+    "options\u0000step\u0000init\u0000data\u0000max_queue_size": {
       "out": "1672db0ce89a",
       "src": "297af7027dd0"
     },
-    "options.step.init.data.missed_cycles": {
+    "options\u0000step\u0000init\u0000data\u0000missed_cycles": {
       "out": "7c2dcd44d53f",
       "src": "59b78644491a"
     },
-    "options.step.init.data.probe_before_queue": {
+    "options\u0000step\u0000init\u0000data\u0000probe_before_queue": {
       "out": "7326df0d45b5",
       "src": "02c4211a58b2"
     },
-    "options.step.init.data.queue_timeout_hours": {
+    "options\u0000step\u0000init\u0000data\u0000queue_timeout_hours": {
       "out": "05c55ba4d9dc",
       "src": "be70fc5cca79"
     },
-    "options.step.init.data.sleep_mode": {
+    "options\u0000step\u0000init\u0000data\u0000sleep_mode": {
       "out": "721a2fa80853",
       "src": "f925c0e541ce"
     },
-    "options.step.init.data_description.blocks_per_ack": {
+    "options\u0000step\u0000init\u0000data_description\u0000blocks_per_ack": {
       "out": "ccf6e5c8e365",
       "src": "3a693b19d3c6"
     },
-    "options.step.init.data_description.max_queue_size": {
+    "options\u0000step\u0000init\u0000data_description\u0000max_queue_size": {
       "out": "f1ed4a0e52a1",
       "src": "50260959ee56"
     },
-    "options.step.init.data_description.missed_cycles": {
+    "options\u0000step\u0000init\u0000data_description\u0000missed_cycles": {
       "out": "9bf19cd10627",
       "src": "6ce493f4c44d"
     },
-    "options.step.init.data_description.probe_before_queue": {
+    "options\u0000step\u0000init\u0000data_description\u0000probe_before_queue": {
       "out": "f3a13221e19f",
       "src": "5d0f2985ffdf"
     },
-    "options.step.init.data_description.queue_timeout_hours": {
+    "options\u0000step\u0000init\u0000data_description\u0000queue_timeout_hours": {
       "out": "e7e28fb41366",
       "src": "34895000b491"
     },
-    "options.step.init.data_description.sleep_mode": {
+    "options\u0000step\u0000init\u0000data_description\u0000sleep_mode": {
       "out": "3aaf61fc6ac2",
       "src": "4acfeb65d10d"
     },
-    "selector.dither_mode.options.atkinson": {
+    "selector\u0000dither_mode\u0000options\u0000atkinson": {
       "out": "7a8fe6d47b5b",
       "src": "7a8fe6d47b5b"
     },
-    "selector.dither_mode.options.burkes": {
+    "selector\u0000dither_mode\u0000options\u0000burkes": {
       "out": "1b75087201fb",
       "src": "1b75087201fb"
     },
-    "selector.dither_mode.options.floyd_steinberg": {
+    "selector\u0000dither_mode\u0000options\u0000floyd_steinberg": {
       "out": "37969811a3cf",
       "src": "37969811a3cf"
     },
-    "selector.dither_mode.options.jarvis_judice_ninke": {
+    "selector\u0000dither_mode\u0000options\u0000jarvis_judice_ninke": {
       "out": "7020241adf78",
       "src": "7020241adf78"
     },
-    "selector.dither_mode.options.none": {
+    "selector\u0000dither_mode\u0000options\u0000none": {
       "out": "4679b3b12de0",
       "src": "dc937b598926"
     },
-    "selector.dither_mode.options.ordered": {
+    "selector\u0000dither_mode\u0000options\u0000ordered": {
       "out": "cdb45168b277",
       "src": "007877479e21"
     },
-    "selector.dither_mode.options.sierra": {
+    "selector\u0000dither_mode\u0000options\u0000sierra": {
       "out": "d5eef8ad210c",
       "src": "d5eef8ad210c"
     },
-    "selector.dither_mode.options.sierra_lite": {
+    "selector\u0000dither_mode\u0000options\u0000sierra_lite": {
       "out": "20da8cc85f38",
       "src": "20da8cc85f38"
     },
-    "selector.dither_mode.options.stucki": {
+    "selector\u0000dither_mode\u0000options\u0000stucki": {
       "out": "a17d2b13b6f9",
       "src": "a17d2b13b6f9"
     },
-    "selector.fit_mode.options.contain": {
+    "selector\u0000fit_mode\u0000options\u0000contain": {
       "out": "ee539ab5622c",
       "src": "e534a2c2b456"
     },
-    "selector.fit_mode.options.cover": {
+    "selector\u0000fit_mode\u0000options\u0000cover": {
       "out": "f5ce6a5c15ed",
       "src": "fa8d84566676"
     },
-    "selector.fit_mode.options.crop": {
+    "selector\u0000fit_mode\u0000options\u0000crop": {
       "out": "950eefa4273c",
       "src": "98caf7c43c6f"
     },
-    "selector.fit_mode.options.stretch": {
+    "selector\u0000fit_mode\u0000options\u0000stretch": {
       "out": "1718c5d331e3",
       "src": "a33fbcf83f7b"
     },
-    "selector.nfc_record_type.options.ha_tag": {
+    "selector\u0000nfc_record_type\u0000options\u0000ha_tag": {
       "out": "3321c29be0cd",
       "src": "d1d47a8fa544"
     },
-    "selector.nfc_record_type.options.mime": {
+    "selector\u0000nfc_record_type\u0000options\u0000mime": {
       "out": "c4f15166f874",
       "src": "f98d7539e627"
     },
-    "selector.nfc_record_type.options.text": {
+    "selector\u0000nfc_record_type\u0000options\u0000text": {
       "out": "bbb0bd5ff551",
       "src": "71988c4d8e08"
     },
-    "selector.nfc_record_type.options.url": {
+    "selector\u0000nfc_record_type\u0000options\u0000url": {
       "out": "e7a241debad5",
       "src": "e7a241debad5"
     },
-    "selector.refresh_mode.options.fast": {
+    "selector\u0000refresh_mode\u0000options\u0000fast": {
       "out": "7939084e40f0",
       "src": "6c582b62e0e5"
     },
-    "selector.refresh_mode.options.full": {
+    "selector\u0000refresh_mode\u0000options\u0000full": {
       "out": "7392885bd96b",
       "src": "008dacb6d1e8"
     },
-    "selector.refresh_mode.options.partial": {
+    "selector\u0000refresh_mode\u0000options\u0000partial": {
       "out": "e9d830119d27",
       "src": "a4d50fb85403"
     },
-    "selector.sleep_mode.options.auto": {
+    "selector\u0000sleep_mode\u0000options\u0000auto": {
       "out": "adfa4f4ae4a5",
       "src": "132990bd8ef7"
     },
-    "selector.sleep_mode.options.off": {
+    "selector\u0000sleep_mode\u0000options\u0000off": {
       "out": "25be7e94bda2",
       "src": "34598efe7b90"
     },
-    "selector.sleep_mode.options.on": {
+    "selector\u0000sleep_mode\u0000options\u0000on": {
       "out": "6ee4373ffd3b",
       "src": "bde131e31c9e"
     },
-    "services.activate_buzzer.description": {
+    "services\u0000activate_buzzer\u0000description": {
       "out": "cb350aff2b76",
       "src": "1898784614cb"
     },
-    "services.activate_buzzer.fields.device_id.description": {
+    "services\u0000activate_buzzer\u0000fields\u0000device_id\u0000description": {
       "out": "70b3a453ffac",
       "src": "7dec980cb238"
     },
-    "services.activate_buzzer.fields.device_id.name": {
+    "services\u0000activate_buzzer\u0000fields\u0000device_id\u0000name": {
       "out": "0944613acb42",
       "src": "6ba0bdeccb42"
     },
-    "services.activate_buzzer.fields.duration_ms.description": {
+    "services\u0000activate_buzzer\u0000fields\u0000duration_ms\u0000description": {
       "out": "03a889f7b901",
       "src": "cd1bc75ca60c"
     },
-    "services.activate_buzzer.fields.duration_ms.name": {
+    "services\u0000activate_buzzer\u0000fields\u0000duration_ms\u0000name": {
       "out": "71d0bad42af1",
       "src": "4fc52a3c4c55"
     },
-    "services.activate_buzzer.fields.frequency_hz.description": {
+    "services\u0000activate_buzzer\u0000fields\u0000frequency_hz\u0000description": {
       "out": "fc0ce13b0f4d",
       "src": "510fc20311e3"
     },
-    "services.activate_buzzer.fields.frequency_hz.name": {
+    "services\u0000activate_buzzer\u0000fields\u0000frequency_hz\u0000name": {
       "out": "12a58326f853",
       "src": "16b6668d9831"
     },
-    "services.activate_buzzer.fields.instance.description": {
+    "services\u0000activate_buzzer\u0000fields\u0000instance\u0000description": {
       "out": "4366b86eb121",
       "src": "f39fa742d55c"
     },
-    "services.activate_buzzer.fields.instance.name": {
+    "services\u0000activate_buzzer\u0000fields\u0000instance\u0000name": {
       "out": "78702905a0c4",
       "src": "1f671ddded9e"
     },
-    "services.activate_buzzer.fields.repeats.description": {
+    "services\u0000activate_buzzer\u0000fields\u0000repeats\u0000description": {
       "out": "ac3129830ca9",
       "src": "1f88b0fe23ea"
     },
-    "services.activate_buzzer.fields.repeats.name": {
+    "services\u0000activate_buzzer\u0000fields\u0000repeats\u0000name": {
       "out": "007319cdfdac",
       "src": "92ee0233f013"
     },
-    "services.activate_buzzer.name": {
+    "services\u0000activate_buzzer\u0000name": {
       "out": "3526c173a0ed",
       "src": "0b80285753b7"
     },
-    "services.activate_led.description": {
+    "services\u0000activate_led\u0000description": {
       "out": "7cf3c32ec9b0",
       "src": "6cbd645597cc"
     },
-    "services.activate_led.fields.brightness.description": {
+    "services\u0000activate_led\u0000fields\u0000brightness\u0000description": {
       "out": "6a1f93de35ee",
       "src": "6ad88a28230d"
     },
-    "services.activate_led.fields.brightness.name": {
+    "services\u0000activate_led\u0000fields\u0000brightness\u0000name": {
       "out": "5b661b4e3e14",
       "src": "ec811d30a89c"
     },
-    "services.activate_led.fields.color1.description": {
+    "services\u0000activate_led\u0000fields\u0000color1\u0000description": {
       "out": "13194efc50e6",
       "src": "17f145013241"
     },
-    "services.activate_led.fields.color1.name": {
+    "services\u0000activate_led\u0000fields\u0000color1\u0000name": {
       "out": "dbaa7ba8e16b",
       "src": "571461f36f3a"
     },
-    "services.activate_led.fields.color2.description": {
+    "services\u0000activate_led\u0000fields\u0000color2\u0000description": {
       "out": "622a170f52c6",
       "src": "f2680a4bbe85"
     },
-    "services.activate_led.fields.color2.name": {
+    "services\u0000activate_led\u0000fields\u0000color2\u0000name": {
       "out": "78419b181d48",
       "src": "ef792d287872"
     },
-    "services.activate_led.fields.color3.description": {
+    "services\u0000activate_led\u0000fields\u0000color3\u0000description": {
       "out": "9b14f0f1e048",
       "src": "b8ecd353b426"
     },
-    "services.activate_led.fields.color3.name": {
+    "services\u0000activate_led\u0000fields\u0000color3\u0000name": {
       "out": "e95f0c9b603f",
       "src": "48d54e046d29"
     },
-    "services.activate_led.fields.device_id.description": {
+    "services\u0000activate_led\u0000fields\u0000device_id\u0000description": {
       "out": "70b3a453ffac",
       "src": "7dec980cb238"
     },
-    "services.activate_led.fields.device_id.name": {
+    "services\u0000activate_led\u0000fields\u0000device_id\u0000name": {
       "out": "0944613acb42",
       "src": "6ba0bdeccb42"
     },
-    "services.activate_led.fields.flash_count1.description": {
+    "services\u0000activate_led\u0000fields\u0000flash_count1\u0000description": {
       "out": "e97a2781dc44",
       "src": "4ffdadde31c2"
     },
-    "services.activate_led.fields.flash_count1.name": {
+    "services\u0000activate_led\u0000fields\u0000flash_count1\u0000name": {
       "out": "82667b563da9",
       "src": "13c6a2e5c22e"
     },
-    "services.activate_led.fields.flash_count2.description": {
+    "services\u0000activate_led\u0000fields\u0000flash_count2\u0000description": {
       "out": "242d06029b98",
       "src": "86dc999a3915"
     },
-    "services.activate_led.fields.flash_count2.name": {
+    "services\u0000activate_led\u0000fields\u0000flash_count2\u0000name": {
       "out": "146b4bc2999c",
       "src": "2be36d8449dc"
     },
-    "services.activate_led.fields.flash_count3.description": {
+    "services\u0000activate_led\u0000fields\u0000flash_count3\u0000description": {
       "out": "fee40813b564",
       "src": "aa40c396a9a4"
     },
-    "services.activate_led.fields.flash_count3.name": {
+    "services\u0000activate_led\u0000fields\u0000flash_count3\u0000name": {
       "out": "84adaca9b350",
       "src": "7978910dc6b2"
     },
-    "services.activate_led.fields.instance.description": {
+    "services\u0000activate_led\u0000fields\u0000instance\u0000description": {
       "out": "567d1fc711f0",
       "src": "0531b37de90a"
     },
-    "services.activate_led.fields.instance.name": {
+    "services\u0000activate_led\u0000fields\u0000instance\u0000name": {
       "out": "b3aa884776b0",
       "src": "f942926204c7"
     },
-    "services.activate_led.fields.inter_delay1.description": {
+    "services\u0000activate_led\u0000fields\u0000inter_delay1\u0000description": {
       "out": "d38792920f2d",
       "src": "1b65dcfcea95"
     },
-    "services.activate_led.fields.inter_delay1.name": {
+    "services\u0000activate_led\u0000fields\u0000inter_delay1\u0000name": {
       "out": "de539a2bfff9",
       "src": "71452f436c33"
     },
-    "services.activate_led.fields.inter_delay2.description": {
+    "services\u0000activate_led\u0000fields\u0000inter_delay2\u0000description": {
       "out": "c551a2d14dd4",
       "src": "181e03f33cbf"
     },
-    "services.activate_led.fields.inter_delay2.name": {
+    "services\u0000activate_led\u0000fields\u0000inter_delay2\u0000name": {
       "out": "ecfe63a4485e",
       "src": "6a50551e5355"
     },
-    "services.activate_led.fields.inter_delay3.description": {
+    "services\u0000activate_led\u0000fields\u0000inter_delay3\u0000description": {
       "out": "99ed5547a43f",
       "src": "5c5973b586df"
     },
-    "services.activate_led.fields.inter_delay3.name": {
+    "services\u0000activate_led\u0000fields\u0000inter_delay3\u0000name": {
       "out": "9b5ba0997ac5",
       "src": "b0f72903777e"
     },
-    "services.activate_led.fields.loop_delay1.description": {
+    "services\u0000activate_led\u0000fields\u0000loop_delay1\u0000description": {
       "out": "cde2861cf6cf",
       "src": "2139915c35bc"
     },
-    "services.activate_led.fields.loop_delay1.name": {
+    "services\u0000activate_led\u0000fields\u0000loop_delay1\u0000name": {
       "out": "db0c8fec1950",
       "src": "2fb02375bae0"
     },
-    "services.activate_led.fields.loop_delay2.description": {
+    "services\u0000activate_led\u0000fields\u0000loop_delay2\u0000description": {
       "out": "be29d941002d",
       "src": "9a3a8cccb3bb"
     },
-    "services.activate_led.fields.loop_delay2.name": {
+    "services\u0000activate_led\u0000fields\u0000loop_delay2\u0000name": {
       "out": "80b40efbb349",
       "src": "597cbe87a7ec"
     },
-    "services.activate_led.fields.loop_delay3.description": {
+    "services\u0000activate_led\u0000fields\u0000loop_delay3\u0000description": {
       "out": "94c29cd76d72",
       "src": "8a965100226c"
     },
-    "services.activate_led.fields.loop_delay3.name": {
+    "services\u0000activate_led\u0000fields\u0000loop_delay3\u0000name": {
       "out": "700ae93133b4",
       "src": "66d787aa1bad"
     },
-    "services.activate_led.fields.repeats.description": {
+    "services\u0000activate_led\u0000fields\u0000repeats\u0000description": {
       "out": "300e7752bf30",
       "src": "e40e956e3762"
     },
-    "services.activate_led.fields.repeats.name": {
+    "services\u0000activate_led\u0000fields\u0000repeats\u0000name": {
       "out": "007319cdfdac",
       "src": "92ee0233f013"
     },
-    "services.activate_led.name": {
+    "services\u0000activate_led\u0000name": {
       "out": "32186d467e6c",
       "src": "91933e94cc57"
     },
-    "services.drawcustom.description": {
+    "services\u0000drawcustom\u0000description": {
       "out": "fdc353e37a39",
       "src": "55f9f3333fc0"
     },
-    "services.drawcustom.fields.background.description": {
+    "services\u0000drawcustom\u0000fields\u0000background\u0000description": {
       "out": "471c23f20ddf",
       "src": "f5858405d78a"
     },
-    "services.drawcustom.fields.background.name": {
+    "services\u0000drawcustom\u0000fields\u0000background\u0000name": {
       "out": "d1aedb1ba5cb",
       "src": "3e314dafdf7c"
     },
-    "services.drawcustom.fields.dither.description": {
+    "services\u0000drawcustom\u0000fields\u0000dither\u0000description": {
       "out": "e72ebaaa3c80",
       "src": "d7c737e5d01e"
     },
-    "services.drawcustom.fields.dither.name": {
+    "services\u0000drawcustom\u0000fields\u0000dither\u0000name": {
       "out": "a67ee5312f9c",
       "src": "35fb13830002"
     },
-    "services.drawcustom.fields.dry-run.description": {
+    "services\u0000drawcustom\u0000fields\u0000dry-run\u0000description": {
       "out": "fc718f2dda27",
       "src": "54f5f06db00c"
     },
-    "services.drawcustom.fields.dry-run.name": {
+    "services\u0000drawcustom\u0000fields\u0000dry-run\u0000name": {
       "out": "7adaf883aa86",
       "src": "d5da154d9f00"
     },
-    "services.drawcustom.fields.measured_palette.description": {
+    "services\u0000drawcustom\u0000fields\u0000measured_palette\u0000description": {
       "out": "de4909ff241c",
       "src": "53842124c7af"
     },
-    "services.drawcustom.fields.measured_palette.name": {
+    "services\u0000drawcustom\u0000fields\u0000measured_palette\u0000name": {
       "out": "07a336053344",
       "src": "672d38bdeb19"
     },
-    "services.drawcustom.fields.payload.description": {
+    "services\u0000drawcustom\u0000fields\u0000payload\u0000description": {
       "out": "862878a45569",
       "src": "a72e3d514ead"
     },
-    "services.drawcustom.fields.payload.name": {
+    "services\u0000drawcustom\u0000fields\u0000payload\u0000name": {
       "out": "75718dabda35",
       "src": "99733344956d"
     },
-    "services.drawcustom.fields.refresh_type.description": {
+    "services\u0000drawcustom\u0000fields\u0000refresh_type\u0000description": {
       "out": "e42d5844b694",
       "src": "d87a3d5c4d06"
     },
-    "services.drawcustom.fields.refresh_type.name": {
+    "services\u0000drawcustom\u0000fields\u0000refresh_type\u0000name": {
       "out": "8eb13e60812c",
       "src": "201b25b874bb"
     },
-    "services.drawcustom.fields.rotate.description": {
+    "services\u0000drawcustom\u0000fields\u0000rotate\u0000description": {
       "out": "ab79bfdc4410",
       "src": "21e39f93db71"
     },
-    "services.drawcustom.fields.rotate.name": {
+    "services\u0000drawcustom\u0000fields\u0000rotate\u0000name": {
       "out": "57b5e2fc1bba",
       "src": "57b5e2fc1bba"
     },
-    "services.drawcustom.name": {
+    "services\u0000drawcustom\u0000name": {
       "out": "09b119dee48e",
       "src": "d0df7a6244ea"
     },
-    "services.upload_image.description": {
+    "services\u0000upload_image\u0000description": {
       "out": "175050ee7e69",
       "src": "24e19354eaa4"
     },
-    "services.upload_image.fields.device_id.description": {
+    "services\u0000upload_image\u0000fields\u0000device_id\u0000description": {
       "out": "536ac258aace",
       "src": "ee157333391e"
     },
-    "services.upload_image.fields.device_id.name": {
+    "services\u0000upload_image\u0000fields\u0000device_id\u0000name": {
       "out": "0944613acb42",
       "src": "6ba0bdeccb42"
     },
-    "services.upload_image.fields.dither_mode.description": {
+    "services\u0000upload_image\u0000fields\u0000dither_mode\u0000description": {
       "out": "ebc46edc92f0",
       "src": "70483fdfe7ec"
     },
-    "services.upload_image.fields.dither_mode.name": {
+    "services\u0000upload_image\u0000fields\u0000dither_mode\u0000name": {
       "out": "a67ee5312f9c",
       "src": "35fb13830002"
     },
-    "services.upload_image.fields.fit_mode.description": {
+    "services\u0000upload_image\u0000fields\u0000fit_mode\u0000description": {
       "out": "0ed34722a3e7",
       "src": "8d2c8735a962"
     },
-    "services.upload_image.fields.fit_mode.name": {
+    "services\u0000upload_image\u0000fields\u0000fit_mode\u0000name": {
       "out": "071687ebc260",
       "src": "8a59790c9187"
     },
-    "services.upload_image.fields.image.description": {
+    "services\u0000upload_image\u0000fields\u0000image\u0000description": {
       "out": "3e073d65e7ab",
       "src": "ba6d9fb759b0"
     },
-    "services.upload_image.fields.image.name": {
+    "services\u0000upload_image\u0000fields\u0000image\u0000name": {
       "out": "1aa4cb0bcca7",
       "src": "1aa4cb0bcca7"
     },
-    "services.upload_image.fields.measured_palette.description": {
+    "services\u0000upload_image\u0000fields\u0000measured_palette\u0000description": {
       "out": "841b36cd330b",
       "src": "53842124c7af"
     },
-    "services.upload_image.fields.measured_palette.name": {
+    "services\u0000upload_image\u0000fields\u0000measured_palette\u0000name": {
       "out": "07a336053344",
       "src": "672d38bdeb19"
     },
-    "services.upload_image.fields.refresh_mode.description": {
+    "services\u0000upload_image\u0000fields\u0000refresh_mode\u0000description": {
       "out": "25e346fc6cf0",
       "src": "0fe957da240a"
     },
-    "services.upload_image.fields.refresh_mode.name": {
+    "services\u0000upload_image\u0000fields\u0000refresh_mode\u0000name": {
       "out": "1a15df70f262",
       "src": "c72fd253298c"
     },
-    "services.upload_image.fields.rotation.description": {
+    "services\u0000upload_image\u0000fields\u0000rotation\u0000description": {
       "out": "e5615edff377",
       "src": "b639ab27209e"
     },
-    "services.upload_image.fields.rotation.name": {
+    "services\u0000upload_image\u0000fields\u0000rotation\u0000name": {
       "out": "57b5e2fc1bba",
       "src": "57b5e2fc1bba"
     },
-    "services.upload_image.fields.tone_compression.description": {
+    "services\u0000upload_image\u0000fields\u0000tone_compression\u0000description": {
       "out": "25944386006f",
       "src": "6453b45ae0cc"
     },
-    "services.upload_image.fields.tone_compression.name": {
+    "services\u0000upload_image\u0000fields\u0000tone_compression\u0000name": {
       "out": "9d3f4c31fdec",
       "src": "ffaed65f03fa"
     },
-    "services.upload_image.name": {
+    "services\u0000upload_image\u0000name": {
       "out": "e529df1ddebd",
       "src": "ffe4df6c7ca6"
     },
-    "services.upload_image.sections.additional_fields.name": {
+    "services\u0000upload_image\u0000sections\u0000additional_fields\u0000name": {
       "out": "70865af370b9",
       "src": "092170b2408b"
     },
-    "services.write_nfc.description": {
+    "services\u0000write_nfc\u0000description": {
       "out": "15a03311e3cf",
       "src": "3c1f6a6d643e"
     },
-    "services.write_nfc.fields.content.description": {
+    "services\u0000write_nfc\u0000fields\u0000content\u0000description": {
       "out": "8fec9cf5e02c",
       "src": "857d1cf0bf90"
     },
-    "services.write_nfc.fields.content.name": {
+    "services\u0000write_nfc\u0000fields\u0000content\u0000name": {
       "out": "7a6de5670ea8",
       "src": "47bd29075f8b"
     },
-    "services.write_nfc.fields.device_id.description": {
+    "services\u0000write_nfc\u0000fields\u0000device_id\u0000description": {
       "out": "70b3a453ffac",
       "src": "7dec980cb238"
     },
-    "services.write_nfc.fields.device_id.name": {
+    "services\u0000write_nfc\u0000fields\u0000device_id\u0000name": {
       "out": "0944613acb42",
       "src": "6ba0bdeccb42"
     },
-    "services.write_nfc.fields.mime_type.description": {
+    "services\u0000write_nfc\u0000fields\u0000mime_type\u0000description": {
       "out": "4f733613d7c9",
       "src": "4eb2b40ec666"
     },
-    "services.write_nfc.fields.mime_type.name": {
+    "services\u0000write_nfc\u0000fields\u0000mime_type\u0000name": {
       "out": "5255235b47eb",
       "src": "849e8a810960"
     },
-    "services.write_nfc.fields.record_type.description": {
+    "services\u0000write_nfc\u0000fields\u0000record_type\u0000description": {
       "out": "b6aafe6c7a4a",
       "src": "936cf634012f"
     },
-    "services.write_nfc.fields.record_type.name": {
+    "services\u0000write_nfc\u0000fields\u0000record_type\u0000name": {
       "out": "b25366adaeab",
       "src": "91cf117b1d70"
     },
-    "services.write_nfc.name": {
+    "services\u0000write_nfc\u0000name": {
       "out": "689db4db448d",
       "src": "96ea14b97cf7"
     }
   },
   "it": {
-    "config.abort.already_configured": {
+    "config\u0000abort\u0000already_configured": {
       "out": "c13c1a7a2d55",
       "src": "c2936e02a0d2"
     },
-    "config.abort.already_in_progress": {
+    "config\u0000abort\u0000already_in_progress": {
       "out": "6d0dce72fc2a",
       "src": "985a72ad93a3"
     },
-    "config.abort.cannot_connect": {
+    "config\u0000abort\u0000cannot_connect": {
       "out": "b1815fe34325",
       "src": "46c9f3b7520f"
     },
-    "config.abort.no_devices_found": {
+    "config\u0000abort\u0000no_devices_found": {
       "out": "f82ec533e69a",
       "src": "b8f28e84cf0b"
     },
-    "config.abort.reauth_successful": {
+    "config\u0000abort\u0000reauth_successful": {
       "out": "619607b89bc8",
       "src": "e5b83989735c"
     },
-    "config.abort.unknown": {
+    "config\u0000abort\u0000unknown": {
       "out": "9ff3c7db40da",
       "src": "d24c41ae530a"
     },
-    "config.error.cannot_connect": {
+    "config\u0000error\u0000cannot_connect": {
       "out": "b1815fe34325",
       "src": "46c9f3b7520f"
     },
-    "config.error.invalid_auth": {
+    "config\u0000error\u0000invalid_auth": {
       "out": "81c7605e72e2",
       "src": "4ca089878c5f"
     },
-    "config.error.invalid_key_format": {
+    "config\u0000error\u0000invalid_key_format": {
       "out": "a938b0921859",
       "src": "f7b03dd699df"
     },
-    "config.error.unknown": {
+    "config\u0000error\u0000unknown": {
       "out": "9ff3c7db40da",
       "src": "d24c41ae530a"
     },
-    "config.flow_title": {
+    "config\u0000flow_title": {
       "out": "5e291d7bcb2d",
       "src": "5e291d7bcb2d"
     },
-    "config.step.bluetooth_confirm.description": {
+    "config\u0000step\u0000bluetooth_confirm\u0000description": {
       "out": "e95a8e5fcfbd",
       "src": "bcfd5a24b7d7"
     },
-    "config.step.encryption_key.data.encryption_key": {
+    "config\u0000step\u0000encryption_key\u0000data\u0000encryption_key": {
       "out": "70bb7c738670",
       "src": "16b3c9d5573d"
     },
-    "config.step.encryption_key.data_description.encryption_key": {
+    "config\u0000step\u0000encryption_key\u0000data_description\u0000encryption_key": {
       "out": "4b90641c3604",
       "src": "e64cd2e7e647"
     },
-    "config.step.encryption_key.description": {
+    "config\u0000step\u0000encryption_key\u0000description": {
       "out": "cffd64e7e489",
       "src": "664d3f12bfe6"
     },
-    "config.step.encryption_key.title": {
+    "config\u0000step\u0000encryption_key\u0000title": {
       "out": "6b977e1a81dc",
       "src": "c30d1ca158a3"
     },
-    "config.step.reauth_confirm.data.encryption_key": {
+    "config\u0000step\u0000reauth_confirm\u0000data\u0000encryption_key": {
       "out": "70bb7c738670",
       "src": "16b3c9d5573d"
     },
-    "config.step.reauth_confirm.data_description.encryption_key": {
+    "config\u0000step\u0000reauth_confirm\u0000data_description\u0000encryption_key": {
       "out": "4b90641c3604",
       "src": "e64cd2e7e647"
     },
-    "config.step.reauth_confirm.description": {
+    "config\u0000step\u0000reauth_confirm\u0000description": {
       "out": "81767ea59923",
       "src": "f53b69d3be84"
     },
-    "config.step.reauth_confirm.title": {
+    "config\u0000step\u0000reauth_confirm\u0000title": {
       "out": "44ac6fa9791c",
       "src": "7e22a752572f"
     },
-    "config.step.user.data.address": {
+    "config\u0000step\u0000user\u0000data\u0000address": {
       "out": "1c555eb7f1c0",
       "src": "6ba0bdeccb42"
     },
-    "config.step.user.data_description.address": {
+    "config\u0000step\u0000user\u0000data_description\u0000address": {
       "out": "35dbd7926214",
       "src": "a083a457cfb1"
     },
-    "config.step.user.description": {
+    "config\u0000step\u0000user\u0000description": {
       "out": "2b0eb62d4b08",
       "src": "109135454652"
     },
-    "entity.binary_sensor.update_pending.name": {
+    "entity\u0000binary_sensor\u0000update_pending\u0000name": {
       "out": "e196fd3b8853",
       "src": "8e0a4b18ae75"
     },
-    "entity.event.button.name": {
+    "entity\u0000event\u0000button\u0000name": {
       "out": "294e6fa3faaa",
       "src": "2dcae43716c2"
     },
-    "entity.event.button.state_attributes.event_type.state.button_down": {
+    "entity\u0000event\u0000button\u0000state_attributes\u0000event_type\u0000state\u0000button_down": {
       "out": "761fe03197e8",
       "src": "8352c89d20b4"
     },
-    "entity.event.button.state_attributes.event_type.state.button_up": {
+    "entity\u0000event\u0000button\u0000state_attributes\u0000event_type\u0000state\u0000button_up": {
       "out": "695fbe3c1136",
       "src": "7f18b4912929"
     },
-    "entity.event.touch.name": {
+    "entity\u0000event\u0000touch\u0000name": {
       "out": "ae3b3445c9f9",
       "src": "c915d14278fc"
     },
-    "entity.event.touch.state_attributes.event_type.state.touch_down": {
+    "entity\u0000event\u0000touch\u0000state_attributes\u0000event_type\u0000state\u0000touch_down": {
       "out": "7fb9054714f7",
       "src": "0234a9576230"
     },
-    "entity.event.touch.state_attributes.event_type.state.touch_move": {
+    "entity\u0000event\u0000touch\u0000state_attributes\u0000event_type\u0000state\u0000touch_move": {
       "out": "3cb75222f535",
       "src": "67aeac815e94"
     },
-    "entity.event.touch.state_attributes.event_type.state.touch_up": {
+    "entity\u0000event\u0000touch\u0000state_attributes\u0000event_type\u0000state\u0000touch_up": {
       "out": "1d536c75388c",
       "src": "7c65519d3bb3"
     },
-    "entity.image.content.name": {
+    "entity\u0000image\u0000content\u0000name": {
       "out": "f00e690fcbf0",
       "src": "047c6db3382a"
     },
-    "entity.sensor.battery_voltage.name": {
+    "entity\u0000sensor\u0000battery_voltage\u0000name": {
       "out": "0226d3e1afe4",
       "src": "39d6c91b57ce"
     },
-    "entity.sensor.last_seen.name": {
+    "entity\u0000sensor\u0000last_seen\u0000name": {
       "out": "17d51dae14bd",
       "src": "21fd79c7de52"
     },
-    "entity.sensor.rssi.name": {
+    "entity\u0000sensor\u0000rssi\u0000name": {
       "out": "ab4fcf55cdb0",
       "src": "2604d15c1187"
     },
-    "entity.update.firmware.name": {
+    "entity\u0000update\u0000firmware\u0000name": {
       "out": "c2a314c3b32b",
       "src": "c2a314c3b32b"
     },
-    "exceptions.authentication_error.message": {
+    "exceptions\u0000authentication_error\u0000message": {
       "out": "808d4428797d",
       "src": "3d9f7c0c6d80"
     },
-    "exceptions.device_not_found.message": {
+    "exceptions\u0000device_not_found\u0000message": {
       "out": "2a6eb6f25f73",
       "src": "f244d0d2db8d"
     },
-    "exceptions.device_sleeping.message": {
+    "exceptions\u0000device_sleeping\u0000message": {
       "out": "8fa146655440",
       "src": "e95d25bd6fc7"
     },
-    "exceptions.device_sleeping_ota.message": {
+    "exceptions\u0000device_sleeping_ota\u0000message": {
       "out": "c945b1b2513e",
       "src": "430e3a1baa6a"
     },
-    "exceptions.invalid_device_id.message": {
+    "exceptions\u0000invalid_device_id\u0000message": {
       "out": "9605015e8c92",
       "src": "cc64cc29ceeb"
     },
-    "exceptions.media_download_error.message": {
+    "exceptions\u0000media_download_error\u0000message": {
       "out": "6e77cf8e55ee",
       "src": "5852129dd920"
     },
-    "exceptions.mime_type_not_applicable.message": {
+    "exceptions\u0000mime_type_not_applicable\u0000message": {
       "out": "380edc862100",
       "src": "de700f02fbd5"
     },
-    "exceptions.multiple_errors.message": {
+    "exceptions\u0000multiple_errors\u0000message": {
       "out": "280310410b47",
       "src": "f17c68e0a848"
     },
-    "exceptions.nfc_content_empty.message": {
+    "exceptions\u0000nfc_content_empty\u0000message": {
       "out": "2c8100dd1c1f",
       "src": "b93a1a6ebdc0"
     },
-    "exceptions.nfc_content_too_long.message": {
+    "exceptions\u0000nfc_content_too_long\u0000message": {
       "out": "0c7f5fd42441",
       "src": "8f580b9c6c76"
     },
-    "exceptions.nfc_mime_type_invalid.message": {
+    "exceptions\u0000nfc_mime_type_invalid\u0000message": {
       "out": "4f112e5cff47",
       "src": "5a5f44fe332f"
     },
-    "exceptions.nfc_not_supported.message": {
+    "exceptions\u0000nfc_not_supported\u0000message": {
       "out": "4ade687e73f7",
       "src": "8fdcd0e2bd17"
     },
-    "exceptions.nfc_write_failed.message": {
+    "exceptions\u0000nfc_write_failed\u0000message": {
       "out": "310cd7bdf035",
       "src": "e8186303a52e"
     },
-    "exceptions.no_buzzers.message": {
+    "exceptions\u0000no_buzzers\u0000message": {
       "out": "1f50fe51f836",
       "src": "9c014dfeac91"
     },
-    "exceptions.no_leds.message": {
+    "exceptions\u0000no_leds\u0000message": {
       "out": "5b10e3358e2a",
       "src": "6a302f8f22ee"
     },
-    "exceptions.no_nfc.message": {
+    "exceptions\u0000no_nfc\u0000message": {
       "out": "4fa38d63c770",
       "src": "abb1917ad57e"
     },
-    "exceptions.no_targets_specified.message": {
+    "exceptions\u0000no_targets_specified\u0000message": {
       "out": "458896e84018",
       "src": "80c472afefe6"
     },
-    "exceptions.upload_error.message": {
+    "exceptions\u0000upload_error\u0000message": {
       "out": "431a9f4a0b8f",
       "src": "75561a03be6e"
     },
-    "exceptions.url_not_allowed.message": {
+    "exceptions\u0000url_not_allowed\u0000message": {
       "out": "4d728bd5af6b",
       "src": "33ffb9a9f2c4"
     },
-    "options.step.init.data.blocks_per_ack": {
+    "options\u0000step\u0000init\u0000data\u0000blocks_per_ack": {
       "out": "179c008aff1b",
       "src": "3e2a554e69a4"
     },
-    "options.step.init.data.max_queue_size": {
+    "options\u0000step\u0000init\u0000data\u0000max_queue_size": {
       "out": "4ca717893020",
       "src": "297af7027dd0"
     },
-    "options.step.init.data.missed_cycles": {
+    "options\u0000step\u0000init\u0000data\u0000missed_cycles": {
       "out": "4a1d01172530",
       "src": "59b78644491a"
     },
-    "options.step.init.data.probe_before_queue": {
+    "options\u0000step\u0000init\u0000data\u0000probe_before_queue": {
       "out": "06cdb2854a7b",
       "src": "02c4211a58b2"
     },
-    "options.step.init.data.queue_timeout_hours": {
+    "options\u0000step\u0000init\u0000data\u0000queue_timeout_hours": {
       "out": "e7e301c02b53",
       "src": "be70fc5cca79"
     },
-    "options.step.init.data.sleep_mode": {
+    "options\u0000step\u0000init\u0000data\u0000sleep_mode": {
       "out": "5be328b31d89",
       "src": "f925c0e541ce"
     },
-    "options.step.init.data_description.blocks_per_ack": {
+    "options\u0000step\u0000init\u0000data_description\u0000blocks_per_ack": {
       "out": "ae8f8d587584",
       "src": "3a693b19d3c6"
     },
-    "options.step.init.data_description.max_queue_size": {
+    "options\u0000step\u0000init\u0000data_description\u0000max_queue_size": {
       "out": "8fcbf102cad8",
       "src": "50260959ee56"
     },
-    "options.step.init.data_description.missed_cycles": {
+    "options\u0000step\u0000init\u0000data_description\u0000missed_cycles": {
       "out": "99a606e9e8da",
       "src": "6ce493f4c44d"
     },
-    "options.step.init.data_description.probe_before_queue": {
+    "options\u0000step\u0000init\u0000data_description\u0000probe_before_queue": {
       "out": "d713e2835e0e",
       "src": "5d0f2985ffdf"
     },
-    "options.step.init.data_description.queue_timeout_hours": {
+    "options\u0000step\u0000init\u0000data_description\u0000queue_timeout_hours": {
       "out": "73fb66832b41",
       "src": "34895000b491"
     },
-    "options.step.init.data_description.sleep_mode": {
+    "options\u0000step\u0000init\u0000data_description\u0000sleep_mode": {
       "out": "5e9565eff78a",
       "src": "4acfeb65d10d"
     },
-    "selector.dither_mode.options.atkinson": {
+    "selector\u0000dither_mode\u0000options\u0000atkinson": {
       "out": "7a8fe6d47b5b",
       "src": "7a8fe6d47b5b"
     },
-    "selector.dither_mode.options.burkes": {
+    "selector\u0000dither_mode\u0000options\u0000burkes": {
       "out": "1b75087201fb",
       "src": "1b75087201fb"
     },
-    "selector.dither_mode.options.floyd_steinberg": {
+    "selector\u0000dither_mode\u0000options\u0000floyd_steinberg": {
       "out": "37969811a3cf",
       "src": "37969811a3cf"
     },
-    "selector.dither_mode.options.jarvis_judice_ninke": {
+    "selector\u0000dither_mode\u0000options\u0000jarvis_judice_ninke": {
       "out": "7020241adf78",
       "src": "7020241adf78"
     },
-    "selector.dither_mode.options.none": {
+    "selector\u0000dither_mode\u0000options\u0000none": {
       "out": "aa201262e9a7",
       "src": "dc937b598926"
     },
-    "selector.dither_mode.options.ordered": {
+    "selector\u0000dither_mode\u0000options\u0000ordered": {
       "out": "15a0e538e63f",
       "src": "007877479e21"
     },
-    "selector.dither_mode.options.sierra": {
+    "selector\u0000dither_mode\u0000options\u0000sierra": {
       "out": "d5eef8ad210c",
       "src": "d5eef8ad210c"
     },
-    "selector.dither_mode.options.sierra_lite": {
+    "selector\u0000dither_mode\u0000options\u0000sierra_lite": {
       "out": "20da8cc85f38",
       "src": "20da8cc85f38"
     },
-    "selector.dither_mode.options.stucki": {
+    "selector\u0000dither_mode\u0000options\u0000stucki": {
       "out": "a17d2b13b6f9",
       "src": "a17d2b13b6f9"
     },
-    "selector.fit_mode.options.contain": {
+    "selector\u0000fit_mode\u0000options\u0000contain": {
       "out": "585ad1b076ef",
       "src": "e534a2c2b456"
     },
-    "selector.fit_mode.options.cover": {
+    "selector\u0000fit_mode\u0000options\u0000cover": {
       "out": "4cd0d886b40b",
       "src": "fa8d84566676"
     },
-    "selector.fit_mode.options.crop": {
+    "selector\u0000fit_mode\u0000options\u0000crop": {
       "out": "be091ff9470e",
       "src": "98caf7c43c6f"
     },
-    "selector.fit_mode.options.stretch": {
+    "selector\u0000fit_mode\u0000options\u0000stretch": {
       "out": "266e2e1e0b53",
       "src": "a33fbcf83f7b"
     },
-    "selector.nfc_record_type.options.ha_tag": {
+    "selector\u0000nfc_record_type\u0000options\u0000ha_tag": {
       "out": "b74c1bf15cfa",
       "src": "d1d47a8fa544"
     },
-    "selector.nfc_record_type.options.mime": {
+    "selector\u0000nfc_record_type\u0000options\u0000mime": {
       "out": "6e66b0f9ef4b",
       "src": "f98d7539e627"
     },
-    "selector.nfc_record_type.options.text": {
+    "selector\u0000nfc_record_type\u0000options\u0000text": {
       "out": "ebb9e60cfec0",
       "src": "71988c4d8e08"
     },
-    "selector.nfc_record_type.options.url": {
+    "selector\u0000nfc_record_type\u0000options\u0000url": {
       "out": "e7a241debad5",
       "src": "e7a241debad5"
     },
-    "selector.refresh_mode.options.fast": {
+    "selector\u0000refresh_mode\u0000options\u0000fast": {
       "out": "e9d2bef80d57",
       "src": "6c582b62e0e5"
     },
-    "selector.refresh_mode.options.full": {
+    "selector\u0000refresh_mode\u0000options\u0000full": {
       "out": "23e3685fbe6c",
       "src": "008dacb6d1e8"
     },
-    "selector.refresh_mode.options.partial": {
+    "selector\u0000refresh_mode\u0000options\u0000partial": {
       "out": "12d5e1468ffa",
       "src": "a4d50fb85403"
     },
-    "selector.sleep_mode.options.auto": {
+    "selector\u0000sleep_mode\u0000options\u0000auto": {
       "out": "fdd0d6ab20c1",
       "src": "132990bd8ef7"
     },
-    "selector.sleep_mode.options.off": {
+    "selector\u0000sleep_mode\u0000options\u0000off": {
       "out": "0ee315fa8ffe",
       "src": "34598efe7b90"
     },
-    "selector.sleep_mode.options.on": {
+    "selector\u0000sleep_mode\u0000options\u0000on": {
       "out": "95ca5f7d875b",
       "src": "bde131e31c9e"
     },
-    "services.activate_buzzer.description": {
+    "services\u0000activate_buzzer\u0000description": {
       "out": "a413ecb3c558",
       "src": "1898784614cb"
     },
-    "services.activate_buzzer.fields.device_id.description": {
+    "services\u0000activate_buzzer\u0000fields\u0000device_id\u0000description": {
       "out": "9f827f83022b",
       "src": "7dec980cb238"
     },
-    "services.activate_buzzer.fields.device_id.name": {
+    "services\u0000activate_buzzer\u0000fields\u0000device_id\u0000name": {
       "out": "1c555eb7f1c0",
       "src": "6ba0bdeccb42"
     },
-    "services.activate_buzzer.fields.duration_ms.description": {
+    "services\u0000activate_buzzer\u0000fields\u0000duration_ms\u0000description": {
       "out": "3e7bfddf5f06",
       "src": "cd1bc75ca60c"
     },
-    "services.activate_buzzer.fields.duration_ms.name": {
+    "services\u0000activate_buzzer\u0000fields\u0000duration_ms\u0000name": {
       "out": "902f1527bb48",
       "src": "4fc52a3c4c55"
     },
-    "services.activate_buzzer.fields.frequency_hz.description": {
+    "services\u0000activate_buzzer\u0000fields\u0000frequency_hz\u0000description": {
       "out": "a67d894d5dfb",
       "src": "510fc20311e3"
     },
-    "services.activate_buzzer.fields.frequency_hz.name": {
+    "services\u0000activate_buzzer\u0000fields\u0000frequency_hz\u0000name": {
       "out": "b8cff750b1c0",
       "src": "16b6668d9831"
     },
-    "services.activate_buzzer.fields.instance.description": {
+    "services\u0000activate_buzzer\u0000fields\u0000instance\u0000description": {
       "out": "0ee80131f2bf",
       "src": "f39fa742d55c"
     },
-    "services.activate_buzzer.fields.instance.name": {
+    "services\u0000activate_buzzer\u0000fields\u0000instance\u0000name": {
       "out": "a7789aec1c65",
       "src": "1f671ddded9e"
     },
-    "services.activate_buzzer.fields.repeats.description": {
+    "services\u0000activate_buzzer\u0000fields\u0000repeats\u0000description": {
       "out": "0d2fc48e2d44",
       "src": "1f88b0fe23ea"
     },
-    "services.activate_buzzer.fields.repeats.name": {
+    "services\u0000activate_buzzer\u0000fields\u0000repeats\u0000name": {
       "out": "d4e1d6b072f6",
       "src": "92ee0233f013"
     },
-    "services.activate_buzzer.name": {
+    "services\u0000activate_buzzer\u0000name": {
       "out": "e6d5008187db",
       "src": "0b80285753b7"
     },
-    "services.activate_led.description": {
+    "services\u0000activate_led\u0000description": {
       "out": "a6b9d2ad88f8",
       "src": "6cbd645597cc"
     },
-    "services.activate_led.fields.brightness.description": {
+    "services\u0000activate_led\u0000fields\u0000brightness\u0000description": {
       "out": "a43465c496a1",
       "src": "6ad88a28230d"
     },
-    "services.activate_led.fields.brightness.name": {
+    "services\u0000activate_led\u0000fields\u0000brightness\u0000name": {
       "out": "48f971e2c07b",
       "src": "ec811d30a89c"
     },
-    "services.activate_led.fields.color1.description": {
+    "services\u0000activate_led\u0000fields\u0000color1\u0000description": {
       "out": "e62825d9c107",
       "src": "17f145013241"
     },
-    "services.activate_led.fields.color1.name": {
+    "services\u0000activate_led\u0000fields\u0000color1\u0000name": {
       "out": "773570f9f353",
       "src": "571461f36f3a"
     },
-    "services.activate_led.fields.color2.description": {
+    "services\u0000activate_led\u0000fields\u0000color2\u0000description": {
       "out": "beab1dc344c4",
       "src": "f2680a4bbe85"
     },
-    "services.activate_led.fields.color2.name": {
+    "services\u0000activate_led\u0000fields\u0000color2\u0000name": {
       "out": "40f82b62eac8",
       "src": "ef792d287872"
     },
-    "services.activate_led.fields.color3.description": {
+    "services\u0000activate_led\u0000fields\u0000color3\u0000description": {
       "out": "500558932c92",
       "src": "b8ecd353b426"
     },
-    "services.activate_led.fields.color3.name": {
+    "services\u0000activate_led\u0000fields\u0000color3\u0000name": {
       "out": "809dde2191d5",
       "src": "48d54e046d29"
     },
-    "services.activate_led.fields.device_id.description": {
+    "services\u0000activate_led\u0000fields\u0000device_id\u0000description": {
       "out": "9f827f83022b",
       "src": "7dec980cb238"
     },
-    "services.activate_led.fields.device_id.name": {
+    "services\u0000activate_led\u0000fields\u0000device_id\u0000name": {
       "out": "1c555eb7f1c0",
       "src": "6ba0bdeccb42"
     },
-    "services.activate_led.fields.flash_count1.description": {
+    "services\u0000activate_led\u0000fields\u0000flash_count1\u0000description": {
       "out": "e216bbe165eb",
       "src": "4ffdadde31c2"
     },
-    "services.activate_led.fields.flash_count1.name": {
+    "services\u0000activate_led\u0000fields\u0000flash_count1\u0000name": {
       "out": "b516fc047936",
       "src": "13c6a2e5c22e"
     },
-    "services.activate_led.fields.flash_count2.description": {
+    "services\u0000activate_led\u0000fields\u0000flash_count2\u0000description": {
       "out": "707e0aa8838e",
       "src": "86dc999a3915"
     },
-    "services.activate_led.fields.flash_count2.name": {
+    "services\u0000activate_led\u0000fields\u0000flash_count2\u0000name": {
       "out": "e2f2bf10635a",
       "src": "2be36d8449dc"
     },
-    "services.activate_led.fields.flash_count3.description": {
+    "services\u0000activate_led\u0000fields\u0000flash_count3\u0000description": {
       "out": "f04ad3ccd536",
       "src": "aa40c396a9a4"
     },
-    "services.activate_led.fields.flash_count3.name": {
+    "services\u0000activate_led\u0000fields\u0000flash_count3\u0000name": {
       "out": "eb6bf46ee577",
       "src": "7978910dc6b2"
     },
-    "services.activate_led.fields.instance.description": {
+    "services\u0000activate_led\u0000fields\u0000instance\u0000description": {
       "out": "39111deb68ff",
       "src": "0531b37de90a"
     },
-    "services.activate_led.fields.instance.name": {
+    "services\u0000activate_led\u0000fields\u0000instance\u0000name": {
       "out": "297a0e45f33f",
       "src": "f942926204c7"
     },
-    "services.activate_led.fields.inter_delay1.description": {
+    "services\u0000activate_led\u0000fields\u0000inter_delay1\u0000description": {
       "out": "c8113597eb05",
       "src": "1b65dcfcea95"
     },
-    "services.activate_led.fields.inter_delay1.name": {
+    "services\u0000activate_led\u0000fields\u0000inter_delay1\u0000name": {
       "out": "ef84aec45cfe",
       "src": "71452f436c33"
     },
-    "services.activate_led.fields.inter_delay2.description": {
+    "services\u0000activate_led\u0000fields\u0000inter_delay2\u0000description": {
       "out": "4ee4d0be439f",
       "src": "181e03f33cbf"
     },
-    "services.activate_led.fields.inter_delay2.name": {
+    "services\u0000activate_led\u0000fields\u0000inter_delay2\u0000name": {
       "out": "9bd223abcae9",
       "src": "6a50551e5355"
     },
-    "services.activate_led.fields.inter_delay3.description": {
+    "services\u0000activate_led\u0000fields\u0000inter_delay3\u0000description": {
       "out": "2e16218def4a",
       "src": "5c5973b586df"
     },
-    "services.activate_led.fields.inter_delay3.name": {
+    "services\u0000activate_led\u0000fields\u0000inter_delay3\u0000name": {
       "out": "9cb9e0ff88c6",
       "src": "b0f72903777e"
     },
-    "services.activate_led.fields.loop_delay1.description": {
+    "services\u0000activate_led\u0000fields\u0000loop_delay1\u0000description": {
       "out": "5bc1a1d02db9",
       "src": "2139915c35bc"
     },
-    "services.activate_led.fields.loop_delay1.name": {
+    "services\u0000activate_led\u0000fields\u0000loop_delay1\u0000name": {
       "out": "0673ed430035",
       "src": "2fb02375bae0"
     },
-    "services.activate_led.fields.loop_delay2.description": {
+    "services\u0000activate_led\u0000fields\u0000loop_delay2\u0000description": {
       "out": "4d9a25d52b20",
       "src": "9a3a8cccb3bb"
     },
-    "services.activate_led.fields.loop_delay2.name": {
+    "services\u0000activate_led\u0000fields\u0000loop_delay2\u0000name": {
       "out": "0621a110d6d0",
       "src": "597cbe87a7ec"
     },
-    "services.activate_led.fields.loop_delay3.description": {
+    "services\u0000activate_led\u0000fields\u0000loop_delay3\u0000description": {
       "out": "8ec2c7fc9856",
       "src": "8a965100226c"
     },
-    "services.activate_led.fields.loop_delay3.name": {
+    "services\u0000activate_led\u0000fields\u0000loop_delay3\u0000name": {
       "out": "f1a8191e8a38",
       "src": "66d787aa1bad"
     },
-    "services.activate_led.fields.repeats.description": {
+    "services\u0000activate_led\u0000fields\u0000repeats\u0000description": {
       "out": "c40b00948b21",
       "src": "e40e956e3762"
     },
-    "services.activate_led.fields.repeats.name": {
+    "services\u0000activate_led\u0000fields\u0000repeats\u0000name": {
       "out": "d4e1d6b072f6",
       "src": "92ee0233f013"
     },
-    "services.activate_led.name": {
+    "services\u0000activate_led\u0000name": {
       "out": "fa2687a1fe5f",
       "src": "91933e94cc57"
     },
-    "services.drawcustom.description": {
+    "services\u0000drawcustom\u0000description": {
       "out": "47fba0269f04",
       "src": "55f9f3333fc0"
     },
-    "services.drawcustom.fields.background.description": {
+    "services\u0000drawcustom\u0000fields\u0000background\u0000description": {
       "out": "198cf58055d1",
       "src": "f5858405d78a"
     },
-    "services.drawcustom.fields.background.name": {
+    "services\u0000drawcustom\u0000fields\u0000background\u0000name": {
       "out": "2f456b484269",
       "src": "3e314dafdf7c"
     },
-    "services.drawcustom.fields.dither.description": {
+    "services\u0000drawcustom\u0000fields\u0000dither\u0000description": {
       "out": "550aaf201259",
       "src": "d7c737e5d01e"
     },
-    "services.drawcustom.fields.dither.name": {
+    "services\u0000drawcustom\u0000fields\u0000dither\u0000name": {
       "out": "ee0d16496c32",
       "src": "35fb13830002"
     },
-    "services.drawcustom.fields.dry-run.description": {
+    "services\u0000drawcustom\u0000fields\u0000dry-run\u0000description": {
       "out": "9a21234b3de9",
       "src": "54f5f06db00c"
     },
-    "services.drawcustom.fields.dry-run.name": {
+    "services\u0000drawcustom\u0000fields\u0000dry-run\u0000name": {
       "out": "964df39f3e64",
       "src": "d5da154d9f00"
     },
-    "services.drawcustom.fields.measured_palette.description": {
+    "services\u0000drawcustom\u0000fields\u0000measured_palette\u0000description": {
       "out": "4c7a8ad652a0",
       "src": "53842124c7af"
     },
-    "services.drawcustom.fields.measured_palette.name": {
+    "services\u0000drawcustom\u0000fields\u0000measured_palette\u0000name": {
       "out": "8fa251e7bc0b",
       "src": "672d38bdeb19"
     },
-    "services.drawcustom.fields.payload.description": {
+    "services\u0000drawcustom\u0000fields\u0000payload\u0000description": {
       "out": "0b8972810d5d",
       "src": "a72e3d514ead"
     },
-    "services.drawcustom.fields.payload.name": {
+    "services\u0000drawcustom\u0000fields\u0000payload\u0000name": {
       "out": "99733344956d",
       "src": "99733344956d"
     },
-    "services.drawcustom.fields.refresh_type.description": {
+    "services\u0000drawcustom\u0000fields\u0000refresh_type\u0000description": {
       "out": "fe3f2e6c5276",
       "src": "d87a3d5c4d06"
     },
-    "services.drawcustom.fields.refresh_type.name": {
+    "services\u0000drawcustom\u0000fields\u0000refresh_type\u0000name": {
       "out": "b7d4ba486600",
       "src": "201b25b874bb"
     },
-    "services.drawcustom.fields.rotate.description": {
+    "services\u0000drawcustom\u0000fields\u0000rotate\u0000description": {
       "out": "df6eea223df5",
       "src": "21e39f93db71"
     },
-    "services.drawcustom.fields.rotate.name": {
+    "services\u0000drawcustom\u0000fields\u0000rotate\u0000name": {
       "out": "62b6f5179077",
       "src": "57b5e2fc1bba"
     },
-    "services.drawcustom.name": {
+    "services\u0000drawcustom\u0000name": {
       "out": "b9f06b92149e",
       "src": "d0df7a6244ea"
     },
-    "services.upload_image.description": {
+    "services\u0000upload_image\u0000description": {
       "out": "2f57f84ec342",
       "src": "24e19354eaa4"
     },
-    "services.upload_image.fields.device_id.description": {
+    "services\u0000upload_image\u0000fields\u0000device_id\u0000description": {
       "out": "6bf21aebaa48",
       "src": "ee157333391e"
     },
-    "services.upload_image.fields.device_id.name": {
+    "services\u0000upload_image\u0000fields\u0000device_id\u0000name": {
       "out": "1c555eb7f1c0",
       "src": "6ba0bdeccb42"
     },
-    "services.upload_image.fields.dither_mode.description": {
+    "services\u0000upload_image\u0000fields\u0000dither_mode\u0000description": {
       "out": "79ae5ade74b7",
       "src": "70483fdfe7ec"
     },
-    "services.upload_image.fields.dither_mode.name": {
+    "services\u0000upload_image\u0000fields\u0000dither_mode\u0000name": {
       "out": "ee0d16496c32",
       "src": "35fb13830002"
     },
-    "services.upload_image.fields.fit_mode.description": {
+    "services\u0000upload_image\u0000fields\u0000fit_mode\u0000description": {
       "out": "72e5ba8df574",
       "src": "8d2c8735a962"
     },
-    "services.upload_image.fields.fit_mode.name": {
+    "services\u0000upload_image\u0000fields\u0000fit_mode\u0000name": {
       "out": "2a4895e491ee",
       "src": "8a59790c9187"
     },
-    "services.upload_image.fields.image.description": {
+    "services\u0000upload_image\u0000fields\u0000image\u0000description": {
       "out": "987c77c4697b",
       "src": "ba6d9fb759b0"
     },
-    "services.upload_image.fields.image.name": {
+    "services\u0000upload_image\u0000fields\u0000image\u0000name": {
       "out": "850b6f310354",
       "src": "1aa4cb0bcca7"
     },
-    "services.upload_image.fields.measured_palette.description": {
+    "services\u0000upload_image\u0000fields\u0000measured_palette\u0000description": {
       "out": "9205f39bb14a",
       "src": "53842124c7af"
     },
-    "services.upload_image.fields.measured_palette.name": {
+    "services\u0000upload_image\u0000fields\u0000measured_palette\u0000name": {
       "out": "8fa251e7bc0b",
       "src": "672d38bdeb19"
     },
-    "services.upload_image.fields.refresh_mode.description": {
+    "services\u0000upload_image\u0000fields\u0000refresh_mode\u0000description": {
       "out": "f7cae6b3137e",
       "src": "0fe957da240a"
     },
-    "services.upload_image.fields.refresh_mode.name": {
+    "services\u0000upload_image\u0000fields\u0000refresh_mode\u0000name": {
       "out": "46f4b72b828f",
       "src": "c72fd253298c"
     },
-    "services.upload_image.fields.rotation.description": {
+    "services\u0000upload_image\u0000fields\u0000rotation\u0000description": {
       "out": "1d02884e134b",
       "src": "b639ab27209e"
     },
-    "services.upload_image.fields.rotation.name": {
+    "services\u0000upload_image\u0000fields\u0000rotation\u0000name": {
       "out": "62b6f5179077",
       "src": "57b5e2fc1bba"
     },
-    "services.upload_image.fields.tone_compression.description": {
+    "services\u0000upload_image\u0000fields\u0000tone_compression\u0000description": {
       "out": "6ab18fa9195d",
       "src": "6453b45ae0cc"
     },
-    "services.upload_image.fields.tone_compression.name": {
+    "services\u0000upload_image\u0000fields\u0000tone_compression\u0000name": {
       "out": "0972768e5378",
       "src": "ffaed65f03fa"
     },
-    "services.upload_image.name": {
+    "services\u0000upload_image\u0000name": {
       "out": "2e6d6a1bf842",
       "src": "ffe4df6c7ca6"
     },
-    "services.upload_image.sections.additional_fields.name": {
+    "services\u0000upload_image\u0000sections\u0000additional_fields\u0000name": {
       "out": "0f5d04b54d2d",
       "src": "092170b2408b"
     },
-    "services.write_nfc.description": {
+    "services\u0000write_nfc\u0000description": {
       "out": "b508906e0996",
       "src": "3c1f6a6d643e"
     },
-    "services.write_nfc.fields.content.description": {
+    "services\u0000write_nfc\u0000fields\u0000content\u0000description": {
       "out": "02b3b37b86ae",
       "src": "857d1cf0bf90"
     },
-    "services.write_nfc.fields.content.name": {
+    "services\u0000write_nfc\u0000fields\u0000content\u0000name": {
       "out": "18a65b799b07",
       "src": "47bd29075f8b"
     },
-    "services.write_nfc.fields.device_id.description": {
+    "services\u0000write_nfc\u0000fields\u0000device_id\u0000description": {
       "out": "9f827f83022b",
       "src": "7dec980cb238"
     },
-    "services.write_nfc.fields.device_id.name": {
+    "services\u0000write_nfc\u0000fields\u0000device_id\u0000name": {
       "out": "1c555eb7f1c0",
       "src": "6ba0bdeccb42"
     },
-    "services.write_nfc.fields.mime_type.description": {
+    "services\u0000write_nfc\u0000fields\u0000mime_type\u0000description": {
       "out": "ae7e1983f50f",
       "src": "4eb2b40ec666"
     },
-    "services.write_nfc.fields.mime_type.name": {
+    "services\u0000write_nfc\u0000fields\u0000mime_type\u0000name": {
       "out": "899f5b786081",
       "src": "849e8a810960"
     },
-    "services.write_nfc.fields.record_type.description": {
+    "services\u0000write_nfc\u0000fields\u0000record_type\u0000description": {
       "out": "263aed09ac2e",
       "src": "936cf634012f"
     },
-    "services.write_nfc.fields.record_type.name": {
+    "services\u0000write_nfc\u0000fields\u0000record_type\u0000name": {
       "out": "662375a7e514",
       "src": "91cf117b1d70"
     },
-    "services.write_nfc.name": {
+    "services\u0000write_nfc\u0000name": {
       "out": "d81775704492",
       "src": "96ea14b97cf7"
     }
   },
   "nl": {
-    "config.abort.already_configured": {
+    "config\u0000abort\u0000already_configured": {
       "out": "aa766e4ba66a",
       "src": "c2936e02a0d2"
     },
-    "config.abort.already_in_progress": {
+    "config\u0000abort\u0000already_in_progress": {
       "out": "56ce1a1bae02",
       "src": "985a72ad93a3"
     },
-    "config.abort.cannot_connect": {
+    "config\u0000abort\u0000cannot_connect": {
       "out": "9c4ba67ae02b",
       "src": "46c9f3b7520f"
     },
-    "config.abort.no_devices_found": {
+    "config\u0000abort\u0000no_devices_found": {
       "out": "a087efe1501f",
       "src": "b8f28e84cf0b"
     },
-    "config.abort.reauth_successful": {
+    "config\u0000abort\u0000reauth_successful": {
       "out": "446ac0c8d0c8",
       "src": "e5b83989735c"
     },
-    "config.abort.unknown": {
+    "config\u0000abort\u0000unknown": {
       "out": "76ed6ea944be",
       "src": "d24c41ae530a"
     },
-    "config.error.cannot_connect": {
+    "config\u0000error\u0000cannot_connect": {
       "out": "9c4ba67ae02b",
       "src": "46c9f3b7520f"
     },
-    "config.error.invalid_auth": {
+    "config\u0000error\u0000invalid_auth": {
       "out": "562f0ab41c80",
       "src": "4ca089878c5f"
     },
-    "config.error.invalid_key_format": {
+    "config\u0000error\u0000invalid_key_format": {
       "out": "fb96f7c89bbb",
       "src": "f7b03dd699df"
     },
-    "config.error.unknown": {
+    "config\u0000error\u0000unknown": {
       "out": "76ed6ea944be",
       "src": "d24c41ae530a"
     },
-    "config.flow_title": {
+    "config\u0000flow_title": {
       "out": "5e291d7bcb2d",
       "src": "5e291d7bcb2d"
     },
-    "config.step.bluetooth_confirm.description": {
+    "config\u0000step\u0000bluetooth_confirm\u0000description": {
       "out": "ee83de2aa708",
       "src": "bcfd5a24b7d7"
     },
-    "config.step.encryption_key.data.encryption_key": {
+    "config\u0000step\u0000encryption_key\u0000data\u0000encryption_key": {
       "out": "c2dca326c3c2",
       "src": "16b3c9d5573d"
     },
-    "config.step.encryption_key.data_description.encryption_key": {
+    "config\u0000step\u0000encryption_key\u0000data_description\u0000encryption_key": {
       "out": "e197482d00f4",
       "src": "e64cd2e7e647"
     },
-    "config.step.encryption_key.description": {
+    "config\u0000step\u0000encryption_key\u0000description": {
       "out": "1cc64666b277",
       "src": "664d3f12bfe6"
     },
-    "config.step.encryption_key.title": {
+    "config\u0000step\u0000encryption_key\u0000title": {
       "out": "ee6db52b2455",
       "src": "c30d1ca158a3"
     },
-    "config.step.reauth_confirm.data.encryption_key": {
+    "config\u0000step\u0000reauth_confirm\u0000data\u0000encryption_key": {
       "out": "c2dca326c3c2",
       "src": "16b3c9d5573d"
     },
-    "config.step.reauth_confirm.data_description.encryption_key": {
+    "config\u0000step\u0000reauth_confirm\u0000data_description\u0000encryption_key": {
       "out": "e197482d00f4",
       "src": "e64cd2e7e647"
     },
-    "config.step.reauth_confirm.description": {
+    "config\u0000step\u0000reauth_confirm\u0000description": {
       "out": "2730fdf8f651",
       "src": "f53b69d3be84"
     },
-    "config.step.reauth_confirm.title": {
+    "config\u0000step\u0000reauth_confirm\u0000title": {
       "out": "fd504e9866ef",
       "src": "7e22a752572f"
     },
-    "config.step.user.data.address": {
+    "config\u0000step\u0000user\u0000data\u0000address": {
       "out": "0e0a54c681e2",
       "src": "6ba0bdeccb42"
     },
-    "config.step.user.data_description.address": {
+    "config\u0000step\u0000user\u0000data_description\u0000address": {
       "out": "d87bfbe38a0b",
       "src": "a083a457cfb1"
     },
-    "config.step.user.description": {
+    "config\u0000step\u0000user\u0000description": {
       "out": "0d218629fbba",
       "src": "109135454652"
     },
-    "entity.binary_sensor.update_pending.name": {
+    "entity\u0000binary_sensor\u0000update_pending\u0000name": {
       "out": "87e6e1582bf5",
       "src": "8e0a4b18ae75"
     },
-    "entity.event.button.name": {
+    "entity\u0000event\u0000button\u0000name": {
       "out": "f65cca5119e6",
       "src": "2dcae43716c2"
     },
-    "entity.event.button.state_attributes.event_type.state.button_down": {
+    "entity\u0000event\u0000button\u0000state_attributes\u0000event_type\u0000state\u0000button_down": {
       "out": "7a938bcacaff",
       "src": "8352c89d20b4"
     },
-    "entity.event.button.state_attributes.event_type.state.button_up": {
+    "entity\u0000event\u0000button\u0000state_attributes\u0000event_type\u0000state\u0000button_up": {
       "out": "90a22edf3186",
       "src": "7f18b4912929"
     },
-    "entity.event.touch.name": {
+    "entity\u0000event\u0000touch\u0000name": {
       "out": "fef3b06a2cfe",
       "src": "c915d14278fc"
     },
-    "entity.event.touch.state_attributes.event_type.state.touch_down": {
+    "entity\u0000event\u0000touch\u0000state_attributes\u0000event_type\u0000state\u0000touch_down": {
       "out": "221538405f03",
       "src": "0234a9576230"
     },
-    "entity.event.touch.state_attributes.event_type.state.touch_move": {
+    "entity\u0000event\u0000touch\u0000state_attributes\u0000event_type\u0000state\u0000touch_move": {
       "out": "38da7e46e73e",
       "src": "67aeac815e94"
     },
-    "entity.event.touch.state_attributes.event_type.state.touch_up": {
+    "entity\u0000event\u0000touch\u0000state_attributes\u0000event_type\u0000state\u0000touch_up": {
       "out": "06350e237c0b",
       "src": "7c65519d3bb3"
     },
-    "entity.image.content.name": {
+    "entity\u0000image\u0000content\u0000name": {
       "out": "57803eaaea84",
       "src": "047c6db3382a"
     },
-    "entity.sensor.battery_voltage.name": {
+    "entity\u0000sensor\u0000battery_voltage\u0000name": {
       "out": "356d1e3e9340",
       "src": "39d6c91b57ce"
     },
-    "entity.sensor.last_seen.name": {
+    "entity\u0000sensor\u0000last_seen\u0000name": {
       "out": "f0a73567f3b8",
       "src": "21fd79c7de52"
     },
-    "entity.sensor.rssi.name": {
+    "entity\u0000sensor\u0000rssi\u0000name": {
       "out": "10239c973206",
       "src": "2604d15c1187"
     },
-    "entity.update.firmware.name": {
+    "entity\u0000update\u0000firmware\u0000name": {
       "out": "c2a314c3b32b",
       "src": "c2a314c3b32b"
     },
-    "exceptions.authentication_error.message": {
+    "exceptions\u0000authentication_error\u0000message": {
       "out": "967e5cf30a74",
       "src": "3d9f7c0c6d80"
     },
-    "exceptions.device_not_found.message": {
+    "exceptions\u0000device_not_found\u0000message": {
       "out": "a80f90799c7a",
       "src": "f244d0d2db8d"
     },
-    "exceptions.device_sleeping.message": {
+    "exceptions\u0000device_sleeping\u0000message": {
       "out": "a96a02bbfa1f",
       "src": "e95d25bd6fc7"
     },
-    "exceptions.device_sleeping_ota.message": {
+    "exceptions\u0000device_sleeping_ota\u0000message": {
       "out": "9b4f8a1e1050",
       "src": "430e3a1baa6a"
     },
-    "exceptions.invalid_device_id.message": {
+    "exceptions\u0000invalid_device_id\u0000message": {
       "out": "f590c38ce79e",
       "src": "cc64cc29ceeb"
     },
-    "exceptions.media_download_error.message": {
+    "exceptions\u0000media_download_error\u0000message": {
       "out": "8c3fa9a46030",
       "src": "5852129dd920"
     },
-    "exceptions.mime_type_not_applicable.message": {
+    "exceptions\u0000mime_type_not_applicable\u0000message": {
       "out": "86016faebbc7",
       "src": "de700f02fbd5"
     },
-    "exceptions.multiple_errors.message": {
+    "exceptions\u0000multiple_errors\u0000message": {
       "out": "8cefc6cf7040",
       "src": "f17c68e0a848"
     },
-    "exceptions.nfc_content_empty.message": {
+    "exceptions\u0000nfc_content_empty\u0000message": {
       "out": "ace5922fd5da",
       "src": "b93a1a6ebdc0"
     },
-    "exceptions.nfc_content_too_long.message": {
+    "exceptions\u0000nfc_content_too_long\u0000message": {
       "out": "83247e1197f1",
       "src": "8f580b9c6c76"
     },
-    "exceptions.nfc_mime_type_invalid.message": {
+    "exceptions\u0000nfc_mime_type_invalid\u0000message": {
       "out": "3a09b518e947",
       "src": "5a5f44fe332f"
     },
-    "exceptions.nfc_not_supported.message": {
+    "exceptions\u0000nfc_not_supported\u0000message": {
       "out": "0430ac7f5b31",
       "src": "8fdcd0e2bd17"
     },
-    "exceptions.nfc_write_failed.message": {
+    "exceptions\u0000nfc_write_failed\u0000message": {
       "out": "3e780f88aaff",
       "src": "e8186303a52e"
     },
-    "exceptions.no_buzzers.message": {
+    "exceptions\u0000no_buzzers\u0000message": {
       "out": "c5057ceb2373",
       "src": "9c014dfeac91"
     },
-    "exceptions.no_leds.message": {
+    "exceptions\u0000no_leds\u0000message": {
       "out": "81d3916a53c5",
       "src": "6a302f8f22ee"
     },
-    "exceptions.no_nfc.message": {
+    "exceptions\u0000no_nfc\u0000message": {
       "out": "dbb1b404f1c2",
       "src": "abb1917ad57e"
     },
-    "exceptions.no_targets_specified.message": {
+    "exceptions\u0000no_targets_specified\u0000message": {
       "out": "ab7b84944fc6",
       "src": "80c472afefe6"
     },
-    "exceptions.upload_error.message": {
+    "exceptions\u0000upload_error\u0000message": {
       "out": "a760962cc17d",
       "src": "75561a03be6e"
     },
-    "exceptions.url_not_allowed.message": {
+    "exceptions\u0000url_not_allowed\u0000message": {
       "out": "ba50f1abf1df",
       "src": "33ffb9a9f2c4"
     },
-    "options.step.init.data.blocks_per_ack": {
+    "options\u0000step\u0000init\u0000data\u0000blocks_per_ack": {
       "out": "43e2e40d805c",
       "src": "3e2a554e69a4"
     },
-    "options.step.init.data.max_queue_size": {
+    "options\u0000step\u0000init\u0000data\u0000max_queue_size": {
       "out": "42ea708451c3",
       "src": "297af7027dd0"
     },
-    "options.step.init.data.missed_cycles": {
+    "options\u0000step\u0000init\u0000data\u0000missed_cycles": {
       "out": "9b47b875581d",
       "src": "59b78644491a"
     },
-    "options.step.init.data.probe_before_queue": {
+    "options\u0000step\u0000init\u0000data\u0000probe_before_queue": {
       "out": "f16ccd3fdc78",
       "src": "02c4211a58b2"
     },
-    "options.step.init.data.queue_timeout_hours": {
+    "options\u0000step\u0000init\u0000data\u0000queue_timeout_hours": {
       "out": "508ac26fb092",
       "src": "be70fc5cca79"
     },
-    "options.step.init.data.sleep_mode": {
+    "options\u0000step\u0000init\u0000data\u0000sleep_mode": {
       "out": "167caa0388d7",
       "src": "f925c0e541ce"
     },
-    "options.step.init.data_description.blocks_per_ack": {
+    "options\u0000step\u0000init\u0000data_description\u0000blocks_per_ack": {
       "out": "c5927e4cfb54",
       "src": "3a693b19d3c6"
     },
-    "options.step.init.data_description.max_queue_size": {
+    "options\u0000step\u0000init\u0000data_description\u0000max_queue_size": {
       "out": "31b81d274785",
       "src": "50260959ee56"
     },
-    "options.step.init.data_description.missed_cycles": {
+    "options\u0000step\u0000init\u0000data_description\u0000missed_cycles": {
       "out": "6400ec6f90f1",
       "src": "6ce493f4c44d"
     },
-    "options.step.init.data_description.probe_before_queue": {
+    "options\u0000step\u0000init\u0000data_description\u0000probe_before_queue": {
       "out": "f7fdd86c6ce2",
       "src": "5d0f2985ffdf"
     },
-    "options.step.init.data_description.queue_timeout_hours": {
+    "options\u0000step\u0000init\u0000data_description\u0000queue_timeout_hours": {
       "out": "3502922f215b",
       "src": "34895000b491"
     },
-    "options.step.init.data_description.sleep_mode": {
+    "options\u0000step\u0000init\u0000data_description\u0000sleep_mode": {
       "out": "1435771ca996",
       "src": "4acfeb65d10d"
     },
-    "selector.dither_mode.options.atkinson": {
+    "selector\u0000dither_mode\u0000options\u0000atkinson": {
       "out": "7a8fe6d47b5b",
       "src": "7a8fe6d47b5b"
     },
-    "selector.dither_mode.options.burkes": {
+    "selector\u0000dither_mode\u0000options\u0000burkes": {
       "out": "1b75087201fb",
       "src": "1b75087201fb"
     },
-    "selector.dither_mode.options.floyd_steinberg": {
+    "selector\u0000dither_mode\u0000options\u0000floyd_steinberg": {
       "out": "37969811a3cf",
       "src": "37969811a3cf"
     },
-    "selector.dither_mode.options.jarvis_judice_ninke": {
+    "selector\u0000dither_mode\u0000options\u0000jarvis_judice_ninke": {
       "out": "7020241adf78",
       "src": "7020241adf78"
     },
-    "selector.dither_mode.options.none": {
+    "selector\u0000dither_mode\u0000options\u0000none": {
       "out": "ed0a2968058c",
       "src": "dc937b598926"
     },
-    "selector.dither_mode.options.ordered": {
+    "selector\u0000dither_mode\u0000options\u0000ordered": {
       "out": "99d8a323481b",
       "src": "007877479e21"
     },
-    "selector.dither_mode.options.sierra": {
+    "selector\u0000dither_mode\u0000options\u0000sierra": {
       "out": "d5eef8ad210c",
       "src": "d5eef8ad210c"
     },
-    "selector.dither_mode.options.sierra_lite": {
+    "selector\u0000dither_mode\u0000options\u0000sierra_lite": {
       "out": "20da8cc85f38",
       "src": "20da8cc85f38"
     },
-    "selector.dither_mode.options.stucki": {
+    "selector\u0000dither_mode\u0000options\u0000stucki": {
       "out": "a17d2b13b6f9",
       "src": "a17d2b13b6f9"
     },
-    "selector.fit_mode.options.contain": {
+    "selector\u0000fit_mode\u0000options\u0000contain": {
       "out": "de3a1ffc7435",
       "src": "e534a2c2b456"
     },
-    "selector.fit_mode.options.cover": {
+    "selector\u0000fit_mode\u0000options\u0000cover": {
       "out": "5ca49d49cd51",
       "src": "fa8d84566676"
     },
-    "selector.fit_mode.options.crop": {
+    "selector\u0000fit_mode\u0000options\u0000crop": {
       "out": "a85716c00d58",
       "src": "98caf7c43c6f"
     },
-    "selector.fit_mode.options.stretch": {
+    "selector\u0000fit_mode\u0000options\u0000stretch": {
       "out": "685b79a8b265",
       "src": "a33fbcf83f7b"
     },
-    "selector.nfc_record_type.options.ha_tag": {
+    "selector\u0000nfc_record_type\u0000options\u0000ha_tag": {
       "out": "01776527bd03",
       "src": "d1d47a8fa544"
     },
-    "selector.nfc_record_type.options.mime": {
+    "selector\u0000nfc_record_type\u0000options\u0000mime": {
       "out": "9af5416cb9cd",
       "src": "f98d7539e627"
     },
-    "selector.nfc_record_type.options.text": {
+    "selector\u0000nfc_record_type\u0000options\u0000text": {
       "out": "5d07abcd8c8c",
       "src": "71988c4d8e08"
     },
-    "selector.nfc_record_type.options.url": {
+    "selector\u0000nfc_record_type\u0000options\u0000url": {
       "out": "e7a241debad5",
       "src": "e7a241debad5"
     },
-    "selector.refresh_mode.options.fast": {
+    "selector\u0000refresh_mode\u0000options\u0000fast": {
       "out": "ad679974a7a5",
       "src": "6c582b62e0e5"
     },
-    "selector.refresh_mode.options.full": {
+    "selector\u0000refresh_mode\u0000options\u0000full": {
       "out": "81c8eab8fd06",
       "src": "008dacb6d1e8"
     },
-    "selector.refresh_mode.options.partial": {
+    "selector\u0000refresh_mode\u0000options\u0000partial": {
       "out": "772714cd8f4b",
       "src": "a4d50fb85403"
     },
-    "selector.sleep_mode.options.auto": {
+    "selector\u0000sleep_mode\u0000options\u0000auto": {
       "out": "b46220271764",
       "src": "132990bd8ef7"
     },
-    "selector.sleep_mode.options.off": {
+    "selector\u0000sleep_mode\u0000options\u0000off": {
       "out": "25f5a2fddc29",
       "src": "34598efe7b90"
     },
-    "selector.sleep_mode.options.on": {
+    "selector\u0000sleep_mode\u0000options\u0000on": {
       "out": "175efbe05d06",
       "src": "bde131e31c9e"
     },
-    "services.activate_buzzer.description": {
+    "services\u0000activate_buzzer\u0000description": {
       "out": "788a623c5546",
       "src": "1898784614cb"
     },
-    "services.activate_buzzer.fields.device_id.description": {
+    "services\u0000activate_buzzer\u0000fields\u0000device_id\u0000description": {
       "out": "56d438ed7456",
       "src": "7dec980cb238"
     },
-    "services.activate_buzzer.fields.device_id.name": {
+    "services\u0000activate_buzzer\u0000fields\u0000device_id\u0000name": {
       "out": "0e0a54c681e2",
       "src": "6ba0bdeccb42"
     },
-    "services.activate_buzzer.fields.duration_ms.description": {
+    "services\u0000activate_buzzer\u0000fields\u0000duration_ms\u0000description": {
       "out": "8e62f9b72f37",
       "src": "cd1bc75ca60c"
     },
-    "services.activate_buzzer.fields.duration_ms.name": {
+    "services\u0000activate_buzzer\u0000fields\u0000duration_ms\u0000name": {
       "out": "c8d7586e9596",
       "src": "4fc52a3c4c55"
     },
-    "services.activate_buzzer.fields.frequency_hz.description": {
+    "services\u0000activate_buzzer\u0000fields\u0000frequency_hz\u0000description": {
       "out": "587a11c9c7f4",
       "src": "510fc20311e3"
     },
-    "services.activate_buzzer.fields.frequency_hz.name": {
+    "services\u0000activate_buzzer\u0000fields\u0000frequency_hz\u0000name": {
       "out": "b3d5bc3dee52",
       "src": "16b6668d9831"
     },
-    "services.activate_buzzer.fields.instance.description": {
+    "services\u0000activate_buzzer\u0000fields\u0000instance\u0000description": {
       "out": "88738842300a",
       "src": "f39fa742d55c"
     },
-    "services.activate_buzzer.fields.instance.name": {
+    "services\u0000activate_buzzer\u0000fields\u0000instance\u0000name": {
       "out": "3aa09216cff5",
       "src": "1f671ddded9e"
     },
-    "services.activate_buzzer.fields.repeats.description": {
+    "services\u0000activate_buzzer\u0000fields\u0000repeats\u0000description": {
       "out": "d668cbb966c4",
       "src": "1f88b0fe23ea"
     },
-    "services.activate_buzzer.fields.repeats.name": {
+    "services\u0000activate_buzzer\u0000fields\u0000repeats\u0000name": {
       "out": "2f873dc8d821",
       "src": "92ee0233f013"
     },
-    "services.activate_buzzer.name": {
+    "services\u0000activate_buzzer\u0000name": {
       "out": "60a8b788ef3d",
       "src": "0b80285753b7"
     },
-    "services.activate_led.description": {
+    "services\u0000activate_led\u0000description": {
       "out": "e6e7dd1a7d6f",
       "src": "6cbd645597cc"
     },
-    "services.activate_led.fields.brightness.description": {
+    "services\u0000activate_led\u0000fields\u0000brightness\u0000description": {
       "out": "e9f37a595f90",
       "src": "6ad88a28230d"
     },
-    "services.activate_led.fields.brightness.name": {
+    "services\u0000activate_led\u0000fields\u0000brightness\u0000name": {
       "out": "00a84b5b30ee",
       "src": "ec811d30a89c"
     },
-    "services.activate_led.fields.color1.description": {
+    "services\u0000activate_led\u0000fields\u0000color1\u0000description": {
       "out": "0a7048f4763f",
       "src": "17f145013241"
     },
-    "services.activate_led.fields.color1.name": {
+    "services\u0000activate_led\u0000fields\u0000color1\u0000name": {
       "out": "da96a9564a87",
       "src": "571461f36f3a"
     },
-    "services.activate_led.fields.color2.description": {
+    "services\u0000activate_led\u0000fields\u0000color2\u0000description": {
       "out": "8dc119ec9576",
       "src": "f2680a4bbe85"
     },
-    "services.activate_led.fields.color2.name": {
+    "services\u0000activate_led\u0000fields\u0000color2\u0000name": {
       "out": "6349757961d6",
       "src": "ef792d287872"
     },
-    "services.activate_led.fields.color3.description": {
+    "services\u0000activate_led\u0000fields\u0000color3\u0000description": {
       "out": "ca30a2364126",
       "src": "b8ecd353b426"
     },
-    "services.activate_led.fields.color3.name": {
+    "services\u0000activate_led\u0000fields\u0000color3\u0000name": {
       "out": "33a1cd2bce3d",
       "src": "48d54e046d29"
     },
-    "services.activate_led.fields.device_id.description": {
+    "services\u0000activate_led\u0000fields\u0000device_id\u0000description": {
       "out": "56d438ed7456",
       "src": "7dec980cb238"
     },
-    "services.activate_led.fields.device_id.name": {
+    "services\u0000activate_led\u0000fields\u0000device_id\u0000name": {
       "out": "0e0a54c681e2",
       "src": "6ba0bdeccb42"
     },
-    "services.activate_led.fields.flash_count1.description": {
+    "services\u0000activate_led\u0000fields\u0000flash_count1\u0000description": {
       "out": "8c89be5fd0bf",
       "src": "4ffdadde31c2"
     },
-    "services.activate_led.fields.flash_count1.name": {
+    "services\u0000activate_led\u0000fields\u0000flash_count1\u0000name": {
       "out": "18d05fbbd928",
       "src": "13c6a2e5c22e"
     },
-    "services.activate_led.fields.flash_count2.description": {
+    "services\u0000activate_led\u0000fields\u0000flash_count2\u0000description": {
       "out": "a3f055da9e3d",
       "src": "86dc999a3915"
     },
-    "services.activate_led.fields.flash_count2.name": {
+    "services\u0000activate_led\u0000fields\u0000flash_count2\u0000name": {
       "out": "0d805251f0d3",
       "src": "2be36d8449dc"
     },
-    "services.activate_led.fields.flash_count3.description": {
+    "services\u0000activate_led\u0000fields\u0000flash_count3\u0000description": {
       "out": "0d647003889f",
       "src": "aa40c396a9a4"
     },
-    "services.activate_led.fields.flash_count3.name": {
+    "services\u0000activate_led\u0000fields\u0000flash_count3\u0000name": {
       "out": "8875cf264a7f",
       "src": "7978910dc6b2"
     },
-    "services.activate_led.fields.instance.description": {
+    "services\u0000activate_led\u0000fields\u0000instance\u0000description": {
       "out": "98e39da0a40b",
       "src": "0531b37de90a"
     },
-    "services.activate_led.fields.instance.name": {
+    "services\u0000activate_led\u0000fields\u0000instance\u0000name": {
       "out": "c6a37cccc41d",
       "src": "f942926204c7"
     },
-    "services.activate_led.fields.inter_delay1.description": {
+    "services\u0000activate_led\u0000fields\u0000inter_delay1\u0000description": {
       "out": "6f3ba4ed2856",
       "src": "1b65dcfcea95"
     },
-    "services.activate_led.fields.inter_delay1.name": {
+    "services\u0000activate_led\u0000fields\u0000inter_delay1\u0000name": {
       "out": "f141c6aeaef4",
       "src": "71452f436c33"
     },
-    "services.activate_led.fields.inter_delay2.description": {
+    "services\u0000activate_led\u0000fields\u0000inter_delay2\u0000description": {
       "out": "227f3163a24b",
       "src": "181e03f33cbf"
     },
-    "services.activate_led.fields.inter_delay2.name": {
+    "services\u0000activate_led\u0000fields\u0000inter_delay2\u0000name": {
       "out": "a9219c337347",
       "src": "6a50551e5355"
     },
-    "services.activate_led.fields.inter_delay3.description": {
+    "services\u0000activate_led\u0000fields\u0000inter_delay3\u0000description": {
       "out": "ca27997486cc",
       "src": "5c5973b586df"
     },
-    "services.activate_led.fields.inter_delay3.name": {
+    "services\u0000activate_led\u0000fields\u0000inter_delay3\u0000name": {
       "out": "34403326b62b",
       "src": "b0f72903777e"
     },
-    "services.activate_led.fields.loop_delay1.description": {
+    "services\u0000activate_led\u0000fields\u0000loop_delay1\u0000description": {
       "out": "525cfeb38939",
       "src": "2139915c35bc"
     },
-    "services.activate_led.fields.loop_delay1.name": {
+    "services\u0000activate_led\u0000fields\u0000loop_delay1\u0000name": {
       "out": "0cdde8c262c8",
       "src": "2fb02375bae0"
     },
-    "services.activate_led.fields.loop_delay2.description": {
+    "services\u0000activate_led\u0000fields\u0000loop_delay2\u0000description": {
       "out": "2263042ae7d4",
       "src": "9a3a8cccb3bb"
     },
-    "services.activate_led.fields.loop_delay2.name": {
+    "services\u0000activate_led\u0000fields\u0000loop_delay2\u0000name": {
       "out": "dd67b82f52f7",
       "src": "597cbe87a7ec"
     },
-    "services.activate_led.fields.loop_delay3.description": {
+    "services\u0000activate_led\u0000fields\u0000loop_delay3\u0000description": {
       "out": "1c41f2a212e0",
       "src": "8a965100226c"
     },
-    "services.activate_led.fields.loop_delay3.name": {
+    "services\u0000activate_led\u0000fields\u0000loop_delay3\u0000name": {
       "out": "74838e0b2bb8",
       "src": "66d787aa1bad"
     },
-    "services.activate_led.fields.repeats.description": {
+    "services\u0000activate_led\u0000fields\u0000repeats\u0000description": {
       "out": "fc191baa4995",
       "src": "e40e956e3762"
     },
-    "services.activate_led.fields.repeats.name": {
+    "services\u0000activate_led\u0000fields\u0000repeats\u0000name": {
       "out": "2f873dc8d821",
       "src": "92ee0233f013"
     },
-    "services.activate_led.name": {
+    "services\u0000activate_led\u0000name": {
       "out": "bbc3fd64a081",
       "src": "91933e94cc57"
     },
-    "services.drawcustom.description": {
+    "services\u0000drawcustom\u0000description": {
       "out": "c3b0fa08c0e2",
       "src": "55f9f3333fc0"
     },
-    "services.drawcustom.fields.background.description": {
+    "services\u0000drawcustom\u0000fields\u0000background\u0000description": {
       "out": "92dbf860d682",
       "src": "f5858405d78a"
     },
-    "services.drawcustom.fields.background.name": {
+    "services\u0000drawcustom\u0000fields\u0000background\u0000name": {
       "out": "7d18ba3d4e8c",
       "src": "3e314dafdf7c"
     },
-    "services.drawcustom.fields.dither.description": {
+    "services\u0000drawcustom\u0000fields\u0000dither\u0000description": {
       "out": "43cc6a955e43",
       "src": "d7c737e5d01e"
     },
-    "services.drawcustom.fields.dither.name": {
+    "services\u0000drawcustom\u0000fields\u0000dither\u0000name": {
       "out": "65e62f3eabaf",
       "src": "35fb13830002"
     },
-    "services.drawcustom.fields.dry-run.description": {
+    "services\u0000drawcustom\u0000fields\u0000dry-run\u0000description": {
       "out": "30bd2c82753a",
       "src": "54f5f06db00c"
     },
-    "services.drawcustom.fields.dry-run.name": {
+    "services\u0000drawcustom\u0000fields\u0000dry-run\u0000name": {
       "out": "af699edeea2d",
       "src": "d5da154d9f00"
     },
-    "services.drawcustom.fields.measured_palette.description": {
+    "services\u0000drawcustom\u0000fields\u0000measured_palette\u0000description": {
       "out": "17fc3b253a69",
       "src": "53842124c7af"
     },
-    "services.drawcustom.fields.measured_palette.name": {
+    "services\u0000drawcustom\u0000fields\u0000measured_palette\u0000name": {
       "out": "cf0f0ae71e1c",
       "src": "672d38bdeb19"
     },
-    "services.drawcustom.fields.payload.description": {
+    "services\u0000drawcustom\u0000fields\u0000payload\u0000description": {
       "out": "b7eea1893c26",
       "src": "a72e3d514ead"
     },
-    "services.drawcustom.fields.payload.name": {
+    "services\u0000drawcustom\u0000fields\u0000payload\u0000name": {
       "out": "99733344956d",
       "src": "99733344956d"
     },
-    "services.drawcustom.fields.refresh_type.description": {
+    "services\u0000drawcustom\u0000fields\u0000refresh_type\u0000description": {
       "out": "0bc3dd0c97cd",
       "src": "d87a3d5c4d06"
     },
-    "services.drawcustom.fields.refresh_type.name": {
+    "services\u0000drawcustom\u0000fields\u0000refresh_type\u0000name": {
       "out": "7706d57c7878",
       "src": "201b25b874bb"
     },
-    "services.drawcustom.fields.rotate.description": {
+    "services\u0000drawcustom\u0000fields\u0000rotate\u0000description": {
       "out": "454fda2bb671",
       "src": "21e39f93db71"
     },
-    "services.drawcustom.fields.rotate.name": {
+    "services\u0000drawcustom\u0000fields\u0000rotate\u0000name": {
       "out": "54cde2c5d0dc",
       "src": "57b5e2fc1bba"
     },
-    "services.drawcustom.name": {
+    "services\u0000drawcustom\u0000name": {
       "out": "983cc0c2b23d",
       "src": "d0df7a6244ea"
     },
-    "services.upload_image.description": {
+    "services\u0000upload_image\u0000description": {
       "out": "e0ff495d7a08",
       "src": "24e19354eaa4"
     },
-    "services.upload_image.fields.device_id.description": {
+    "services\u0000upload_image\u0000fields\u0000device_id\u0000description": {
       "out": "d5bb31349f9d",
       "src": "ee157333391e"
     },
-    "services.upload_image.fields.device_id.name": {
+    "services\u0000upload_image\u0000fields\u0000device_id\u0000name": {
       "out": "0e0a54c681e2",
       "src": "6ba0bdeccb42"
     },
-    "services.upload_image.fields.dither_mode.description": {
+    "services\u0000upload_image\u0000fields\u0000dither_mode\u0000description": {
       "out": "5f34f6b8bc82",
       "src": "70483fdfe7ec"
     },
-    "services.upload_image.fields.dither_mode.name": {
+    "services\u0000upload_image\u0000fields\u0000dither_mode\u0000name": {
       "out": "65e62f3eabaf",
       "src": "35fb13830002"
     },
-    "services.upload_image.fields.fit_mode.description": {
+    "services\u0000upload_image\u0000fields\u0000fit_mode\u0000description": {
       "out": "ae8000aba281",
       "src": "8d2c8735a962"
     },
-    "services.upload_image.fields.fit_mode.name": {
+    "services\u0000upload_image\u0000fields\u0000fit_mode\u0000name": {
       "out": "a5383a529d47",
       "src": "8a59790c9187"
     },
-    "services.upload_image.fields.image.description": {
+    "services\u0000upload_image\u0000fields\u0000image\u0000description": {
       "out": "15cb21b21c2c",
       "src": "ba6d9fb759b0"
     },
-    "services.upload_image.fields.image.name": {
+    "services\u0000upload_image\u0000fields\u0000image\u0000name": {
       "out": "b68d3009a8a8",
       "src": "1aa4cb0bcca7"
     },
-    "services.upload_image.fields.measured_palette.description": {
+    "services\u0000upload_image\u0000fields\u0000measured_palette\u0000description": {
       "out": "49598c65f3d4",
       "src": "53842124c7af"
     },
-    "services.upload_image.fields.measured_palette.name": {
+    "services\u0000upload_image\u0000fields\u0000measured_palette\u0000name": {
       "out": "cf0f0ae71e1c",
       "src": "672d38bdeb19"
     },
-    "services.upload_image.fields.refresh_mode.description": {
+    "services\u0000upload_image\u0000fields\u0000refresh_mode\u0000description": {
       "out": "f79a2bbbc325",
       "src": "0fe957da240a"
     },
-    "services.upload_image.fields.refresh_mode.name": {
+    "services\u0000upload_image\u0000fields\u0000refresh_mode\u0000name": {
       "out": "1bb55bc32fdb",
       "src": "c72fd253298c"
     },
-    "services.upload_image.fields.rotation.description": {
+    "services\u0000upload_image\u0000fields\u0000rotation\u0000description": {
       "out": "fb8c07da429a",
       "src": "b639ab27209e"
     },
-    "services.upload_image.fields.rotation.name": {
+    "services\u0000upload_image\u0000fields\u0000rotation\u0000name": {
       "out": "54cde2c5d0dc",
       "src": "57b5e2fc1bba"
     },
-    "services.upload_image.fields.tone_compression.description": {
+    "services\u0000upload_image\u0000fields\u0000tone_compression\u0000description": {
       "out": "4948f89d2185",
       "src": "6453b45ae0cc"
     },
-    "services.upload_image.fields.tone_compression.name": {
+    "services\u0000upload_image\u0000fields\u0000tone_compression\u0000name": {
       "out": "da7fa5a3a2c3",
       "src": "ffaed65f03fa"
     },
-    "services.upload_image.name": {
+    "services\u0000upload_image\u0000name": {
       "out": "99c8b455db2e",
       "src": "ffe4df6c7ca6"
     },
-    "services.upload_image.sections.additional_fields.name": {
+    "services\u0000upload_image\u0000sections\u0000additional_fields\u0000name": {
       "out": "05cb4850f703",
       "src": "092170b2408b"
     },
-    "services.write_nfc.description": {
+    "services\u0000write_nfc\u0000description": {
       "out": "142e6f991dec",
       "src": "3c1f6a6d643e"
     },
-    "services.write_nfc.fields.content.description": {
+    "services\u0000write_nfc\u0000fields\u0000content\u0000description": {
       "out": "65e31beafe43",
       "src": "857d1cf0bf90"
     },
-    "services.write_nfc.fields.content.name": {
+    "services\u0000write_nfc\u0000fields\u0000content\u0000name": {
       "out": "0286255c9d0d",
       "src": "47bd29075f8b"
     },
-    "services.write_nfc.fields.device_id.description": {
+    "services\u0000write_nfc\u0000fields\u0000device_id\u0000description": {
       "out": "56d438ed7456",
       "src": "7dec980cb238"
     },
-    "services.write_nfc.fields.device_id.name": {
+    "services\u0000write_nfc\u0000fields\u0000device_id\u0000name": {
       "out": "0e0a54c681e2",
       "src": "6ba0bdeccb42"
     },
-    "services.write_nfc.fields.mime_type.description": {
+    "services\u0000write_nfc\u0000fields\u0000mime_type\u0000description": {
       "out": "0340c82247f4",
       "src": "4eb2b40ec666"
     },
-    "services.write_nfc.fields.mime_type.name": {
+    "services\u0000write_nfc\u0000fields\u0000mime_type\u0000name": {
       "out": "217809ebc697",
       "src": "849e8a810960"
     },
-    "services.write_nfc.fields.record_type.description": {
+    "services\u0000write_nfc\u0000fields\u0000record_type\u0000description": {
       "out": "0023968493d7",
       "src": "936cf634012f"
     },
-    "services.write_nfc.fields.record_type.name": {
+    "services\u0000write_nfc\u0000fields\u0000record_type\u0000name": {
       "out": "1654122245d3",
       "src": "91cf117b1d70"
     },
-    "services.write_nfc.name": {
+    "services\u0000write_nfc\u0000name": {
       "out": "74d126940437",
       "src": "96ea14b97cf7"
     }
   },
   "pl": {
-    "config.abort.already_configured": {
+    "config\u0000abort\u0000already_configured": {
       "out": "97c0139dfd70",
       "src": "c2936e02a0d2"
     },
-    "config.abort.already_in_progress": {
+    "config\u0000abort\u0000already_in_progress": {
       "out": "1b0116d4e2ce",
       "src": "985a72ad93a3"
     },
-    "config.abort.cannot_connect": {
+    "config\u0000abort\u0000cannot_connect": {
       "out": "c05eb31368c5",
       "src": "46c9f3b7520f"
     },
-    "config.abort.no_devices_found": {
+    "config\u0000abort\u0000no_devices_found": {
       "out": "d5583c81f32e",
       "src": "b8f28e84cf0b"
     },
-    "config.abort.reauth_successful": {
+    "config\u0000abort\u0000reauth_successful": {
       "out": "4e97976f368e",
       "src": "e5b83989735c"
     },
-    "config.abort.unknown": {
+    "config\u0000abort\u0000unknown": {
       "out": "16c896774461",
       "src": "d24c41ae530a"
     },
-    "config.error.cannot_connect": {
+    "config\u0000error\u0000cannot_connect": {
       "out": "c05eb31368c5",
       "src": "46c9f3b7520f"
     },
-    "config.error.invalid_auth": {
+    "config\u0000error\u0000invalid_auth": {
       "out": "272c54a36da4",
       "src": "4ca089878c5f"
     },
-    "config.error.invalid_key_format": {
+    "config\u0000error\u0000invalid_key_format": {
       "out": "8256cdb88d1d",
       "src": "f7b03dd699df"
     },
-    "config.error.unknown": {
+    "config\u0000error\u0000unknown": {
       "out": "16c896774461",
       "src": "d24c41ae530a"
     },
-    "config.flow_title": {
+    "config\u0000flow_title": {
       "out": "5e291d7bcb2d",
       "src": "5e291d7bcb2d"
     },
-    "config.step.bluetooth_confirm.description": {
+    "config\u0000step\u0000bluetooth_confirm\u0000description": {
       "out": "d1b7b3a598f6",
       "src": "bcfd5a24b7d7"
     },
-    "config.step.encryption_key.data.encryption_key": {
+    "config\u0000step\u0000encryption_key\u0000data\u0000encryption_key": {
       "out": "461667a14ec0",
       "src": "16b3c9d5573d"
     },
-    "config.step.encryption_key.data_description.encryption_key": {
+    "config\u0000step\u0000encryption_key\u0000data_description\u0000encryption_key": {
       "out": "091198a90d57",
       "src": "e64cd2e7e647"
     },
-    "config.step.encryption_key.description": {
+    "config\u0000step\u0000encryption_key\u0000description": {
       "out": "004a00e79430",
       "src": "664d3f12bfe6"
     },
-    "config.step.encryption_key.title": {
+    "config\u0000step\u0000encryption_key\u0000title": {
       "out": "d30cd9ea1714",
       "src": "c30d1ca158a3"
     },
-    "config.step.reauth_confirm.data.encryption_key": {
+    "config\u0000step\u0000reauth_confirm\u0000data\u0000encryption_key": {
       "out": "461667a14ec0",
       "src": "16b3c9d5573d"
     },
-    "config.step.reauth_confirm.data_description.encryption_key": {
+    "config\u0000step\u0000reauth_confirm\u0000data_description\u0000encryption_key": {
       "out": "091198a90d57",
       "src": "e64cd2e7e647"
     },
-    "config.step.reauth_confirm.description": {
+    "config\u0000step\u0000reauth_confirm\u0000description": {
       "out": "2a769e50539d",
       "src": "f53b69d3be84"
     },
-    "config.step.reauth_confirm.title": {
+    "config\u0000step\u0000reauth_confirm\u0000title": {
       "out": "ec53e40e2bae",
       "src": "7e22a752572f"
     },
-    "config.step.user.data.address": {
+    "config\u0000step\u0000user\u0000data\u0000address": {
       "out": "5c72d15d094f",
       "src": "6ba0bdeccb42"
     },
-    "config.step.user.data_description.address": {
+    "config\u0000step\u0000user\u0000data_description\u0000address": {
       "out": "0e05c8a3dd11",
       "src": "a083a457cfb1"
     },
-    "config.step.user.description": {
+    "config\u0000step\u0000user\u0000description": {
       "out": "29d3b3fd16aa",
       "src": "109135454652"
     },
-    "entity.binary_sensor.update_pending.name": {
+    "entity\u0000binary_sensor\u0000update_pending\u0000name": {
       "out": "6fad1ebd0512",
       "src": "8e0a4b18ae75"
     },
-    "entity.event.button.name": {
+    "entity\u0000event\u0000button\u0000name": {
       "out": "97c874f78dd0",
       "src": "2dcae43716c2"
     },
-    "entity.event.button.state_attributes.event_type.state.button_down": {
+    "entity\u0000event\u0000button\u0000state_attributes\u0000event_type\u0000state\u0000button_down": {
       "out": "ccd0b5875ef8",
       "src": "8352c89d20b4"
     },
-    "entity.event.button.state_attributes.event_type.state.button_up": {
+    "entity\u0000event\u0000button\u0000state_attributes\u0000event_type\u0000state\u0000button_up": {
       "out": "b9ac9ecb4a44",
       "src": "7f18b4912929"
     },
-    "entity.event.touch.name": {
+    "entity\u0000event\u0000touch\u0000name": {
       "out": "b415304a8343",
       "src": "c915d14278fc"
     },
-    "entity.event.touch.state_attributes.event_type.state.touch_down": {
+    "entity\u0000event\u0000touch\u0000state_attributes\u0000event_type\u0000state\u0000touch_down": {
       "out": "a398ea808da6",
       "src": "0234a9576230"
     },
-    "entity.event.touch.state_attributes.event_type.state.touch_move": {
+    "entity\u0000event\u0000touch\u0000state_attributes\u0000event_type\u0000state\u0000touch_move": {
       "out": "2650f44b98db",
       "src": "67aeac815e94"
     },
-    "entity.event.touch.state_attributes.event_type.state.touch_up": {
+    "entity\u0000event\u0000touch\u0000state_attributes\u0000event_type\u0000state\u0000touch_up": {
       "out": "592faa55ad1a",
       "src": "7c65519d3bb3"
     },
-    "entity.image.content.name": {
+    "entity\u0000image\u0000content\u0000name": {
       "out": "1fbb4876113e",
       "src": "047c6db3382a"
     },
-    "entity.sensor.battery_voltage.name": {
+    "entity\u0000sensor\u0000battery_voltage\u0000name": {
       "out": "b0054cb59b34",
       "src": "39d6c91b57ce"
     },
-    "entity.sensor.last_seen.name": {
+    "entity\u0000sensor\u0000last_seen\u0000name": {
       "out": "ab7234aa45fa",
       "src": "21fd79c7de52"
     },
-    "entity.sensor.rssi.name": {
+    "entity\u0000sensor\u0000rssi\u0000name": {
       "out": "11168c1d9026",
       "src": "2604d15c1187"
     },
-    "entity.update.firmware.name": {
+    "entity\u0000update\u0000firmware\u0000name": {
       "out": "a4d7d2f2d26a",
       "src": "c2a314c3b32b"
     },
-    "exceptions.authentication_error.message": {
+    "exceptions\u0000authentication_error\u0000message": {
       "out": "b7f02c4bb3f9",
       "src": "3d9f7c0c6d80"
     },
-    "exceptions.device_not_found.message": {
+    "exceptions\u0000device_not_found\u0000message": {
       "out": "3701c74aad7c",
       "src": "f244d0d2db8d"
     },
-    "exceptions.device_sleeping.message": {
+    "exceptions\u0000device_sleeping\u0000message": {
       "out": "2216c5b0a968",
       "src": "e95d25bd6fc7"
     },
-    "exceptions.device_sleeping_ota.message": {
+    "exceptions\u0000device_sleeping_ota\u0000message": {
       "out": "0192d49a67dd",
       "src": "430e3a1baa6a"
     },
-    "exceptions.invalid_device_id.message": {
+    "exceptions\u0000invalid_device_id\u0000message": {
       "out": "8aa03e853d19",
       "src": "cc64cc29ceeb"
     },
-    "exceptions.media_download_error.message": {
+    "exceptions\u0000media_download_error\u0000message": {
       "out": "7deddd9f19d7",
       "src": "5852129dd920"
     },
-    "exceptions.mime_type_not_applicable.message": {
+    "exceptions\u0000mime_type_not_applicable\u0000message": {
       "out": "bd333cd592af",
       "src": "de700f02fbd5"
     },
-    "exceptions.multiple_errors.message": {
+    "exceptions\u0000multiple_errors\u0000message": {
       "out": "b5d5ed102c46",
       "src": "f17c68e0a848"
     },
-    "exceptions.nfc_content_empty.message": {
+    "exceptions\u0000nfc_content_empty\u0000message": {
       "out": "54f20d9c8dd7",
       "src": "b93a1a6ebdc0"
     },
-    "exceptions.nfc_content_too_long.message": {
+    "exceptions\u0000nfc_content_too_long\u0000message": {
       "out": "cc979f81eef6",
       "src": "8f580b9c6c76"
     },
-    "exceptions.nfc_mime_type_invalid.message": {
+    "exceptions\u0000nfc_mime_type_invalid\u0000message": {
       "out": "d7d4581b998f",
       "src": "5a5f44fe332f"
     },
-    "exceptions.nfc_not_supported.message": {
+    "exceptions\u0000nfc_not_supported\u0000message": {
       "out": "9de7b8ec4029",
       "src": "8fdcd0e2bd17"
     },
-    "exceptions.nfc_write_failed.message": {
+    "exceptions\u0000nfc_write_failed\u0000message": {
       "out": "3db2600787a6",
       "src": "e8186303a52e"
     },
-    "exceptions.no_buzzers.message": {
+    "exceptions\u0000no_buzzers\u0000message": {
       "out": "ede3df71a984",
       "src": "9c014dfeac91"
     },
-    "exceptions.no_leds.message": {
+    "exceptions\u0000no_leds\u0000message": {
       "out": "45037de77499",
       "src": "6a302f8f22ee"
     },
-    "exceptions.no_nfc.message": {
+    "exceptions\u0000no_nfc\u0000message": {
       "out": "3fbd00e69614",
       "src": "abb1917ad57e"
     },
-    "exceptions.no_targets_specified.message": {
+    "exceptions\u0000no_targets_specified\u0000message": {
       "out": "9753955e1882",
       "src": "80c472afefe6"
     },
-    "exceptions.upload_error.message": {
+    "exceptions\u0000upload_error\u0000message": {
       "out": "781b6268b30d",
       "src": "75561a03be6e"
     },
-    "exceptions.url_not_allowed.message": {
+    "exceptions\u0000url_not_allowed\u0000message": {
       "out": "6ee8fc0b163f",
       "src": "33ffb9a9f2c4"
     },
-    "options.step.init.data.blocks_per_ack": {
+    "options\u0000step\u0000init\u0000data\u0000blocks_per_ack": {
       "out": "c908f1878f2b",
       "src": "3e2a554e69a4"
     },
-    "options.step.init.data.max_queue_size": {
+    "options\u0000step\u0000init\u0000data\u0000max_queue_size": {
       "out": "c4c1a87f69e5",
       "src": "297af7027dd0"
     },
-    "options.step.init.data.missed_cycles": {
+    "options\u0000step\u0000init\u0000data\u0000missed_cycles": {
       "out": "cae4faced2df",
       "src": "59b78644491a"
     },
-    "options.step.init.data.probe_before_queue": {
+    "options\u0000step\u0000init\u0000data\u0000probe_before_queue": {
       "out": "a918722b4938",
       "src": "02c4211a58b2"
     },
-    "options.step.init.data.queue_timeout_hours": {
+    "options\u0000step\u0000init\u0000data\u0000queue_timeout_hours": {
       "out": "b18b431f5913",
       "src": "be70fc5cca79"
     },
-    "options.step.init.data.sleep_mode": {
+    "options\u0000step\u0000init\u0000data\u0000sleep_mode": {
       "out": "ebb1d30f6d9f",
       "src": "f925c0e541ce"
     },
-    "options.step.init.data_description.blocks_per_ack": {
+    "options\u0000step\u0000init\u0000data_description\u0000blocks_per_ack": {
       "out": "238540d4d0e0",
       "src": "3a693b19d3c6"
     },
-    "options.step.init.data_description.max_queue_size": {
+    "options\u0000step\u0000init\u0000data_description\u0000max_queue_size": {
       "out": "086aafdfcfef",
       "src": "50260959ee56"
     },
-    "options.step.init.data_description.missed_cycles": {
+    "options\u0000step\u0000init\u0000data_description\u0000missed_cycles": {
       "out": "6dca59616d2e",
       "src": "6ce493f4c44d"
     },
-    "options.step.init.data_description.probe_before_queue": {
+    "options\u0000step\u0000init\u0000data_description\u0000probe_before_queue": {
       "out": "9628e8e06bee",
       "src": "5d0f2985ffdf"
     },
-    "options.step.init.data_description.queue_timeout_hours": {
+    "options\u0000step\u0000init\u0000data_description\u0000queue_timeout_hours": {
       "out": "fd7e9853fded",
       "src": "34895000b491"
     },
-    "options.step.init.data_description.sleep_mode": {
+    "options\u0000step\u0000init\u0000data_description\u0000sleep_mode": {
       "out": "7520ea638004",
       "src": "4acfeb65d10d"
     },
-    "selector.dither_mode.options.atkinson": {
+    "selector\u0000dither_mode\u0000options\u0000atkinson": {
       "out": "7a8fe6d47b5b",
       "src": "7a8fe6d47b5b"
     },
-    "selector.dither_mode.options.burkes": {
+    "selector\u0000dither_mode\u0000options\u0000burkes": {
       "out": "1b75087201fb",
       "src": "1b75087201fb"
     },
-    "selector.dither_mode.options.floyd_steinberg": {
+    "selector\u0000dither_mode\u0000options\u0000floyd_steinberg": {
       "out": "37969811a3cf",
       "src": "37969811a3cf"
     },
-    "selector.dither_mode.options.jarvis_judice_ninke": {
+    "selector\u0000dither_mode\u0000options\u0000jarvis_judice_ninke": {
       "out": "7020241adf78",
       "src": "7020241adf78"
     },
-    "selector.dither_mode.options.none": {
+    "selector\u0000dither_mode\u0000options\u0000none": {
       "out": "b30f40d8dbce",
       "src": "dc937b598926"
     },
-    "selector.dither_mode.options.ordered": {
+    "selector\u0000dither_mode\u0000options\u0000ordered": {
       "out": "433e5990e88d",
       "src": "007877479e21"
     },
-    "selector.dither_mode.options.sierra": {
+    "selector\u0000dither_mode\u0000options\u0000sierra": {
       "out": "d5eef8ad210c",
       "src": "d5eef8ad210c"
     },
-    "selector.dither_mode.options.sierra_lite": {
+    "selector\u0000dither_mode\u0000options\u0000sierra_lite": {
       "out": "20da8cc85f38",
       "src": "20da8cc85f38"
     },
-    "selector.dither_mode.options.stucki": {
+    "selector\u0000dither_mode\u0000options\u0000stucki": {
       "out": "a17d2b13b6f9",
       "src": "a17d2b13b6f9"
     },
-    "selector.fit_mode.options.contain": {
+    "selector\u0000fit_mode\u0000options\u0000contain": {
       "out": "10c79152695e",
       "src": "e534a2c2b456"
     },
-    "selector.fit_mode.options.cover": {
+    "selector\u0000fit_mode\u0000options\u0000cover": {
       "out": "ad6eb90d9619",
       "src": "fa8d84566676"
     },
-    "selector.fit_mode.options.crop": {
+    "selector\u0000fit_mode\u0000options\u0000crop": {
       "out": "74ce2120b6ba",
       "src": "98caf7c43c6f"
     },
-    "selector.fit_mode.options.stretch": {
+    "selector\u0000fit_mode\u0000options\u0000stretch": {
       "out": "673801477566",
       "src": "a33fbcf83f7b"
     },
-    "selector.nfc_record_type.options.ha_tag": {
+    "selector\u0000nfc_record_type\u0000options\u0000ha_tag": {
       "out": "b74c1bf15cfa",
       "src": "d1d47a8fa544"
     },
-    "selector.nfc_record_type.options.mime": {
+    "selector\u0000nfc_record_type\u0000options\u0000mime": {
       "out": "4b9a862de3f3",
       "src": "f98d7539e627"
     },
-    "selector.nfc_record_type.options.text": {
+    "selector\u0000nfc_record_type\u0000options\u0000text": {
       "out": "5d07abcd8c8c",
       "src": "71988c4d8e08"
     },
-    "selector.nfc_record_type.options.url": {
+    "selector\u0000nfc_record_type\u0000options\u0000url": {
       "out": "e7a241debad5",
       "src": "e7a241debad5"
     },
-    "selector.refresh_mode.options.fast": {
+    "selector\u0000refresh_mode\u0000options\u0000fast": {
       "out": "6107d2336cb1",
       "src": "6c582b62e0e5"
     },
-    "selector.refresh_mode.options.full": {
+    "selector\u0000refresh_mode\u0000options\u0000full": {
       "out": "1f965d7d73ad",
       "src": "008dacb6d1e8"
     },
-    "selector.refresh_mode.options.partial": {
+    "selector\u0000refresh_mode\u0000options\u0000partial": {
       "out": "059ce04698ef",
       "src": "a4d50fb85403"
     },
-    "selector.sleep_mode.options.auto": {
+    "selector\u0000sleep_mode\u0000options\u0000auto": {
       "out": "e13075cc902e",
       "src": "132990bd8ef7"
     },
-    "selector.sleep_mode.options.off": {
+    "selector\u0000sleep_mode\u0000options\u0000off": {
       "out": "81b5639bd853",
       "src": "34598efe7b90"
     },
-    "selector.sleep_mode.options.on": {
+    "selector\u0000sleep_mode\u0000options\u0000on": {
       "out": "23a265677316",
       "src": "bde131e31c9e"
     },
-    "services.activate_buzzer.description": {
+    "services\u0000activate_buzzer\u0000description": {
       "out": "7fe759fa3bf6",
       "src": "1898784614cb"
     },
-    "services.activate_buzzer.fields.device_id.description": {
+    "services\u0000activate_buzzer\u0000fields\u0000device_id\u0000description": {
       "out": "59b92f8722df",
       "src": "7dec980cb238"
     },
-    "services.activate_buzzer.fields.device_id.name": {
+    "services\u0000activate_buzzer\u0000fields\u0000device_id\u0000name": {
       "out": "5c72d15d094f",
       "src": "6ba0bdeccb42"
     },
-    "services.activate_buzzer.fields.duration_ms.description": {
+    "services\u0000activate_buzzer\u0000fields\u0000duration_ms\u0000description": {
       "out": "a064bb175973",
       "src": "cd1bc75ca60c"
     },
-    "services.activate_buzzer.fields.duration_ms.name": {
+    "services\u0000activate_buzzer\u0000fields\u0000duration_ms\u0000name": {
       "out": "119496feb778",
       "src": "4fc52a3c4c55"
     },
-    "services.activate_buzzer.fields.frequency_hz.description": {
+    "services\u0000activate_buzzer\u0000fields\u0000frequency_hz\u0000description": {
       "out": "b81ffe0280b1",
       "src": "510fc20311e3"
     },
-    "services.activate_buzzer.fields.frequency_hz.name": {
+    "services\u0000activate_buzzer\u0000fields\u0000frequency_hz\u0000name": {
       "out": "4c4e8557c086",
       "src": "16b6668d9831"
     },
-    "services.activate_buzzer.fields.instance.description": {
+    "services\u0000activate_buzzer\u0000fields\u0000instance\u0000description": {
       "out": "a5372770f8a7",
       "src": "f39fa742d55c"
     },
-    "services.activate_buzzer.fields.instance.name": {
+    "services\u0000activate_buzzer\u0000fields\u0000instance\u0000name": {
       "out": "7ef53bf746ba",
       "src": "1f671ddded9e"
     },
-    "services.activate_buzzer.fields.repeats.description": {
+    "services\u0000activate_buzzer\u0000fields\u0000repeats\u0000description": {
       "out": "4f62a790b90f",
       "src": "1f88b0fe23ea"
     },
-    "services.activate_buzzer.fields.repeats.name": {
+    "services\u0000activate_buzzer\u0000fields\u0000repeats\u0000name": {
       "out": "df33d7880448",
       "src": "92ee0233f013"
     },
-    "services.activate_buzzer.name": {
+    "services\u0000activate_buzzer\u0000name": {
       "out": "81cf6025de0d",
       "src": "0b80285753b7"
     },
-    "services.activate_led.description": {
+    "services\u0000activate_led\u0000description": {
       "out": "a98172f5fdf3",
       "src": "6cbd645597cc"
     },
-    "services.activate_led.fields.brightness.description": {
+    "services\u0000activate_led\u0000fields\u0000brightness\u0000description": {
       "out": "91cb414b24fc",
       "src": "6ad88a28230d"
     },
-    "services.activate_led.fields.brightness.name": {
+    "services\u0000activate_led\u0000fields\u0000brightness\u0000name": {
       "out": "787b2a6f2462",
       "src": "ec811d30a89c"
     },
-    "services.activate_led.fields.color1.description": {
+    "services\u0000activate_led\u0000fields\u0000color1\u0000description": {
       "out": "45e4e737e9e5",
       "src": "17f145013241"
     },
-    "services.activate_led.fields.color1.name": {
+    "services\u0000activate_led\u0000fields\u0000color1\u0000name": {
       "out": "e77cf52832d6",
       "src": "571461f36f3a"
     },
-    "services.activate_led.fields.color2.description": {
+    "services\u0000activate_led\u0000fields\u0000color2\u0000description": {
       "out": "4e2ff0ee6649",
       "src": "f2680a4bbe85"
     },
-    "services.activate_led.fields.color2.name": {
+    "services\u0000activate_led\u0000fields\u0000color2\u0000name": {
       "out": "5259747029ef",
       "src": "ef792d287872"
     },
-    "services.activate_led.fields.color3.description": {
+    "services\u0000activate_led\u0000fields\u0000color3\u0000description": {
       "out": "e6d2dbc5c597",
       "src": "b8ecd353b426"
     },
-    "services.activate_led.fields.color3.name": {
+    "services\u0000activate_led\u0000fields\u0000color3\u0000name": {
       "out": "fb8bc6bfa982",
       "src": "48d54e046d29"
     },
-    "services.activate_led.fields.device_id.description": {
+    "services\u0000activate_led\u0000fields\u0000device_id\u0000description": {
       "out": "59b92f8722df",
       "src": "7dec980cb238"
     },
-    "services.activate_led.fields.device_id.name": {
+    "services\u0000activate_led\u0000fields\u0000device_id\u0000name": {
       "out": "5c72d15d094f",
       "src": "6ba0bdeccb42"
     },
-    "services.activate_led.fields.flash_count1.description": {
+    "services\u0000activate_led\u0000fields\u0000flash_count1\u0000description": {
       "out": "4cf58bce582d",
       "src": "4ffdadde31c2"
     },
-    "services.activate_led.fields.flash_count1.name": {
+    "services\u0000activate_led\u0000fields\u0000flash_count1\u0000name": {
       "out": "a8223e2f25a3",
       "src": "13c6a2e5c22e"
     },
-    "services.activate_led.fields.flash_count2.description": {
+    "services\u0000activate_led\u0000fields\u0000flash_count2\u0000description": {
       "out": "dc390ce4aeb1",
       "src": "86dc999a3915"
     },
-    "services.activate_led.fields.flash_count2.name": {
+    "services\u0000activate_led\u0000fields\u0000flash_count2\u0000name": {
       "out": "562919c1fed9",
       "src": "2be36d8449dc"
     },
-    "services.activate_led.fields.flash_count3.description": {
+    "services\u0000activate_led\u0000fields\u0000flash_count3\u0000description": {
       "out": "a9d417ea8ce9",
       "src": "aa40c396a9a4"
     },
-    "services.activate_led.fields.flash_count3.name": {
+    "services\u0000activate_led\u0000fields\u0000flash_count3\u0000name": {
       "out": "1a992ea28e0e",
       "src": "7978910dc6b2"
     },
-    "services.activate_led.fields.instance.description": {
+    "services\u0000activate_led\u0000fields\u0000instance\u0000description": {
       "out": "23b7d4723e5f",
       "src": "0531b37de90a"
     },
-    "services.activate_led.fields.instance.name": {
+    "services\u0000activate_led\u0000fields\u0000instance\u0000name": {
       "out": "6ec3c2dc06ac",
       "src": "f942926204c7"
     },
-    "services.activate_led.fields.inter_delay1.description": {
+    "services\u0000activate_led\u0000fields\u0000inter_delay1\u0000description": {
       "out": "1b4fe47e4b68",
       "src": "1b65dcfcea95"
     },
-    "services.activate_led.fields.inter_delay1.name": {
+    "services\u0000activate_led\u0000fields\u0000inter_delay1\u0000name": {
       "out": "e5172a98cd14",
       "src": "71452f436c33"
     },
-    "services.activate_led.fields.inter_delay2.description": {
+    "services\u0000activate_led\u0000fields\u0000inter_delay2\u0000description": {
       "out": "f5d792954f0d",
       "src": "181e03f33cbf"
     },
-    "services.activate_led.fields.inter_delay2.name": {
+    "services\u0000activate_led\u0000fields\u0000inter_delay2\u0000name": {
       "out": "1f5f71ce46bf",
       "src": "6a50551e5355"
     },
-    "services.activate_led.fields.inter_delay3.description": {
+    "services\u0000activate_led\u0000fields\u0000inter_delay3\u0000description": {
       "out": "ba7c678a8bf1",
       "src": "5c5973b586df"
     },
-    "services.activate_led.fields.inter_delay3.name": {
+    "services\u0000activate_led\u0000fields\u0000inter_delay3\u0000name": {
       "out": "f3b41f142a2b",
       "src": "b0f72903777e"
     },
-    "services.activate_led.fields.loop_delay1.description": {
+    "services\u0000activate_led\u0000fields\u0000loop_delay1\u0000description": {
       "out": "3a5f0c4fff5e",
       "src": "2139915c35bc"
     },
-    "services.activate_led.fields.loop_delay1.name": {
+    "services\u0000activate_led\u0000fields\u0000loop_delay1\u0000name": {
       "out": "2a3864dea098",
       "src": "2fb02375bae0"
     },
-    "services.activate_led.fields.loop_delay2.description": {
+    "services\u0000activate_led\u0000fields\u0000loop_delay2\u0000description": {
       "out": "339c1bbe3e1c",
       "src": "9a3a8cccb3bb"
     },
-    "services.activate_led.fields.loop_delay2.name": {
+    "services\u0000activate_led\u0000fields\u0000loop_delay2\u0000name": {
       "out": "5b817619a14d",
       "src": "597cbe87a7ec"
     },
-    "services.activate_led.fields.loop_delay3.description": {
+    "services\u0000activate_led\u0000fields\u0000loop_delay3\u0000description": {
       "out": "df58d76abd54",
       "src": "8a965100226c"
     },
-    "services.activate_led.fields.loop_delay3.name": {
+    "services\u0000activate_led\u0000fields\u0000loop_delay3\u0000name": {
       "out": "d2ef03a35a26",
       "src": "66d787aa1bad"
     },
-    "services.activate_led.fields.repeats.description": {
+    "services\u0000activate_led\u0000fields\u0000repeats\u0000description": {
       "out": "fa5c34282405",
       "src": "e40e956e3762"
     },
-    "services.activate_led.fields.repeats.name": {
+    "services\u0000activate_led\u0000fields\u0000repeats\u0000name": {
       "out": "df33d7880448",
       "src": "92ee0233f013"
     },
-    "services.activate_led.name": {
+    "services\u0000activate_led\u0000name": {
       "out": "50820b2d0e96",
       "src": "91933e94cc57"
     },
-    "services.drawcustom.description": {
+    "services\u0000drawcustom\u0000description": {
       "out": "91ba56da32b5",
       "src": "55f9f3333fc0"
     },
-    "services.drawcustom.fields.background.description": {
+    "services\u0000drawcustom\u0000fields\u0000background\u0000description": {
       "out": "4792411fced4",
       "src": "f5858405d78a"
     },
-    "services.drawcustom.fields.background.name": {
+    "services\u0000drawcustom\u0000fields\u0000background\u0000name": {
       "out": "09e61720b37b",
       "src": "3e314dafdf7c"
     },
-    "services.drawcustom.fields.dither.description": {
+    "services\u0000drawcustom\u0000fields\u0000dither\u0000description": {
       "out": "05ca87404b5a",
       "src": "d7c737e5d01e"
     },
-    "services.drawcustom.fields.dither.name": {
+    "services\u0000drawcustom\u0000fields\u0000dither\u0000name": {
       "out": "22762d93021c",
       "src": "35fb13830002"
     },
-    "services.drawcustom.fields.dry-run.description": {
+    "services\u0000drawcustom\u0000fields\u0000dry-run\u0000description": {
       "out": "d2603aa6f73a",
       "src": "54f5f06db00c"
     },
-    "services.drawcustom.fields.dry-run.name": {
+    "services\u0000drawcustom\u0000fields\u0000dry-run\u0000name": {
       "out": "1a6e5991510a",
       "src": "d5da154d9f00"
     },
-    "services.drawcustom.fields.measured_palette.description": {
+    "services\u0000drawcustom\u0000fields\u0000measured_palette\u0000description": {
       "out": "86118979b5c5",
       "src": "53842124c7af"
     },
-    "services.drawcustom.fields.measured_palette.name": {
+    "services\u0000drawcustom\u0000fields\u0000measured_palette\u0000name": {
       "out": "0dc89a1bd99a",
       "src": "672d38bdeb19"
     },
-    "services.drawcustom.fields.payload.description": {
+    "services\u0000drawcustom\u0000fields\u0000payload\u0000description": {
       "out": "42d856db003c",
       "src": "a72e3d514ead"
     },
-    "services.drawcustom.fields.payload.name": {
+    "services\u0000drawcustom\u0000fields\u0000payload\u0000name": {
       "out": "79cfa503bcf0",
       "src": "99733344956d"
     },
-    "services.drawcustom.fields.refresh_type.description": {
+    "services\u0000drawcustom\u0000fields\u0000refresh_type\u0000description": {
       "out": "d4752cef1b7b",
       "src": "d87a3d5c4d06"
     },
-    "services.drawcustom.fields.refresh_type.name": {
+    "services\u0000drawcustom\u0000fields\u0000refresh_type\u0000name": {
       "out": "447179c803cf",
       "src": "201b25b874bb"
     },
-    "services.drawcustom.fields.rotate.description": {
+    "services\u0000drawcustom\u0000fields\u0000rotate\u0000description": {
       "out": "b2417d015c10",
       "src": "21e39f93db71"
     },
-    "services.drawcustom.fields.rotate.name": {
+    "services\u0000drawcustom\u0000fields\u0000rotate\u0000name": {
       "out": "01f2743fbfe3",
       "src": "57b5e2fc1bba"
     },
-    "services.drawcustom.name": {
+    "services\u0000drawcustom\u0000name": {
       "out": "e3bfe60f32f2",
       "src": "d0df7a6244ea"
     },
-    "services.upload_image.description": {
+    "services\u0000upload_image\u0000description": {
       "out": "804be76a6be5",
       "src": "24e19354eaa4"
     },
-    "services.upload_image.fields.device_id.description": {
+    "services\u0000upload_image\u0000fields\u0000device_id\u0000description": {
       "out": "6a2a8fa3f62b",
       "src": "ee157333391e"
     },
-    "services.upload_image.fields.device_id.name": {
+    "services\u0000upload_image\u0000fields\u0000device_id\u0000name": {
       "out": "5c72d15d094f",
       "src": "6ba0bdeccb42"
     },
-    "services.upload_image.fields.dither_mode.description": {
+    "services\u0000upload_image\u0000fields\u0000dither_mode\u0000description": {
       "out": "6dac7aedfa6f",
       "src": "70483fdfe7ec"
     },
-    "services.upload_image.fields.dither_mode.name": {
+    "services\u0000upload_image\u0000fields\u0000dither_mode\u0000name": {
       "out": "22762d93021c",
       "src": "35fb13830002"
     },
-    "services.upload_image.fields.fit_mode.description": {
+    "services\u0000upload_image\u0000fields\u0000fit_mode\u0000description": {
       "out": "56bc2cec177d",
       "src": "8d2c8735a962"
     },
-    "services.upload_image.fields.fit_mode.name": {
+    "services\u0000upload_image\u0000fields\u0000fit_mode\u0000name": {
       "out": "634e0197affc",
       "src": "8a59790c9187"
     },
-    "services.upload_image.fields.image.description": {
+    "services\u0000upload_image\u0000fields\u0000image\u0000description": {
       "out": "4d826c5920f1",
       "src": "ba6d9fb759b0"
     },
-    "services.upload_image.fields.image.name": {
+    "services\u0000upload_image\u0000fields\u0000image\u0000name": {
       "out": "98732be95aba",
       "src": "1aa4cb0bcca7"
     },
-    "services.upload_image.fields.measured_palette.description": {
+    "services\u0000upload_image\u0000fields\u0000measured_palette\u0000description": {
       "out": "88f42f4c1f04",
       "src": "53842124c7af"
     },
-    "services.upload_image.fields.measured_palette.name": {
+    "services\u0000upload_image\u0000fields\u0000measured_palette\u0000name": {
       "out": "0dc89a1bd99a",
       "src": "672d38bdeb19"
     },
-    "services.upload_image.fields.refresh_mode.description": {
+    "services\u0000upload_image\u0000fields\u0000refresh_mode\u0000description": {
       "out": "2c1e87687bda",
       "src": "0fe957da240a"
     },
-    "services.upload_image.fields.refresh_mode.name": {
+    "services\u0000upload_image\u0000fields\u0000refresh_mode\u0000name": {
       "out": "9fe0a274b5c7",
       "src": "c72fd253298c"
     },
-    "services.upload_image.fields.rotation.description": {
+    "services\u0000upload_image\u0000fields\u0000rotation\u0000description": {
       "out": "41acbe171017",
       "src": "b639ab27209e"
     },
-    "services.upload_image.fields.rotation.name": {
+    "services\u0000upload_image\u0000fields\u0000rotation\u0000name": {
       "out": "01f2743fbfe3",
       "src": "57b5e2fc1bba"
     },
-    "services.upload_image.fields.tone_compression.description": {
+    "services\u0000upload_image\u0000fields\u0000tone_compression\u0000description": {
       "out": "7b56fb88a56e",
       "src": "6453b45ae0cc"
     },
-    "services.upload_image.fields.tone_compression.name": {
+    "services\u0000upload_image\u0000fields\u0000tone_compression\u0000name": {
       "out": "b303ed82470b",
       "src": "ffaed65f03fa"
     },
-    "services.upload_image.name": {
+    "services\u0000upload_image\u0000name": {
       "out": "39ed4b94ad28",
       "src": "ffe4df6c7ca6"
     },
-    "services.upload_image.sections.additional_fields.name": {
+    "services\u0000upload_image\u0000sections\u0000additional_fields\u0000name": {
       "out": "479054da3881",
       "src": "092170b2408b"
     },
-    "services.write_nfc.description": {
+    "services\u0000write_nfc\u0000description": {
       "out": "370e3aca0845",
       "src": "3c1f6a6d643e"
     },
-    "services.write_nfc.fields.content.description": {
+    "services\u0000write_nfc\u0000fields\u0000content\u0000description": {
       "out": "6dc827ae64f8",
       "src": "857d1cf0bf90"
     },
-    "services.write_nfc.fields.content.name": {
+    "services\u0000write_nfc\u0000fields\u0000content\u0000name": {
       "out": "3fb7430d89a9",
       "src": "47bd29075f8b"
     },
-    "services.write_nfc.fields.device_id.description": {
+    "services\u0000write_nfc\u0000fields\u0000device_id\u0000description": {
       "out": "59b92f8722df",
       "src": "7dec980cb238"
     },
-    "services.write_nfc.fields.device_id.name": {
+    "services\u0000write_nfc\u0000fields\u0000device_id\u0000name": {
       "out": "5c72d15d094f",
       "src": "6ba0bdeccb42"
     },
-    "services.write_nfc.fields.mime_type.description": {
+    "services\u0000write_nfc\u0000fields\u0000mime_type\u0000description": {
       "out": "629fc23445d5",
       "src": "4eb2b40ec666"
     },
-    "services.write_nfc.fields.mime_type.name": {
+    "services\u0000write_nfc\u0000fields\u0000mime_type\u0000name": {
       "out": "ccd03106d237",
       "src": "849e8a810960"
     },
-    "services.write_nfc.fields.record_type.description": {
+    "services\u0000write_nfc\u0000fields\u0000record_type\u0000description": {
       "out": "51348cf060a0",
       "src": "936cf634012f"
     },
-    "services.write_nfc.fields.record_type.name": {
+    "services\u0000write_nfc\u0000fields\u0000record_type\u0000name": {
       "out": "39567fc896b3",
       "src": "91cf117b1d70"
     },
-    "services.write_nfc.name": {
+    "services\u0000write_nfc\u0000name": {
       "out": "fe0467e9a56d",
       "src": "96ea14b97cf7"
     }
   },
   "pt-BR": {
-    "config.abort.already_configured": {
+    "config\u0000abort\u0000already_configured": {
       "out": "dd3b80abffdd",
       "src": "c2936e02a0d2"
     },
-    "config.abort.already_in_progress": {
+    "config\u0000abort\u0000already_in_progress": {
       "out": "75b4c720d7cf",
       "src": "985a72ad93a3"
     },
-    "config.abort.cannot_connect": {
+    "config\u0000abort\u0000cannot_connect": {
       "out": "49e6f1def75f",
       "src": "46c9f3b7520f"
     },
-    "config.abort.no_devices_found": {
+    "config\u0000abort\u0000no_devices_found": {
       "out": "99b93bd5fcb6",
       "src": "b8f28e84cf0b"
     },
-    "config.abort.reauth_successful": {
+    "config\u0000abort\u0000reauth_successful": {
       "out": "c3a3779b59e8",
       "src": "e5b83989735c"
     },
-    "config.abort.unknown": {
+    "config\u0000abort\u0000unknown": {
       "out": "ad9544920db5",
       "src": "d24c41ae530a"
     },
-    "config.error.cannot_connect": {
+    "config\u0000error\u0000cannot_connect": {
       "out": "49e6f1def75f",
       "src": "46c9f3b7520f"
     },
-    "config.error.invalid_auth": {
+    "config\u0000error\u0000invalid_auth": {
       "out": "80c2dd42d824",
       "src": "4ca089878c5f"
     },
-    "config.error.invalid_key_format": {
+    "config\u0000error\u0000invalid_key_format": {
       "out": "5ad480a7dbf9",
       "src": "f7b03dd699df"
     },
-    "config.error.unknown": {
+    "config\u0000error\u0000unknown": {
       "out": "ad9544920db5",
       "src": "d24c41ae530a"
     },
-    "config.flow_title": {
+    "config\u0000flow_title": {
       "out": "5e291d7bcb2d",
       "src": "5e291d7bcb2d"
     },
-    "config.step.bluetooth_confirm.description": {
+    "config\u0000step\u0000bluetooth_confirm\u0000description": {
       "out": "9e758bdb4d0a",
       "src": "bcfd5a24b7d7"
     },
-    "config.step.encryption_key.data.encryption_key": {
+    "config\u0000step\u0000encryption_key\u0000data\u0000encryption_key": {
       "out": "30473842fa0d",
       "src": "16b3c9d5573d"
     },
-    "config.step.encryption_key.data_description.encryption_key": {
+    "config\u0000step\u0000encryption_key\u0000data_description\u0000encryption_key": {
       "out": "a4242d7514ce",
       "src": "e64cd2e7e647"
     },
-    "config.step.encryption_key.description": {
+    "config\u0000step\u0000encryption_key\u0000description": {
       "out": "38525fe63015",
       "src": "664d3f12bfe6"
     },
-    "config.step.encryption_key.title": {
+    "config\u0000step\u0000encryption_key\u0000title": {
       "out": "60f576819b33",
       "src": "c30d1ca158a3"
     },
-    "config.step.reauth_confirm.data.encryption_key": {
+    "config\u0000step\u0000reauth_confirm\u0000data\u0000encryption_key": {
       "out": "30473842fa0d",
       "src": "16b3c9d5573d"
     },
-    "config.step.reauth_confirm.data_description.encryption_key": {
+    "config\u0000step\u0000reauth_confirm\u0000data_description\u0000encryption_key": {
       "out": "a4242d7514ce",
       "src": "e64cd2e7e647"
     },
-    "config.step.reauth_confirm.description": {
+    "config\u0000step\u0000reauth_confirm\u0000description": {
       "out": "d329f39cdde5",
       "src": "f53b69d3be84"
     },
-    "config.step.reauth_confirm.title": {
+    "config\u0000step\u0000reauth_confirm\u0000title": {
       "out": "a434d6e7a842",
       "src": "7e22a752572f"
     },
-    "config.step.user.data.address": {
+    "config\u0000step\u0000user\u0000data\u0000address": {
       "out": "1c555eb7f1c0",
       "src": "6ba0bdeccb42"
     },
-    "config.step.user.data_description.address": {
+    "config\u0000step\u0000user\u0000data_description\u0000address": {
       "out": "68fbf6a80aac",
       "src": "a083a457cfb1"
     },
-    "config.step.user.description": {
+    "config\u0000step\u0000user\u0000description": {
       "out": "b90ef1e43fe2",
       "src": "109135454652"
     },
-    "entity.binary_sensor.update_pending.name": {
+    "entity\u0000binary_sensor\u0000update_pending\u0000name": {
       "out": "ead340a37e92",
       "src": "8e0a4b18ae75"
     },
-    "entity.event.button.name": {
+    "entity\u0000event\u0000button\u0000name": {
       "out": "4111fd0385ea",
       "src": "2dcae43716c2"
     },
-    "entity.event.button.state_attributes.event_type.state.button_down": {
+    "entity\u0000event\u0000button\u0000state_attributes\u0000event_type\u0000state\u0000button_down": {
       "out": "1d1f3249eb2c",
       "src": "8352c89d20b4"
     },
-    "entity.event.button.state_attributes.event_type.state.button_up": {
+    "entity\u0000event\u0000button\u0000state_attributes\u0000event_type\u0000state\u0000button_up": {
       "out": "881d0dec6932",
       "src": "7f18b4912929"
     },
-    "entity.event.touch.name": {
+    "entity\u0000event\u0000touch\u0000name": {
       "out": "837842a1ac38",
       "src": "c915d14278fc"
     },
-    "entity.event.touch.state_attributes.event_type.state.touch_down": {
+    "entity\u0000event\u0000touch\u0000state_attributes\u0000event_type\u0000state\u0000touch_down": {
       "out": "eed1a75d8672",
       "src": "0234a9576230"
     },
-    "entity.event.touch.state_attributes.event_type.state.touch_move": {
+    "entity\u0000event\u0000touch\u0000state_attributes\u0000event_type\u0000state\u0000touch_move": {
       "out": "14b0a47ffaef",
       "src": "67aeac815e94"
     },
-    "entity.event.touch.state_attributes.event_type.state.touch_up": {
+    "entity\u0000event\u0000touch\u0000state_attributes\u0000event_type\u0000state\u0000touch_up": {
       "out": "fb2fc38bb228",
       "src": "7c65519d3bb3"
     },
-    "entity.image.content.name": {
+    "entity\u0000image\u0000content\u0000name": {
       "out": "5711fb229b61",
       "src": "047c6db3382a"
     },
-    "entity.sensor.battery_voltage.name": {
+    "entity\u0000sensor\u0000battery_voltage\u0000name": {
       "out": "9558199749f3",
       "src": "39d6c91b57ce"
     },
-    "entity.sensor.last_seen.name": {
+    "entity\u0000sensor\u0000last_seen\u0000name": {
       "out": "a060c6768208",
       "src": "21fd79c7de52"
     },
-    "entity.sensor.rssi.name": {
+    "entity\u0000sensor\u0000rssi\u0000name": {
       "out": "e56501a19190",
       "src": "2604d15c1187"
     },
-    "entity.update.firmware.name": {
+    "entity\u0000update\u0000firmware\u0000name": {
       "out": "c2a314c3b32b",
       "src": "c2a314c3b32b"
     },
-    "exceptions.authentication_error.message": {
+    "exceptions\u0000authentication_error\u0000message": {
       "out": "09ff0363aa17",
       "src": "3d9f7c0c6d80"
     },
-    "exceptions.device_not_found.message": {
+    "exceptions\u0000device_not_found\u0000message": {
       "out": "dd2fad6c9806",
       "src": "f244d0d2db8d"
     },
-    "exceptions.device_sleeping.message": {
+    "exceptions\u0000device_sleeping\u0000message": {
       "out": "fca193a03cca",
       "src": "e95d25bd6fc7"
     },
-    "exceptions.device_sleeping_ota.message": {
+    "exceptions\u0000device_sleeping_ota\u0000message": {
       "out": "b0d5ab4a0e7e",
       "src": "430e3a1baa6a"
     },
-    "exceptions.invalid_device_id.message": {
+    "exceptions\u0000invalid_device_id\u0000message": {
       "out": "f001b2f55b3b",
       "src": "cc64cc29ceeb"
     },
-    "exceptions.media_download_error.message": {
+    "exceptions\u0000media_download_error\u0000message": {
       "out": "a3c0a46506c3",
       "src": "5852129dd920"
     },
-    "exceptions.mime_type_not_applicable.message": {
+    "exceptions\u0000mime_type_not_applicable\u0000message": {
       "out": "4dba9dc9cf06",
       "src": "de700f02fbd5"
     },
-    "exceptions.multiple_errors.message": {
+    "exceptions\u0000multiple_errors\u0000message": {
       "out": "be3dca23ac69",
       "src": "f17c68e0a848"
     },
-    "exceptions.nfc_content_empty.message": {
+    "exceptions\u0000nfc_content_empty\u0000message": {
       "out": "18796d161a54",
       "src": "b93a1a6ebdc0"
     },
-    "exceptions.nfc_content_too_long.message": {
+    "exceptions\u0000nfc_content_too_long\u0000message": {
       "out": "c00d4010d19d",
       "src": "8f580b9c6c76"
     },
-    "exceptions.nfc_mime_type_invalid.message": {
+    "exceptions\u0000nfc_mime_type_invalid\u0000message": {
       "out": "ab146b824727",
       "src": "5a5f44fe332f"
     },
-    "exceptions.nfc_not_supported.message": {
+    "exceptions\u0000nfc_not_supported\u0000message": {
       "out": "4fae039f6bde",
       "src": "8fdcd0e2bd17"
     },
-    "exceptions.nfc_write_failed.message": {
+    "exceptions\u0000nfc_write_failed\u0000message": {
       "out": "549fdf773195",
       "src": "e8186303a52e"
     },
-    "exceptions.no_buzzers.message": {
+    "exceptions\u0000no_buzzers\u0000message": {
       "out": "79675db97ead",
       "src": "9c014dfeac91"
     },
-    "exceptions.no_leds.message": {
+    "exceptions\u0000no_leds\u0000message": {
       "out": "5ea1a19390b6",
       "src": "6a302f8f22ee"
     },
-    "exceptions.no_nfc.message": {
+    "exceptions\u0000no_nfc\u0000message": {
       "out": "9f2692ab0584",
       "src": "abb1917ad57e"
     },
-    "exceptions.no_targets_specified.message": {
+    "exceptions\u0000no_targets_specified\u0000message": {
       "out": "82b619c1673b",
       "src": "80c472afefe6"
     },
-    "exceptions.upload_error.message": {
+    "exceptions\u0000upload_error\u0000message": {
       "out": "1462256b83ef",
       "src": "75561a03be6e"
     },
-    "exceptions.url_not_allowed.message": {
+    "exceptions\u0000url_not_allowed\u0000message": {
       "out": "7a9528bffb26",
       "src": "33ffb9a9f2c4"
     },
-    "options.step.init.data.blocks_per_ack": {
+    "options\u0000step\u0000init\u0000data\u0000blocks_per_ack": {
       "out": "b3fa9ef0928e",
       "src": "3e2a554e69a4"
     },
-    "options.step.init.data.max_queue_size": {
+    "options\u0000step\u0000init\u0000data\u0000max_queue_size": {
       "out": "8a1bef728edd",
       "src": "297af7027dd0"
     },
-    "options.step.init.data.missed_cycles": {
+    "options\u0000step\u0000init\u0000data\u0000missed_cycles": {
       "out": "8c13f06661c0",
       "src": "59b78644491a"
     },
-    "options.step.init.data.probe_before_queue": {
+    "options\u0000step\u0000init\u0000data\u0000probe_before_queue": {
       "out": "096e2800d348",
       "src": "02c4211a58b2"
     },
-    "options.step.init.data.queue_timeout_hours": {
+    "options\u0000step\u0000init\u0000data\u0000queue_timeout_hours": {
       "out": "bcc4fff0e185",
       "src": "be70fc5cca79"
     },
-    "options.step.init.data.sleep_mode": {
+    "options\u0000step\u0000init\u0000data\u0000sleep_mode": {
       "out": "f22b93baf411",
       "src": "f925c0e541ce"
     },
-    "options.step.init.data_description.blocks_per_ack": {
+    "options\u0000step\u0000init\u0000data_description\u0000blocks_per_ack": {
       "out": "d4310ef82bb5",
       "src": "3a693b19d3c6"
     },
-    "options.step.init.data_description.max_queue_size": {
+    "options\u0000step\u0000init\u0000data_description\u0000max_queue_size": {
       "out": "f154752824d5",
       "src": "50260959ee56"
     },
-    "options.step.init.data_description.missed_cycles": {
+    "options\u0000step\u0000init\u0000data_description\u0000missed_cycles": {
       "out": "5c01b85067e3",
       "src": "6ce493f4c44d"
     },
-    "options.step.init.data_description.probe_before_queue": {
+    "options\u0000step\u0000init\u0000data_description\u0000probe_before_queue": {
       "out": "9320c008fc80",
       "src": "5d0f2985ffdf"
     },
-    "options.step.init.data_description.queue_timeout_hours": {
+    "options\u0000step\u0000init\u0000data_description\u0000queue_timeout_hours": {
       "out": "f4d40da4fe5b",
       "src": "34895000b491"
     },
-    "options.step.init.data_description.sleep_mode": {
+    "options\u0000step\u0000init\u0000data_description\u0000sleep_mode": {
       "out": "f75a06dbe12d",
       "src": "4acfeb65d10d"
     },
-    "selector.dither_mode.options.atkinson": {
+    "selector\u0000dither_mode\u0000options\u0000atkinson": {
       "out": "7a8fe6d47b5b",
       "src": "7a8fe6d47b5b"
     },
-    "selector.dither_mode.options.burkes": {
+    "selector\u0000dither_mode\u0000options\u0000burkes": {
       "out": "1b75087201fb",
       "src": "1b75087201fb"
     },
-    "selector.dither_mode.options.floyd_steinberg": {
+    "selector\u0000dither_mode\u0000options\u0000floyd_steinberg": {
       "out": "37969811a3cf",
       "src": "37969811a3cf"
     },
-    "selector.dither_mode.options.jarvis_judice_ninke": {
+    "selector\u0000dither_mode\u0000options\u0000jarvis_judice_ninke": {
       "out": "7020241adf78",
       "src": "7020241adf78"
     },
-    "selector.dither_mode.options.none": {
+    "selector\u0000dither_mode\u0000options\u0000none": {
       "out": "496a53a0f11e",
       "src": "dc937b598926"
     },
-    "selector.dither_mode.options.ordered": {
+    "selector\u0000dither_mode\u0000options\u0000ordered": {
       "out": "d2aba6849adb",
       "src": "007877479e21"
     },
-    "selector.dither_mode.options.sierra": {
+    "selector\u0000dither_mode\u0000options\u0000sierra": {
       "out": "d5eef8ad210c",
       "src": "d5eef8ad210c"
     },
-    "selector.dither_mode.options.sierra_lite": {
+    "selector\u0000dither_mode\u0000options\u0000sierra_lite": {
       "out": "20da8cc85f38",
       "src": "20da8cc85f38"
     },
-    "selector.dither_mode.options.stucki": {
+    "selector\u0000dither_mode\u0000options\u0000stucki": {
       "out": "a17d2b13b6f9",
       "src": "a17d2b13b6f9"
     },
-    "selector.fit_mode.options.contain": {
+    "selector\u0000fit_mode\u0000options\u0000contain": {
       "out": "a190afc4b4ad",
       "src": "e534a2c2b456"
     },
-    "selector.fit_mode.options.cover": {
+    "selector\u0000fit_mode\u0000options\u0000cover": {
       "out": "236ed490ad06",
       "src": "fa8d84566676"
     },
-    "selector.fit_mode.options.crop": {
+    "selector\u0000fit_mode\u0000options\u0000crop": {
       "out": "2f04fbd94be9",
       "src": "98caf7c43c6f"
     },
-    "selector.fit_mode.options.stretch": {
+    "selector\u0000fit_mode\u0000options\u0000stretch": {
       "out": "63031bd7189f",
       "src": "a33fbcf83f7b"
     },
-    "selector.nfc_record_type.options.ha_tag": {
+    "selector\u0000nfc_record_type\u0000options\u0000ha_tag": {
       "out": "865fe819376c",
       "src": "d1d47a8fa544"
     },
-    "selector.nfc_record_type.options.mime": {
+    "selector\u0000nfc_record_type\u0000options\u0000mime": {
       "out": "c2bd593b48e2",
       "src": "f98d7539e627"
     },
-    "selector.nfc_record_type.options.text": {
+    "selector\u0000nfc_record_type\u0000options\u0000text": {
       "out": "6df3d6661c09",
       "src": "71988c4d8e08"
     },
-    "selector.nfc_record_type.options.url": {
+    "selector\u0000nfc_record_type\u0000options\u0000url": {
       "out": "e7a241debad5",
       "src": "e7a241debad5"
     },
-    "selector.refresh_mode.options.fast": {
+    "selector\u0000refresh_mode\u0000options\u0000fast": {
       "out": "76495f26e6c5",
       "src": "6c582b62e0e5"
     },
-    "selector.refresh_mode.options.full": {
+    "selector\u0000refresh_mode\u0000options\u0000full": {
       "out": "23e3685fbe6c",
       "src": "008dacb6d1e8"
     },
-    "selector.refresh_mode.options.partial": {
+    "selector\u0000refresh_mode\u0000options\u0000partial": {
       "out": "154b61b1e9da",
       "src": "a4d50fb85403"
     },
-    "selector.sleep_mode.options.auto": {
+    "selector\u0000sleep_mode\u0000options\u0000auto": {
       "out": "7557cb15b0a8",
       "src": "132990bd8ef7"
     },
-    "selector.sleep_mode.options.off": {
+    "selector\u0000sleep_mode\u0000options\u0000off": {
       "out": "e0730e1a1194",
       "src": "34598efe7b90"
     },
-    "selector.sleep_mode.options.on": {
+    "selector\u0000sleep_mode\u0000options\u0000on": {
       "out": "8d06f622b89e",
       "src": "bde131e31c9e"
     },
-    "services.activate_buzzer.description": {
+    "services\u0000activate_buzzer\u0000description": {
       "out": "d4c30266033a",
       "src": "1898784614cb"
     },
-    "services.activate_buzzer.fields.device_id.description": {
+    "services\u0000activate_buzzer\u0000fields\u0000device_id\u0000description": {
       "out": "8533aacf2904",
       "src": "7dec980cb238"
     },
-    "services.activate_buzzer.fields.device_id.name": {
+    "services\u0000activate_buzzer\u0000fields\u0000device_id\u0000name": {
       "out": "1c555eb7f1c0",
       "src": "6ba0bdeccb42"
     },
-    "services.activate_buzzer.fields.duration_ms.description": {
+    "services\u0000activate_buzzer\u0000fields\u0000duration_ms\u0000description": {
       "out": "c8b37eb09106",
       "src": "cd1bc75ca60c"
     },
-    "services.activate_buzzer.fields.duration_ms.name": {
+    "services\u0000activate_buzzer\u0000fields\u0000duration_ms\u0000name": {
       "out": "6cecb49a79df",
       "src": "4fc52a3c4c55"
     },
-    "services.activate_buzzer.fields.frequency_hz.description": {
+    "services\u0000activate_buzzer\u0000fields\u0000frequency_hz\u0000description": {
       "out": "7b1bb1eec059",
       "src": "510fc20311e3"
     },
-    "services.activate_buzzer.fields.frequency_hz.name": {
+    "services\u0000activate_buzzer\u0000fields\u0000frequency_hz\u0000name": {
       "out": "4ccef85f69f6",
       "src": "16b6668d9831"
     },
-    "services.activate_buzzer.fields.instance.description": {
+    "services\u0000activate_buzzer\u0000fields\u0000instance\u0000description": {
       "out": "5eb44e6b6ba0",
       "src": "f39fa742d55c"
     },
-    "services.activate_buzzer.fields.instance.name": {
+    "services\u0000activate_buzzer\u0000fields\u0000instance\u0000name": {
       "out": "7ce81db09421",
       "src": "1f671ddded9e"
     },
-    "services.activate_buzzer.fields.repeats.description": {
+    "services\u0000activate_buzzer\u0000fields\u0000repeats\u0000description": {
       "out": "3dfd2b7ef116",
       "src": "1f88b0fe23ea"
     },
-    "services.activate_buzzer.fields.repeats.name": {
+    "services\u0000activate_buzzer\u0000fields\u0000repeats\u0000name": {
       "out": "49ddd1cb9a27",
       "src": "92ee0233f013"
     },
-    "services.activate_buzzer.name": {
+    "services\u0000activate_buzzer\u0000name": {
       "out": "1d809ae66dbe",
       "src": "0b80285753b7"
     },
-    "services.activate_led.description": {
+    "services\u0000activate_led\u0000description": {
       "out": "dae0b6106c90",
       "src": "6cbd645597cc"
     },
-    "services.activate_led.fields.brightness.description": {
+    "services\u0000activate_led\u0000fields\u0000brightness\u0000description": {
       "out": "345a664f32bb",
       "src": "6ad88a28230d"
     },
-    "services.activate_led.fields.brightness.name": {
+    "services\u0000activate_led\u0000fields\u0000brightness\u0000name": {
       "out": "ff070ada77b9",
       "src": "ec811d30a89c"
     },
-    "services.activate_led.fields.color1.description": {
+    "services\u0000activate_led\u0000fields\u0000color1\u0000description": {
       "out": "9fc052573aad",
       "src": "17f145013241"
     },
-    "services.activate_led.fields.color1.name": {
+    "services\u0000activate_led\u0000fields\u0000color1\u0000name": {
       "out": "067701d4a113",
       "src": "571461f36f3a"
     },
-    "services.activate_led.fields.color2.description": {
+    "services\u0000activate_led\u0000fields\u0000color2\u0000description": {
       "out": "7068c896d0ec",
       "src": "f2680a4bbe85"
     },
-    "services.activate_led.fields.color2.name": {
+    "services\u0000activate_led\u0000fields\u0000color2\u0000name": {
       "out": "87ad039b4534",
       "src": "ef792d287872"
     },
-    "services.activate_led.fields.color3.description": {
+    "services\u0000activate_led\u0000fields\u0000color3\u0000description": {
       "out": "7586f57fab74",
       "src": "b8ecd353b426"
     },
-    "services.activate_led.fields.color3.name": {
+    "services\u0000activate_led\u0000fields\u0000color3\u0000name": {
       "out": "474cb86742e3",
       "src": "48d54e046d29"
     },
-    "services.activate_led.fields.device_id.description": {
+    "services\u0000activate_led\u0000fields\u0000device_id\u0000description": {
       "out": "8533aacf2904",
       "src": "7dec980cb238"
     },
-    "services.activate_led.fields.device_id.name": {
+    "services\u0000activate_led\u0000fields\u0000device_id\u0000name": {
       "out": "1c555eb7f1c0",
       "src": "6ba0bdeccb42"
     },
-    "services.activate_led.fields.flash_count1.description": {
+    "services\u0000activate_led\u0000fields\u0000flash_count1\u0000description": {
       "out": "7f7ee6fc1e31",
       "src": "4ffdadde31c2"
     },
-    "services.activate_led.fields.flash_count1.name": {
+    "services\u0000activate_led\u0000fields\u0000flash_count1\u0000name": {
       "out": "ed6275c95d0e",
       "src": "13c6a2e5c22e"
     },
-    "services.activate_led.fields.flash_count2.description": {
+    "services\u0000activate_led\u0000fields\u0000flash_count2\u0000description": {
       "out": "36efb7bd06be",
       "src": "86dc999a3915"
     },
-    "services.activate_led.fields.flash_count2.name": {
+    "services\u0000activate_led\u0000fields\u0000flash_count2\u0000name": {
       "out": "85892035b1b3",
       "src": "2be36d8449dc"
     },
-    "services.activate_led.fields.flash_count3.description": {
+    "services\u0000activate_led\u0000fields\u0000flash_count3\u0000description": {
       "out": "ff6b585a7816",
       "src": "aa40c396a9a4"
     },
-    "services.activate_led.fields.flash_count3.name": {
+    "services\u0000activate_led\u0000fields\u0000flash_count3\u0000name": {
       "out": "6c9301e03578",
       "src": "7978910dc6b2"
     },
-    "services.activate_led.fields.instance.description": {
+    "services\u0000activate_led\u0000fields\u0000instance\u0000description": {
       "out": "85f9f142ab02",
       "src": "0531b37de90a"
     },
-    "services.activate_led.fields.instance.name": {
+    "services\u0000activate_led\u0000fields\u0000instance\u0000name": {
       "out": "698c0545eb19",
       "src": "f942926204c7"
     },
-    "services.activate_led.fields.inter_delay1.description": {
+    "services\u0000activate_led\u0000fields\u0000inter_delay1\u0000description": {
       "out": "70fe714133bf",
       "src": "1b65dcfcea95"
     },
-    "services.activate_led.fields.inter_delay1.name": {
+    "services\u0000activate_led\u0000fields\u0000inter_delay1\u0000name": {
       "out": "2e08efa9b344",
       "src": "71452f436c33"
     },
-    "services.activate_led.fields.inter_delay2.description": {
+    "services\u0000activate_led\u0000fields\u0000inter_delay2\u0000description": {
       "out": "044b3d76c5b8",
       "src": "181e03f33cbf"
     },
-    "services.activate_led.fields.inter_delay2.name": {
+    "services\u0000activate_led\u0000fields\u0000inter_delay2\u0000name": {
       "out": "5f094e45de54",
       "src": "6a50551e5355"
     },
-    "services.activate_led.fields.inter_delay3.description": {
+    "services\u0000activate_led\u0000fields\u0000inter_delay3\u0000description": {
       "out": "df4e5697770e",
       "src": "5c5973b586df"
     },
-    "services.activate_led.fields.inter_delay3.name": {
+    "services\u0000activate_led\u0000fields\u0000inter_delay3\u0000name": {
       "out": "ef688ac09ca2",
       "src": "b0f72903777e"
     },
-    "services.activate_led.fields.loop_delay1.description": {
+    "services\u0000activate_led\u0000fields\u0000loop_delay1\u0000description": {
       "out": "96add63966d7",
       "src": "2139915c35bc"
     },
-    "services.activate_led.fields.loop_delay1.name": {
+    "services\u0000activate_led\u0000fields\u0000loop_delay1\u0000name": {
       "out": "43a959caaa5a",
       "src": "2fb02375bae0"
     },
-    "services.activate_led.fields.loop_delay2.description": {
+    "services\u0000activate_led\u0000fields\u0000loop_delay2\u0000description": {
       "out": "09eb9a85c5a6",
       "src": "9a3a8cccb3bb"
     },
-    "services.activate_led.fields.loop_delay2.name": {
+    "services\u0000activate_led\u0000fields\u0000loop_delay2\u0000name": {
       "out": "49cfb3d3f05e",
       "src": "597cbe87a7ec"
     },
-    "services.activate_led.fields.loop_delay3.description": {
+    "services\u0000activate_led\u0000fields\u0000loop_delay3\u0000description": {
       "out": "b619bbb5324c",
       "src": "8a965100226c"
     },
-    "services.activate_led.fields.loop_delay3.name": {
+    "services\u0000activate_led\u0000fields\u0000loop_delay3\u0000name": {
       "out": "164a38e4e4d7",
       "src": "66d787aa1bad"
     },
-    "services.activate_led.fields.repeats.description": {
+    "services\u0000activate_led\u0000fields\u0000repeats\u0000description": {
       "out": "3ef2e5bd1fb0",
       "src": "e40e956e3762"
     },
-    "services.activate_led.fields.repeats.name": {
+    "services\u0000activate_led\u0000fields\u0000repeats\u0000name": {
       "out": "49ddd1cb9a27",
       "src": "92ee0233f013"
     },
-    "services.activate_led.name": {
+    "services\u0000activate_led\u0000name": {
       "out": "f7f571044e1e",
       "src": "91933e94cc57"
     },
-    "services.drawcustom.description": {
+    "services\u0000drawcustom\u0000description": {
       "out": "d08dc809f528",
       "src": "55f9f3333fc0"
     },
-    "services.drawcustom.fields.background.description": {
+    "services\u0000drawcustom\u0000fields\u0000background\u0000description": {
       "out": "ae7d4384b96f",
       "src": "f5858405d78a"
     },
-    "services.drawcustom.fields.background.name": {
+    "services\u0000drawcustom\u0000fields\u0000background\u0000name": {
       "out": "4c1191f0c8bf",
       "src": "3e314dafdf7c"
     },
-    "services.drawcustom.fields.dither.description": {
+    "services\u0000drawcustom\u0000fields\u0000dither\u0000description": {
       "out": "f9bdeb9d8284",
       "src": "d7c737e5d01e"
     },
-    "services.drawcustom.fields.dither.name": {
+    "services\u0000drawcustom\u0000fields\u0000dither\u0000name": {
       "out": "576d270bd2f5",
       "src": "35fb13830002"
     },
-    "services.drawcustom.fields.dry-run.description": {
+    "services\u0000drawcustom\u0000fields\u0000dry-run\u0000description": {
       "out": "9c323228c60d",
       "src": "54f5f06db00c"
     },
-    "services.drawcustom.fields.dry-run.name": {
+    "services\u0000drawcustom\u0000fields\u0000dry-run\u0000name": {
       "out": "0b66acd48cad",
       "src": "d5da154d9f00"
     },
-    "services.drawcustom.fields.measured_palette.description": {
+    "services\u0000drawcustom\u0000fields\u0000measured_palette\u0000description": {
       "out": "c23788096043",
       "src": "53842124c7af"
     },
-    "services.drawcustom.fields.measured_palette.name": {
+    "services\u0000drawcustom\u0000fields\u0000measured_palette\u0000name": {
       "out": "2e8f0e046ee9",
       "src": "672d38bdeb19"
     },
-    "services.drawcustom.fields.payload.description": {
+    "services\u0000drawcustom\u0000fields\u0000payload\u0000description": {
       "out": "dc2db307984f",
       "src": "a72e3d514ead"
     },
-    "services.drawcustom.fields.payload.name": {
+    "services\u0000drawcustom\u0000fields\u0000payload\u0000name": {
       "out": "5fc119964393",
       "src": "99733344956d"
     },
-    "services.drawcustom.fields.refresh_type.description": {
+    "services\u0000drawcustom\u0000fields\u0000refresh_type\u0000description": {
       "out": "710bea91a9c3",
       "src": "d87a3d5c4d06"
     },
-    "services.drawcustom.fields.refresh_type.name": {
+    "services\u0000drawcustom\u0000fields\u0000refresh_type\u0000name": {
       "out": "721e465fbff3",
       "src": "201b25b874bb"
     },
-    "services.drawcustom.fields.rotate.description": {
+    "services\u0000drawcustom\u0000fields\u0000rotate\u0000description": {
       "out": "e49ff8cca2d0",
       "src": "21e39f93db71"
     },
-    "services.drawcustom.fields.rotate.name": {
+    "services\u0000drawcustom\u0000fields\u0000rotate\u0000name": {
       "out": "ae0506abfa72",
       "src": "57b5e2fc1bba"
     },
-    "services.drawcustom.name": {
+    "services\u0000drawcustom\u0000name": {
       "out": "9c4313360381",
       "src": "d0df7a6244ea"
     },
-    "services.upload_image.description": {
+    "services\u0000upload_image\u0000description": {
       "out": "86df30f38eee",
       "src": "24e19354eaa4"
     },
-    "services.upload_image.fields.device_id.description": {
+    "services\u0000upload_image\u0000fields\u0000device_id\u0000description": {
       "out": "a15b5b9e9f53",
       "src": "ee157333391e"
     },
-    "services.upload_image.fields.device_id.name": {
+    "services\u0000upload_image\u0000fields\u0000device_id\u0000name": {
       "out": "1c555eb7f1c0",
       "src": "6ba0bdeccb42"
     },
-    "services.upload_image.fields.dither_mode.description": {
+    "services\u0000upload_image\u0000fields\u0000dither_mode\u0000description": {
       "out": "c6e7107bf8f8",
       "src": "70483fdfe7ec"
     },
-    "services.upload_image.fields.dither_mode.name": {
+    "services\u0000upload_image\u0000fields\u0000dither_mode\u0000name": {
       "out": "576d270bd2f5",
       "src": "35fb13830002"
     },
-    "services.upload_image.fields.fit_mode.description": {
+    "services\u0000upload_image\u0000fields\u0000fit_mode\u0000description": {
       "out": "2ee4880a2a81",
       "src": "8d2c8735a962"
     },
-    "services.upload_image.fields.fit_mode.name": {
+    "services\u0000upload_image\u0000fields\u0000fit_mode\u0000name": {
       "out": "66d2c4bb0197",
       "src": "8a59790c9187"
     },
-    "services.upload_image.fields.image.description": {
+    "services\u0000upload_image\u0000fields\u0000image\u0000description": {
       "out": "cec3c20c95f6",
       "src": "ba6d9fb759b0"
     },
-    "services.upload_image.fields.image.name": {
+    "services\u0000upload_image\u0000fields\u0000image\u0000name": {
       "out": "8fc6b8b69804",
       "src": "1aa4cb0bcca7"
     },
-    "services.upload_image.fields.measured_palette.description": {
+    "services\u0000upload_image\u0000fields\u0000measured_palette\u0000description": {
       "out": "9d7cd76b1b3f",
       "src": "53842124c7af"
     },
-    "services.upload_image.fields.measured_palette.name": {
+    "services\u0000upload_image\u0000fields\u0000measured_palette\u0000name": {
       "out": "2e8f0e046ee9",
       "src": "672d38bdeb19"
     },
-    "services.upload_image.fields.refresh_mode.description": {
+    "services\u0000upload_image\u0000fields\u0000refresh_mode\u0000description": {
       "out": "2fb68afd6acf",
       "src": "0fe957da240a"
     },
-    "services.upload_image.fields.refresh_mode.name": {
+    "services\u0000upload_image\u0000fields\u0000refresh_mode\u0000name": {
       "out": "6fae77d3314e",
       "src": "c72fd253298c"
     },
-    "services.upload_image.fields.rotation.description": {
+    "services\u0000upload_image\u0000fields\u0000rotation\u0000description": {
       "out": "051cc317049a",
       "src": "b639ab27209e"
     },
-    "services.upload_image.fields.rotation.name": {
+    "services\u0000upload_image\u0000fields\u0000rotation\u0000name": {
       "out": "ae0506abfa72",
       "src": "57b5e2fc1bba"
     },
-    "services.upload_image.fields.tone_compression.description": {
+    "services\u0000upload_image\u0000fields\u0000tone_compression\u0000description": {
       "out": "d7fbbc46e817",
       "src": "6453b45ae0cc"
     },
-    "services.upload_image.fields.tone_compression.name": {
+    "services\u0000upload_image\u0000fields\u0000tone_compression\u0000name": {
       "out": "c0a153bdc251",
       "src": "ffaed65f03fa"
     },
-    "services.upload_image.name": {
+    "services\u0000upload_image\u0000name": {
       "out": "20a0a35690fa",
       "src": "ffe4df6c7ca6"
     },
-    "services.upload_image.sections.additional_fields.name": {
+    "services\u0000upload_image\u0000sections\u0000additional_fields\u0000name": {
       "out": "06c23075d12f",
       "src": "092170b2408b"
     },
-    "services.write_nfc.description": {
+    "services\u0000write_nfc\u0000description": {
       "out": "6d899b3ffaff",
       "src": "3c1f6a6d643e"
     },
-    "services.write_nfc.fields.content.description": {
+    "services\u0000write_nfc\u0000fields\u0000content\u0000description": {
       "out": "21ecbcb21d0d",
       "src": "857d1cf0bf90"
     },
-    "services.write_nfc.fields.content.name": {
+    "services\u0000write_nfc\u0000fields\u0000content\u0000name": {
       "out": "5fc119964393",
       "src": "47bd29075f8b"
     },
-    "services.write_nfc.fields.device_id.description": {
+    "services\u0000write_nfc\u0000fields\u0000device_id\u0000description": {
       "out": "8533aacf2904",
       "src": "7dec980cb238"
     },
-    "services.write_nfc.fields.device_id.name": {
+    "services\u0000write_nfc\u0000fields\u0000device_id\u0000name": {
       "out": "1c555eb7f1c0",
       "src": "6ba0bdeccb42"
     },
-    "services.write_nfc.fields.mime_type.description": {
+    "services\u0000write_nfc\u0000fields\u0000mime_type\u0000description": {
       "out": "00adeea09ddb",
       "src": "4eb2b40ec666"
     },
-    "services.write_nfc.fields.mime_type.name": {
+    "services\u0000write_nfc\u0000fields\u0000mime_type\u0000name": {
       "out": "899f5b786081",
       "src": "849e8a810960"
     },
-    "services.write_nfc.fields.record_type.description": {
+    "services\u0000write_nfc\u0000fields\u0000record_type\u0000description": {
       "out": "c05864f36cb1",
       "src": "936cf634012f"
     },
-    "services.write_nfc.fields.record_type.name": {
+    "services\u0000write_nfc\u0000fields\u0000record_type\u0000name": {
       "out": "ffc69bba602f",
       "src": "91cf117b1d70"
     },
-    "services.write_nfc.name": {
+    "services\u0000write_nfc\u0000name": {
       "out": "16fb8440ce6b",
       "src": "96ea14b97cf7"
     }

--- a/.github/translation-state.json
+++ b/.github/translation-state.json
@@ -1,0 +1,5810 @@
+{
+  "cs": {
+    "config.abort.already_configured": {
+      "out": "cfebe6abdf22",
+      "src": "c2936e02a0d2"
+    },
+    "config.abort.already_in_progress": {
+      "out": "6ebbfd9173a4",
+      "src": "985a72ad93a3"
+    },
+    "config.abort.cannot_connect": {
+      "out": "9a1dc8859d5e",
+      "src": "46c9f3b7520f"
+    },
+    "config.abort.no_devices_found": {
+      "out": "2b75b2bd2d47",
+      "src": "b8f28e84cf0b"
+    },
+    "config.abort.reauth_successful": {
+      "out": "e0c7a53681ca",
+      "src": "e5b83989735c"
+    },
+    "config.abort.unknown": {
+      "out": "05aa2a2eef83",
+      "src": "d24c41ae530a"
+    },
+    "config.error.cannot_connect": {
+      "out": "9a1dc8859d5e",
+      "src": "46c9f3b7520f"
+    },
+    "config.error.invalid_auth": {
+      "out": "4aeb94da6f2e",
+      "src": "4ca089878c5f"
+    },
+    "config.error.invalid_key_format": {
+      "out": "cbc799d354b8",
+      "src": "f7b03dd699df"
+    },
+    "config.error.unknown": {
+      "out": "05aa2a2eef83",
+      "src": "d24c41ae530a"
+    },
+    "config.flow_title": {
+      "out": "5e291d7bcb2d",
+      "src": "5e291d7bcb2d"
+    },
+    "config.step.bluetooth_confirm.description": {
+      "out": "0f66fd954120",
+      "src": "bcfd5a24b7d7"
+    },
+    "config.step.encryption_key.data.encryption_key": {
+      "out": "c357a59fb745",
+      "src": "16b3c9d5573d"
+    },
+    "config.step.encryption_key.data_description.encryption_key": {
+      "out": "46053a9ce60b",
+      "src": "e64cd2e7e647"
+    },
+    "config.step.encryption_key.description": {
+      "out": "b126b2ba8ac7",
+      "src": "664d3f12bfe6"
+    },
+    "config.step.encryption_key.title": {
+      "out": "51ff494c9466",
+      "src": "c30d1ca158a3"
+    },
+    "config.step.reauth_confirm.data.encryption_key": {
+      "out": "c357a59fb745",
+      "src": "16b3c9d5573d"
+    },
+    "config.step.reauth_confirm.data_description.encryption_key": {
+      "out": "46053a9ce60b",
+      "src": "e64cd2e7e647"
+    },
+    "config.step.reauth_confirm.description": {
+      "out": "f5965a3ea787",
+      "src": "f53b69d3be84"
+    },
+    "config.step.reauth_confirm.title": {
+      "out": "c4a20af90fb5",
+      "src": "7e22a752572f"
+    },
+    "config.step.user.data.address": {
+      "out": "e1363fae54dc",
+      "src": "6ba0bdeccb42"
+    },
+    "config.step.user.data_description.address": {
+      "out": "47cb83a900b6",
+      "src": "a083a457cfb1"
+    },
+    "config.step.user.description": {
+      "out": "1d2972ba825f",
+      "src": "109135454652"
+    },
+    "entity.binary_sensor.update_pending.name": {
+      "out": "1662dbb14ec4",
+      "src": "8e0a4b18ae75"
+    },
+    "entity.event.button.name": {
+      "out": "1fe4b52f1a66",
+      "src": "2dcae43716c2"
+    },
+    "entity.event.button.state_attributes.event_type.state.button_down": {
+      "out": "bcd890b7d63c",
+      "src": "8352c89d20b4"
+    },
+    "entity.event.button.state_attributes.event_type.state.button_up": {
+      "out": "70621e79373a",
+      "src": "7f18b4912929"
+    },
+    "entity.event.touch.name": {
+      "out": "b415304a8343",
+      "src": "c915d14278fc"
+    },
+    "entity.event.touch.state_attributes.event_type.state.touch_down": {
+      "out": "5bdaf56856ad",
+      "src": "0234a9576230"
+    },
+    "entity.event.touch.state_attributes.event_type.state.touch_move": {
+      "out": "9ae4a3a42e2c",
+      "src": "67aeac815e94"
+    },
+    "entity.event.touch.state_attributes.event_type.state.touch_up": {
+      "out": "a5a11748360a",
+      "src": "7c65519d3bb3"
+    },
+    "entity.image.content.name": {
+      "out": "99187c3ed5a1",
+      "src": "047c6db3382a"
+    },
+    "entity.sensor.battery_voltage.name": {
+      "out": "1035f4b7fc64",
+      "src": "39d6c91b57ce"
+    },
+    "entity.sensor.last_seen.name": {
+      "out": "64d7ab22fd32",
+      "src": "21fd79c7de52"
+    },
+    "entity.sensor.rssi.name": {
+      "out": "0def3420aa7a",
+      "src": "2604d15c1187"
+    },
+    "entity.update.firmware.name": {
+      "out": "c2a314c3b32b",
+      "src": "c2a314c3b32b"
+    },
+    "exceptions.authentication_error.message": {
+      "out": "451ec0042a3e",
+      "src": "3d9f7c0c6d80"
+    },
+    "exceptions.device_not_found.message": {
+      "out": "e469310c63c6",
+      "src": "f244d0d2db8d"
+    },
+    "exceptions.device_sleeping.message": {
+      "out": "faf083e36325",
+      "src": "e95d25bd6fc7"
+    },
+    "exceptions.device_sleeping_ota.message": {
+      "out": "2aab933151b7",
+      "src": "430e3a1baa6a"
+    },
+    "exceptions.invalid_device_id.message": {
+      "out": "2ede118246db",
+      "src": "cc64cc29ceeb"
+    },
+    "exceptions.media_download_error.message": {
+      "out": "f737579995ff",
+      "src": "5852129dd920"
+    },
+    "exceptions.mime_type_not_applicable.message": {
+      "out": "990faf3da728",
+      "src": "de700f02fbd5"
+    },
+    "exceptions.multiple_errors.message": {
+      "out": "e0151482bbbb",
+      "src": "f17c68e0a848"
+    },
+    "exceptions.nfc_content_empty.message": {
+      "out": "2694884c2464",
+      "src": "b93a1a6ebdc0"
+    },
+    "exceptions.nfc_content_too_long.message": {
+      "out": "d42c574e4c8a",
+      "src": "8f580b9c6c76"
+    },
+    "exceptions.nfc_mime_type_invalid.message": {
+      "out": "db70a8ea32bc",
+      "src": "5a5f44fe332f"
+    },
+    "exceptions.nfc_not_supported.message": {
+      "out": "89124d492c32",
+      "src": "8fdcd0e2bd17"
+    },
+    "exceptions.nfc_write_failed.message": {
+      "out": "bcfba9a035a1",
+      "src": "e8186303a52e"
+    },
+    "exceptions.no_buzzers.message": {
+      "out": "ba1f84e9b306",
+      "src": "9c014dfeac91"
+    },
+    "exceptions.no_leds.message": {
+      "out": "0fc1bf821d13",
+      "src": "6a302f8f22ee"
+    },
+    "exceptions.no_nfc.message": {
+      "out": "7e12bbb18870",
+      "src": "abb1917ad57e"
+    },
+    "exceptions.no_targets_specified.message": {
+      "out": "5e2456ad2a50",
+      "src": "80c472afefe6"
+    },
+    "exceptions.upload_error.message": {
+      "out": "946a74a36d9a",
+      "src": "75561a03be6e"
+    },
+    "exceptions.url_not_allowed.message": {
+      "out": "4f1612b673a0",
+      "src": "33ffb9a9f2c4"
+    },
+    "options.step.init.data.blocks_per_ack": {
+      "out": "f4064970f630",
+      "src": "3e2a554e69a4"
+    },
+    "options.step.init.data.max_queue_size": {
+      "out": "9984405cecb9",
+      "src": "297af7027dd0"
+    },
+    "options.step.init.data.missed_cycles": {
+      "out": "fa60491af79d",
+      "src": "59b78644491a"
+    },
+    "options.step.init.data.probe_before_queue": {
+      "out": "20b0c0f9b40f",
+      "src": "02c4211a58b2"
+    },
+    "options.step.init.data.queue_timeout_hours": {
+      "out": "580423afef62",
+      "src": "be70fc5cca79"
+    },
+    "options.step.init.data.sleep_mode": {
+      "out": "58f710c3ec6c",
+      "src": "f925c0e541ce"
+    },
+    "options.step.init.data_description.blocks_per_ack": {
+      "out": "cfffaab8d04a",
+      "src": "3a693b19d3c6"
+    },
+    "options.step.init.data_description.max_queue_size": {
+      "out": "25377f83bfe4",
+      "src": "50260959ee56"
+    },
+    "options.step.init.data_description.missed_cycles": {
+      "out": "7b08ce81fbe9",
+      "src": "6ce493f4c44d"
+    },
+    "options.step.init.data_description.probe_before_queue": {
+      "out": "c5a7e5c67a64",
+      "src": "5d0f2985ffdf"
+    },
+    "options.step.init.data_description.queue_timeout_hours": {
+      "out": "c4f34e43c09f",
+      "src": "34895000b491"
+    },
+    "options.step.init.data_description.sleep_mode": {
+      "out": "ab4c59deeb76",
+      "src": "4acfeb65d10d"
+    },
+    "selector.dither_mode.options.atkinson": {
+      "out": "7a8fe6d47b5b",
+      "src": "7a8fe6d47b5b"
+    },
+    "selector.dither_mode.options.burkes": {
+      "out": "1b75087201fb",
+      "src": "1b75087201fb"
+    },
+    "selector.dither_mode.options.floyd_steinberg": {
+      "out": "37969811a3cf",
+      "src": "37969811a3cf"
+    },
+    "selector.dither_mode.options.jarvis_judice_ninke": {
+      "out": "7020241adf78",
+      "src": "7020241adf78"
+    },
+    "selector.dither_mode.options.none": {
+      "out": "e4a313af66a4",
+      "src": "dc937b598926"
+    },
+    "selector.dither_mode.options.ordered": {
+      "out": "73292ad4ebb1",
+      "src": "007877479e21"
+    },
+    "selector.dither_mode.options.sierra": {
+      "out": "d5eef8ad210c",
+      "src": "d5eef8ad210c"
+    },
+    "selector.dither_mode.options.sierra_lite": {
+      "out": "20da8cc85f38",
+      "src": "20da8cc85f38"
+    },
+    "selector.dither_mode.options.stucki": {
+      "out": "a17d2b13b6f9",
+      "src": "a17d2b13b6f9"
+    },
+    "selector.fit_mode.options.contain": {
+      "out": "da805da4ef64",
+      "src": "e534a2c2b456"
+    },
+    "selector.fit_mode.options.cover": {
+      "out": "48c7c7dbd8ef",
+      "src": "fa8d84566676"
+    },
+    "selector.fit_mode.options.crop": {
+      "out": "299c5826ed0b",
+      "src": "98caf7c43c6f"
+    },
+    "selector.fit_mode.options.stretch": {
+      "out": "279e56f5fabf",
+      "src": "a33fbcf83f7b"
+    },
+    "selector.nfc_record_type.options.ha_tag": {
+      "out": "d1d47a8fa544",
+      "src": "d1d47a8fa544"
+    },
+    "selector.nfc_record_type.options.mime": {
+      "out": "c9a55c719e07",
+      "src": "f98d7539e627"
+    },
+    "selector.nfc_record_type.options.text": {
+      "out": "71988c4d8e08",
+      "src": "71988c4d8e08"
+    },
+    "selector.nfc_record_type.options.url": {
+      "out": "e7a241debad5",
+      "src": "e7a241debad5"
+    },
+    "selector.refresh_mode.options.fast": {
+      "out": "466ff56b59b2",
+      "src": "6c582b62e0e5"
+    },
+    "selector.refresh_mode.options.full": {
+      "out": "a2b95a053c53",
+      "src": "008dacb6d1e8"
+    },
+    "selector.refresh_mode.options.partial": {
+      "out": "269582aff3f4",
+      "src": "a4d50fb85403"
+    },
+    "selector.sleep_mode.options.auto": {
+      "out": "35727d4fb111",
+      "src": "132990bd8ef7"
+    },
+    "selector.sleep_mode.options.off": {
+      "out": "10740875f5b8",
+      "src": "34598efe7b90"
+    },
+    "selector.sleep_mode.options.on": {
+      "out": "d94c08d8165a",
+      "src": "bde131e31c9e"
+    },
+    "services.activate_buzzer.description": {
+      "out": "37b20ddf2753",
+      "src": "1898784614cb"
+    },
+    "services.activate_buzzer.fields.device_id.description": {
+      "out": "082aa38abb33",
+      "src": "7dec980cb238"
+    },
+    "services.activate_buzzer.fields.device_id.name": {
+      "out": "e1363fae54dc",
+      "src": "6ba0bdeccb42"
+    },
+    "services.activate_buzzer.fields.duration_ms.description": {
+      "out": "c4c224c6bbe6",
+      "src": "cd1bc75ca60c"
+    },
+    "services.activate_buzzer.fields.duration_ms.name": {
+      "out": "e2ebfffce3d1",
+      "src": "4fc52a3c4c55"
+    },
+    "services.activate_buzzer.fields.frequency_hz.description": {
+      "out": "efd5b116bd7b",
+      "src": "510fc20311e3"
+    },
+    "services.activate_buzzer.fields.frequency_hz.name": {
+      "out": "18e0c4322b87",
+      "src": "16b6668d9831"
+    },
+    "services.activate_buzzer.fields.instance.description": {
+      "out": "1dfe53f07145",
+      "src": "f39fa742d55c"
+    },
+    "services.activate_buzzer.fields.instance.name": {
+      "out": "7a641c371be6",
+      "src": "1f671ddded9e"
+    },
+    "services.activate_buzzer.fields.repeats.description": {
+      "out": "1d1a01d8a595",
+      "src": "1f88b0fe23ea"
+    },
+    "services.activate_buzzer.fields.repeats.name": {
+      "out": "57db92bda9a5",
+      "src": "92ee0233f013"
+    },
+    "services.activate_buzzer.name": {
+      "out": "5a7492da70ee",
+      "src": "0b80285753b7"
+    },
+    "services.activate_led.description": {
+      "out": "8f1501d74247",
+      "src": "6cbd645597cc"
+    },
+    "services.activate_led.fields.brightness.description": {
+      "out": "e20dd7ae15e5",
+      "src": "6ad88a28230d"
+    },
+    "services.activate_led.fields.brightness.name": {
+      "out": "92fb5f5d87e9",
+      "src": "ec811d30a89c"
+    },
+    "services.activate_led.fields.color1.description": {
+      "out": "8d7b32f32c8a",
+      "src": "17f145013241"
+    },
+    "services.activate_led.fields.color1.name": {
+      "out": "5c3a7978a694",
+      "src": "571461f36f3a"
+    },
+    "services.activate_led.fields.color2.description": {
+      "out": "cf13c4f8927c",
+      "src": "f2680a4bbe85"
+    },
+    "services.activate_led.fields.color2.name": {
+      "out": "949ea85f5b37",
+      "src": "ef792d287872"
+    },
+    "services.activate_led.fields.color3.description": {
+      "out": "203a3870bafb",
+      "src": "b8ecd353b426"
+    },
+    "services.activate_led.fields.color3.name": {
+      "out": "b0ff9ce9cc3f",
+      "src": "48d54e046d29"
+    },
+    "services.activate_led.fields.device_id.description": {
+      "out": "082aa38abb33",
+      "src": "7dec980cb238"
+    },
+    "services.activate_led.fields.device_id.name": {
+      "out": "e1363fae54dc",
+      "src": "6ba0bdeccb42"
+    },
+    "services.activate_led.fields.flash_count1.description": {
+      "out": "350002775c00",
+      "src": "4ffdadde31c2"
+    },
+    "services.activate_led.fields.flash_count1.name": {
+      "out": "022cd1537b90",
+      "src": "13c6a2e5c22e"
+    },
+    "services.activate_led.fields.flash_count2.description": {
+      "out": "7d9657597aae",
+      "src": "86dc999a3915"
+    },
+    "services.activate_led.fields.flash_count2.name": {
+      "out": "ad031bf6de32",
+      "src": "2be36d8449dc"
+    },
+    "services.activate_led.fields.flash_count3.description": {
+      "out": "884c08260a1d",
+      "src": "aa40c396a9a4"
+    },
+    "services.activate_led.fields.flash_count3.name": {
+      "out": "74a7c7895831",
+      "src": "7978910dc6b2"
+    },
+    "services.activate_led.fields.instance.description": {
+      "out": "705fc5dde0fd",
+      "src": "0531b37de90a"
+    },
+    "services.activate_led.fields.instance.name": {
+      "out": "b3aa884776b0",
+      "src": "f942926204c7"
+    },
+    "services.activate_led.fields.inter_delay1.description": {
+      "out": "83facb388e1d",
+      "src": "1b65dcfcea95"
+    },
+    "services.activate_led.fields.inter_delay1.name": {
+      "out": "b17882b9b4e0",
+      "src": "71452f436c33"
+    },
+    "services.activate_led.fields.inter_delay2.description": {
+      "out": "e1e2dd642684",
+      "src": "181e03f33cbf"
+    },
+    "services.activate_led.fields.inter_delay2.name": {
+      "out": "5c1101644dbb",
+      "src": "6a50551e5355"
+    },
+    "services.activate_led.fields.inter_delay3.description": {
+      "out": "db2759a1495c",
+      "src": "5c5973b586df"
+    },
+    "services.activate_led.fields.inter_delay3.name": {
+      "out": "656f06132f4f",
+      "src": "b0f72903777e"
+    },
+    "services.activate_led.fields.loop_delay1.description": {
+      "out": "22fabf9e8658",
+      "src": "2139915c35bc"
+    },
+    "services.activate_led.fields.loop_delay1.name": {
+      "out": "cf0342b33575",
+      "src": "2fb02375bae0"
+    },
+    "services.activate_led.fields.loop_delay2.description": {
+      "out": "b893b4c35f01",
+      "src": "9a3a8cccb3bb"
+    },
+    "services.activate_led.fields.loop_delay2.name": {
+      "out": "886b24677799",
+      "src": "597cbe87a7ec"
+    },
+    "services.activate_led.fields.loop_delay3.description": {
+      "out": "f9a5da863e9b",
+      "src": "8a965100226c"
+    },
+    "services.activate_led.fields.loop_delay3.name": {
+      "out": "589b4807f8a3",
+      "src": "66d787aa1bad"
+    },
+    "services.activate_led.fields.repeats.description": {
+      "out": "ffec2e7fc70c",
+      "src": "e40e956e3762"
+    },
+    "services.activate_led.fields.repeats.name": {
+      "out": "57db92bda9a5",
+      "src": "92ee0233f013"
+    },
+    "services.activate_led.name": {
+      "out": "0457442a4a9a",
+      "src": "91933e94cc57"
+    },
+    "services.drawcustom.description": {
+      "out": "c41ec5a1e657",
+      "src": "55f9f3333fc0"
+    },
+    "services.drawcustom.fields.background.description": {
+      "out": "ea091067cfa8",
+      "src": "f5858405d78a"
+    },
+    "services.drawcustom.fields.background.name": {
+      "out": "957e64d35fd3",
+      "src": "3e314dafdf7c"
+    },
+    "services.drawcustom.fields.dither.description": {
+      "out": "92b10f6b069c",
+      "src": "d7c737e5d01e"
+    },
+    "services.drawcustom.fields.dither.name": {
+      "out": "0fa65914f534",
+      "src": "35fb13830002"
+    },
+    "services.drawcustom.fields.dry-run.description": {
+      "out": "0913d7609357",
+      "src": "54f5f06db00c"
+    },
+    "services.drawcustom.fields.dry-run.name": {
+      "out": "cd9c1744785c",
+      "src": "d5da154d9f00"
+    },
+    "services.drawcustom.fields.measured_palette.description": {
+      "out": "b637e22adff7",
+      "src": "53842124c7af"
+    },
+    "services.drawcustom.fields.measured_palette.name": {
+      "out": "0466eb8ca82b",
+      "src": "672d38bdeb19"
+    },
+    "services.drawcustom.fields.payload.description": {
+      "out": "e687b78d71f1",
+      "src": "a72e3d514ead"
+    },
+    "services.drawcustom.fields.payload.name": {
+      "out": "cec8c2eed133",
+      "src": "99733344956d"
+    },
+    "services.drawcustom.fields.refresh_type.description": {
+      "out": "aec55315bee1",
+      "src": "d87a3d5c4d06"
+    },
+    "services.drawcustom.fields.refresh_type.name": {
+      "out": "df798e91afea",
+      "src": "201b25b874bb"
+    },
+    "services.drawcustom.fields.rotate.description": {
+      "out": "67334075f5c1",
+      "src": "21e39f93db71"
+    },
+    "services.drawcustom.fields.rotate.name": {
+      "out": "a607297da2aa",
+      "src": "57b5e2fc1bba"
+    },
+    "services.drawcustom.name": {
+      "out": "e258d0bbfad9",
+      "src": "d0df7a6244ea"
+    },
+    "services.upload_image.description": {
+      "out": "d0a115fc3148",
+      "src": "24e19354eaa4"
+    },
+    "services.upload_image.fields.device_id.description": {
+      "out": "2e3bc6c204bc",
+      "src": "ee157333391e"
+    },
+    "services.upload_image.fields.device_id.name": {
+      "out": "e1363fae54dc",
+      "src": "6ba0bdeccb42"
+    },
+    "services.upload_image.fields.dither_mode.description": {
+      "out": "6370658d6970",
+      "src": "70483fdfe7ec"
+    },
+    "services.upload_image.fields.dither_mode.name": {
+      "out": "0fa65914f534",
+      "src": "35fb13830002"
+    },
+    "services.upload_image.fields.fit_mode.description": {
+      "out": "9db7c9fc40cd",
+      "src": "8d2c8735a962"
+    },
+    "services.upload_image.fields.fit_mode.name": {
+      "out": "dc6f12db12ac",
+      "src": "8a59790c9187"
+    },
+    "services.upload_image.fields.image.description": {
+      "out": "7fff4af997f1",
+      "src": "ba6d9fb759b0"
+    },
+    "services.upload_image.fields.image.name": {
+      "out": "61f1115604e3",
+      "src": "1aa4cb0bcca7"
+    },
+    "services.upload_image.fields.measured_palette.description": {
+      "out": "489976f9cc3f",
+      "src": "53842124c7af"
+    },
+    "services.upload_image.fields.measured_palette.name": {
+      "out": "0466eb8ca82b",
+      "src": "672d38bdeb19"
+    },
+    "services.upload_image.fields.refresh_mode.description": {
+      "out": "b9e70315e14a",
+      "src": "0fe957da240a"
+    },
+    "services.upload_image.fields.refresh_mode.name": {
+      "out": "c41e76bb7993",
+      "src": "c72fd253298c"
+    },
+    "services.upload_image.fields.rotation.description": {
+      "out": "0670ee63d178",
+      "src": "b639ab27209e"
+    },
+    "services.upload_image.fields.rotation.name": {
+      "out": "dca80c8604f0",
+      "src": "57b5e2fc1bba"
+    },
+    "services.upload_image.fields.tone_compression.description": {
+      "out": "43814e4235b6",
+      "src": "6453b45ae0cc"
+    },
+    "services.upload_image.fields.tone_compression.name": {
+      "out": "7d3542453da5",
+      "src": "ffaed65f03fa"
+    },
+    "services.upload_image.name": {
+      "out": "803d97e4739e",
+      "src": "ffe4df6c7ca6"
+    },
+    "services.upload_image.sections.additional_fields.name": {
+      "out": "a127f78dbb07",
+      "src": "092170b2408b"
+    },
+    "services.write_nfc.description": {
+      "out": "a503a1d01e8b",
+      "src": "3c1f6a6d643e"
+    },
+    "services.write_nfc.fields.content.description": {
+      "out": "6eb3a3b98a3a",
+      "src": "857d1cf0bf90"
+    },
+    "services.write_nfc.fields.content.name": {
+      "out": "cec8c2eed133",
+      "src": "47bd29075f8b"
+    },
+    "services.write_nfc.fields.device_id.description": {
+      "out": "082aa38abb33",
+      "src": "7dec980cb238"
+    },
+    "services.write_nfc.fields.device_id.name": {
+      "out": "e1363fae54dc",
+      "src": "6ba0bdeccb42"
+    },
+    "services.write_nfc.fields.mime_type.description": {
+      "out": "317edf3902f2",
+      "src": "4eb2b40ec666"
+    },
+    "services.write_nfc.fields.mime_type.name": {
+      "out": "a6175133210c",
+      "src": "849e8a810960"
+    },
+    "services.write_nfc.fields.record_type.description": {
+      "out": "e1274dbe5fd7",
+      "src": "936cf634012f"
+    },
+    "services.write_nfc.fields.record_type.name": {
+      "out": "f6b062c049e9",
+      "src": "91cf117b1d70"
+    },
+    "services.write_nfc.name": {
+      "out": "045d72869ebd",
+      "src": "96ea14b97cf7"
+    }
+  },
+  "de": {
+    "config.abort.already_configured": {
+      "out": "c9b4894d2c0a",
+      "src": "c2936e02a0d2"
+    },
+    "config.abort.already_in_progress": {
+      "out": "4133b45916fd",
+      "src": "985a72ad93a3"
+    },
+    "config.abort.cannot_connect": {
+      "out": "9f5c81a587e0",
+      "src": "46c9f3b7520f"
+    },
+    "config.abort.no_devices_found": {
+      "out": "8733c1f43375",
+      "src": "b8f28e84cf0b"
+    },
+    "config.abort.reauth_successful": {
+      "out": "6abfbf86672f",
+      "src": "e5b83989735c"
+    },
+    "config.abort.unknown": {
+      "out": "1bb6bb85adff",
+      "src": "d24c41ae530a"
+    },
+    "config.error.cannot_connect": {
+      "out": "9f5c81a587e0",
+      "src": "46c9f3b7520f"
+    },
+    "config.error.invalid_auth": {
+      "out": "0c1e9f96ab73",
+      "src": "4ca089878c5f"
+    },
+    "config.error.invalid_key_format": {
+      "out": "51a4db5b6494",
+      "src": "f7b03dd699df"
+    },
+    "config.error.unknown": {
+      "out": "1bb6bb85adff",
+      "src": "d24c41ae530a"
+    },
+    "config.flow_title": {
+      "out": "5e291d7bcb2d",
+      "src": "5e291d7bcb2d"
+    },
+    "config.step.bluetooth_confirm.description": {
+      "out": "ecff72aba247",
+      "src": "bcfd5a24b7d7"
+    },
+    "config.step.encryption_key.data.encryption_key": {
+      "out": "b60d860c061b",
+      "src": "16b3c9d5573d"
+    },
+    "config.step.encryption_key.data_description.encryption_key": {
+      "out": "14c2dc6bdbf9",
+      "src": "e64cd2e7e647"
+    },
+    "config.step.encryption_key.description": {
+      "out": "8b7e9493d7b5",
+      "src": "664d3f12bfe6"
+    },
+    "config.step.encryption_key.title": {
+      "out": "e64cc8c774de",
+      "src": "c30d1ca158a3"
+    },
+    "config.step.reauth_confirm.data.encryption_key": {
+      "out": "b60d860c061b",
+      "src": "16b3c9d5573d"
+    },
+    "config.step.reauth_confirm.data_description.encryption_key": {
+      "out": "14c2dc6bdbf9",
+      "src": "e64cd2e7e647"
+    },
+    "config.step.reauth_confirm.description": {
+      "out": "b8118ea64501",
+      "src": "f53b69d3be84"
+    },
+    "config.step.reauth_confirm.title": {
+      "out": "4a8707a38e51",
+      "src": "7e22a752572f"
+    },
+    "config.step.user.data.address": {
+      "out": "b32db78620d9",
+      "src": "6ba0bdeccb42"
+    },
+    "config.step.user.data_description.address": {
+      "out": "2c8fea906f6e",
+      "src": "a083a457cfb1"
+    },
+    "config.step.user.description": {
+      "out": "557f8f83b684",
+      "src": "109135454652"
+    },
+    "entity.binary_sensor.update_pending.name": {
+      "out": "f891020eff67",
+      "src": "8e0a4b18ae75"
+    },
+    "entity.event.button.name": {
+      "out": "76cf838efac6",
+      "src": "2dcae43716c2"
+    },
+    "entity.event.button.state_attributes.event_type.state.button_down": {
+      "out": "1d47b9367e9b",
+      "src": "8352c89d20b4"
+    },
+    "entity.event.button.state_attributes.event_type.state.button_up": {
+      "out": "8c2301b474ea",
+      "src": "7f18b4912929"
+    },
+    "entity.event.touch.name": {
+      "out": "32bb934a90a5",
+      "src": "c915d14278fc"
+    },
+    "entity.event.touch.state_attributes.event_type.state.touch_down": {
+      "out": "fc293df02339",
+      "src": "0234a9576230"
+    },
+    "entity.event.touch.state_attributes.event_type.state.touch_move": {
+      "out": "ff7d5231d9a8",
+      "src": "67aeac815e94"
+    },
+    "entity.event.touch.state_attributes.event_type.state.touch_up": {
+      "out": "3b8887e21536",
+      "src": "7c65519d3bb3"
+    },
+    "entity.image.content.name": {
+      "out": "c38ca3f0b649",
+      "src": "047c6db3382a"
+    },
+    "entity.sensor.battery_voltage.name": {
+      "out": "beeb8ebab924",
+      "src": "39d6c91b57ce"
+    },
+    "entity.sensor.last_seen.name": {
+      "out": "32522f222b66",
+      "src": "21fd79c7de52"
+    },
+    "entity.sensor.rssi.name": {
+      "out": "26a29a7b13f7",
+      "src": "2604d15c1187"
+    },
+    "entity.update.firmware.name": {
+      "out": "c2a314c3b32b",
+      "src": "c2a314c3b32b"
+    },
+    "exceptions.authentication_error.message": {
+      "out": "9e507db4cc0f",
+      "src": "3d9f7c0c6d80"
+    },
+    "exceptions.device_not_found.message": {
+      "out": "5c1f9c1134fc",
+      "src": "f244d0d2db8d"
+    },
+    "exceptions.device_sleeping.message": {
+      "out": "61fe3775a645",
+      "src": "e95d25bd6fc7"
+    },
+    "exceptions.device_sleeping_ota.message": {
+      "out": "5b60bade6dcc",
+      "src": "430e3a1baa6a"
+    },
+    "exceptions.invalid_device_id.message": {
+      "out": "9c06ec0618e4",
+      "src": "cc64cc29ceeb"
+    },
+    "exceptions.media_download_error.message": {
+      "out": "55b588a0733a",
+      "src": "5852129dd920"
+    },
+    "exceptions.mime_type_not_applicable.message": {
+      "out": "3c2db98f77c2",
+      "src": "de700f02fbd5"
+    },
+    "exceptions.multiple_errors.message": {
+      "out": "b35c4f55b78e",
+      "src": "f17c68e0a848"
+    },
+    "exceptions.nfc_content_empty.message": {
+      "out": "3d9b3519fd41",
+      "src": "b93a1a6ebdc0"
+    },
+    "exceptions.nfc_content_too_long.message": {
+      "out": "9d31c9e46595",
+      "src": "8f580b9c6c76"
+    },
+    "exceptions.nfc_mime_type_invalid.message": {
+      "out": "617172c5484f",
+      "src": "5a5f44fe332f"
+    },
+    "exceptions.nfc_not_supported.message": {
+      "out": "3e0390544aec",
+      "src": "8fdcd0e2bd17"
+    },
+    "exceptions.nfc_write_failed.message": {
+      "out": "76c221e2e752",
+      "src": "e8186303a52e"
+    },
+    "exceptions.no_buzzers.message": {
+      "out": "76d6204ff6bc",
+      "src": "9c014dfeac91"
+    },
+    "exceptions.no_leds.message": {
+      "out": "d5a8382fb1a5",
+      "src": "6a302f8f22ee"
+    },
+    "exceptions.no_nfc.message": {
+      "out": "5c539dd0cc41",
+      "src": "abb1917ad57e"
+    },
+    "exceptions.no_targets_specified.message": {
+      "out": "1937c120929b",
+      "src": "80c472afefe6"
+    },
+    "exceptions.upload_error.message": {
+      "out": "a0d49d0ede2c",
+      "src": "75561a03be6e"
+    },
+    "exceptions.url_not_allowed.message": {
+      "out": "fbd45bf5d464",
+      "src": "33ffb9a9f2c4"
+    },
+    "options.step.init.data.blocks_per_ack": {
+      "out": "f407ac69b8bd",
+      "src": "3e2a554e69a4"
+    },
+    "options.step.init.data.max_queue_size": {
+      "out": "5d89bbe0c4ff",
+      "src": "297af7027dd0"
+    },
+    "options.step.init.data.missed_cycles": {
+      "out": "5615dc03f7cf",
+      "src": "59b78644491a"
+    },
+    "options.step.init.data.probe_before_queue": {
+      "out": "e3543b3b4739",
+      "src": "02c4211a58b2"
+    },
+    "options.step.init.data.queue_timeout_hours": {
+      "out": "638bc53d3ee0",
+      "src": "be70fc5cca79"
+    },
+    "options.step.init.data.sleep_mode": {
+      "out": "f5eca6790b6e",
+      "src": "f925c0e541ce"
+    },
+    "options.step.init.data_description.blocks_per_ack": {
+      "out": "88a9bf326be4",
+      "src": "3a693b19d3c6"
+    },
+    "options.step.init.data_description.max_queue_size": {
+      "out": "3ab2a26606e1",
+      "src": "50260959ee56"
+    },
+    "options.step.init.data_description.missed_cycles": {
+      "out": "88826c48d3e3",
+      "src": "6ce493f4c44d"
+    },
+    "options.step.init.data_description.probe_before_queue": {
+      "out": "5246b4eabf36",
+      "src": "5d0f2985ffdf"
+    },
+    "options.step.init.data_description.queue_timeout_hours": {
+      "out": "e748b489eecb",
+      "src": "34895000b491"
+    },
+    "options.step.init.data_description.sleep_mode": {
+      "out": "adcf41634e3b",
+      "src": "4acfeb65d10d"
+    },
+    "selector.dither_mode.options.atkinson": {
+      "out": "7a8fe6d47b5b",
+      "src": "7a8fe6d47b5b"
+    },
+    "selector.dither_mode.options.burkes": {
+      "out": "1b75087201fb",
+      "src": "1b75087201fb"
+    },
+    "selector.dither_mode.options.floyd_steinberg": {
+      "out": "37969811a3cf",
+      "src": "37969811a3cf"
+    },
+    "selector.dither_mode.options.jarvis_judice_ninke": {
+      "out": "7020241adf78",
+      "src": "7020241adf78"
+    },
+    "selector.dither_mode.options.none": {
+      "out": "8a572015c49b",
+      "src": "dc937b598926"
+    },
+    "selector.dither_mode.options.ordered": {
+      "out": "f496918f9be6",
+      "src": "007877479e21"
+    },
+    "selector.dither_mode.options.sierra": {
+      "out": "d5eef8ad210c",
+      "src": "d5eef8ad210c"
+    },
+    "selector.dither_mode.options.sierra_lite": {
+      "out": "20da8cc85f38",
+      "src": "20da8cc85f38"
+    },
+    "selector.dither_mode.options.stucki": {
+      "out": "a17d2b13b6f9",
+      "src": "a17d2b13b6f9"
+    },
+    "selector.fit_mode.options.contain": {
+      "out": "56743fb5d71a",
+      "src": "e534a2c2b456"
+    },
+    "selector.fit_mode.options.cover": {
+      "out": "03a2eb101be5",
+      "src": "fa8d84566676"
+    },
+    "selector.fit_mode.options.crop": {
+      "out": "a7ee0740f7f1",
+      "src": "98caf7c43c6f"
+    },
+    "selector.fit_mode.options.stretch": {
+      "out": "88a2b24c1ce0",
+      "src": "a33fbcf83f7b"
+    },
+    "selector.nfc_record_type.options.ha_tag": {
+      "out": "1f919f97794b",
+      "src": "d1d47a8fa544"
+    },
+    "selector.nfc_record_type.options.mime": {
+      "out": "620341f3ccc0",
+      "src": "f98d7539e627"
+    },
+    "selector.nfc_record_type.options.text": {
+      "out": "71988c4d8e08",
+      "src": "71988c4d8e08"
+    },
+    "selector.nfc_record_type.options.url": {
+      "out": "e7a241debad5",
+      "src": "e7a241debad5"
+    },
+    "selector.refresh_mode.options.fast": {
+      "out": "4d1272d42b9b",
+      "src": "6c582b62e0e5"
+    },
+    "selector.refresh_mode.options.full": {
+      "out": "9eae8e7efb47",
+      "src": "008dacb6d1e8"
+    },
+    "selector.refresh_mode.options.partial": {
+      "out": "296f1fe2c06d",
+      "src": "a4d50fb85403"
+    },
+    "selector.sleep_mode.options.auto": {
+      "out": "0a99ee8281a3",
+      "src": "132990bd8ef7"
+    },
+    "selector.sleep_mode.options.off": {
+      "out": "a150b5702aff",
+      "src": "34598efe7b90"
+    },
+    "selector.sleep_mode.options.on": {
+      "out": "b7d0f2c29d4e",
+      "src": "bde131e31c9e"
+    },
+    "services.activate_buzzer.description": {
+      "out": "b67a5314e9bc",
+      "src": "1898784614cb"
+    },
+    "services.activate_buzzer.fields.device_id.description": {
+      "out": "c9d3248db546",
+      "src": "7dec980cb238"
+    },
+    "services.activate_buzzer.fields.device_id.name": {
+      "out": "b32db78620d9",
+      "src": "6ba0bdeccb42"
+    },
+    "services.activate_buzzer.fields.duration_ms.description": {
+      "out": "51ea736fee20",
+      "src": "cd1bc75ca60c"
+    },
+    "services.activate_buzzer.fields.duration_ms.name": {
+      "out": "668cbe316167",
+      "src": "4fc52a3c4c55"
+    },
+    "services.activate_buzzer.fields.frequency_hz.description": {
+      "out": "ac4bba206ebd",
+      "src": "510fc20311e3"
+    },
+    "services.activate_buzzer.fields.frequency_hz.name": {
+      "out": "68b6fcc1ea1b",
+      "src": "16b6668d9831"
+    },
+    "services.activate_buzzer.fields.instance.description": {
+      "out": "adc1a6c3c436",
+      "src": "f39fa742d55c"
+    },
+    "services.activate_buzzer.fields.instance.name": {
+      "out": "9280d2bb03e2",
+      "src": "1f671ddded9e"
+    },
+    "services.activate_buzzer.fields.repeats.description": {
+      "out": "39741bdba44d",
+      "src": "1f88b0fe23ea"
+    },
+    "services.activate_buzzer.fields.repeats.name": {
+      "out": "b93838e6408f",
+      "src": "92ee0233f013"
+    },
+    "services.activate_buzzer.name": {
+      "out": "949c6996af70",
+      "src": "0b80285753b7"
+    },
+    "services.activate_led.description": {
+      "out": "bf1feaf64630",
+      "src": "6cbd645597cc"
+    },
+    "services.activate_led.fields.brightness.description": {
+      "out": "a2a49c5e243a",
+      "src": "6ad88a28230d"
+    },
+    "services.activate_led.fields.brightness.name": {
+      "out": "00b737a90a4a",
+      "src": "ec811d30a89c"
+    },
+    "services.activate_led.fields.color1.description": {
+      "out": "528ef41884fd",
+      "src": "17f145013241"
+    },
+    "services.activate_led.fields.color1.name": {
+      "out": "0539eb2c084a",
+      "src": "571461f36f3a"
+    },
+    "services.activate_led.fields.color2.description": {
+      "out": "b03d5b89f419",
+      "src": "f2680a4bbe85"
+    },
+    "services.activate_led.fields.color2.name": {
+      "out": "5da9bac05b38",
+      "src": "ef792d287872"
+    },
+    "services.activate_led.fields.color3.description": {
+      "out": "f35b1e471369",
+      "src": "b8ecd353b426"
+    },
+    "services.activate_led.fields.color3.name": {
+      "out": "4dfaa7e17220",
+      "src": "48d54e046d29"
+    },
+    "services.activate_led.fields.device_id.description": {
+      "out": "c9d3248db546",
+      "src": "7dec980cb238"
+    },
+    "services.activate_led.fields.device_id.name": {
+      "out": "b32db78620d9",
+      "src": "6ba0bdeccb42"
+    },
+    "services.activate_led.fields.flash_count1.description": {
+      "out": "510b9dbf8c6b",
+      "src": "4ffdadde31c2"
+    },
+    "services.activate_led.fields.flash_count1.name": {
+      "out": "e8b4d938c9cd",
+      "src": "13c6a2e5c22e"
+    },
+    "services.activate_led.fields.flash_count2.description": {
+      "out": "fb78d61d9443",
+      "src": "86dc999a3915"
+    },
+    "services.activate_led.fields.flash_count2.name": {
+      "out": "5fdb5ef0ab6c",
+      "src": "2be36d8449dc"
+    },
+    "services.activate_led.fields.flash_count3.description": {
+      "out": "0e460c43a75c",
+      "src": "aa40c396a9a4"
+    },
+    "services.activate_led.fields.flash_count3.name": {
+      "out": "ddef8b74eb45",
+      "src": "7978910dc6b2"
+    },
+    "services.activate_led.fields.instance.description": {
+      "out": "488e61e0b007",
+      "src": "0531b37de90a"
+    },
+    "services.activate_led.fields.instance.name": {
+      "out": "d45911100f53",
+      "src": "f942926204c7"
+    },
+    "services.activate_led.fields.inter_delay1.description": {
+      "out": "d6b3493aefae",
+      "src": "1b65dcfcea95"
+    },
+    "services.activate_led.fields.inter_delay1.name": {
+      "out": "15d328411824",
+      "src": "71452f436c33"
+    },
+    "services.activate_led.fields.inter_delay2.description": {
+      "out": "c472b1cbd40b",
+      "src": "181e03f33cbf"
+    },
+    "services.activate_led.fields.inter_delay2.name": {
+      "out": "a21f401e77a6",
+      "src": "6a50551e5355"
+    },
+    "services.activate_led.fields.inter_delay3.description": {
+      "out": "4c0f68b1894a",
+      "src": "5c5973b586df"
+    },
+    "services.activate_led.fields.inter_delay3.name": {
+      "out": "ee390ed0822c",
+      "src": "b0f72903777e"
+    },
+    "services.activate_led.fields.loop_delay1.description": {
+      "out": "6c65dd5b1d5e",
+      "src": "2139915c35bc"
+    },
+    "services.activate_led.fields.loop_delay1.name": {
+      "out": "f231caca47fd",
+      "src": "2fb02375bae0"
+    },
+    "services.activate_led.fields.loop_delay2.description": {
+      "out": "0d6ad5afb805",
+      "src": "9a3a8cccb3bb"
+    },
+    "services.activate_led.fields.loop_delay2.name": {
+      "out": "31824443e583",
+      "src": "597cbe87a7ec"
+    },
+    "services.activate_led.fields.loop_delay3.description": {
+      "out": "bc62fd7f23ed",
+      "src": "8a965100226c"
+    },
+    "services.activate_led.fields.loop_delay3.name": {
+      "out": "8d76ef9731fb",
+      "src": "66d787aa1bad"
+    },
+    "services.activate_led.fields.repeats.description": {
+      "out": "e2e8578f3089",
+      "src": "e40e956e3762"
+    },
+    "services.activate_led.fields.repeats.name": {
+      "out": "b93838e6408f",
+      "src": "92ee0233f013"
+    },
+    "services.activate_led.name": {
+      "out": "695c29fa44b0",
+      "src": "91933e94cc57"
+    },
+    "services.drawcustom.description": {
+      "out": "76a8ef04c1a6",
+      "src": "55f9f3333fc0"
+    },
+    "services.drawcustom.fields.background.description": {
+      "out": "449e352f699b",
+      "src": "f5858405d78a"
+    },
+    "services.drawcustom.fields.background.name": {
+      "out": "ac31c0c1c7e7",
+      "src": "3e314dafdf7c"
+    },
+    "services.drawcustom.fields.dither.description": {
+      "out": "cacbd413daf9",
+      "src": "d7c737e5d01e"
+    },
+    "services.drawcustom.fields.dither.name": {
+      "out": "ed8bce595a2d",
+      "src": "35fb13830002"
+    },
+    "services.drawcustom.fields.dry-run.description": {
+      "out": "3211c4927a10",
+      "src": "54f5f06db00c"
+    },
+    "services.drawcustom.fields.dry-run.name": {
+      "out": "e6a47af0d12e",
+      "src": "d5da154d9f00"
+    },
+    "services.drawcustom.fields.measured_palette.description": {
+      "out": "3f08436f9451",
+      "src": "53842124c7af"
+    },
+    "services.drawcustom.fields.measured_palette.name": {
+      "out": "708f2b8f834d",
+      "src": "672d38bdeb19"
+    },
+    "services.drawcustom.fields.payload.description": {
+      "out": "b7f39b62bb92",
+      "src": "a72e3d514ead"
+    },
+    "services.drawcustom.fields.payload.name": {
+      "out": "ccc72cfa3a65",
+      "src": "99733344956d"
+    },
+    "services.drawcustom.fields.refresh_type.description": {
+      "out": "0738ab314ced",
+      "src": "d87a3d5c4d06"
+    },
+    "services.drawcustom.fields.refresh_type.name": {
+      "out": "fd61a7155b28",
+      "src": "201b25b874bb"
+    },
+    "services.drawcustom.fields.rotate.description": {
+      "out": "773fcdf3be50",
+      "src": "21e39f93db71"
+    },
+    "services.drawcustom.fields.rotate.name": {
+      "out": "212c09d28b0c",
+      "src": "57b5e2fc1bba"
+    },
+    "services.drawcustom.name": {
+      "out": "8d49c980745b",
+      "src": "d0df7a6244ea"
+    },
+    "services.upload_image.description": {
+      "out": "c2473cdf6eaa",
+      "src": "24e19354eaa4"
+    },
+    "services.upload_image.fields.device_id.description": {
+      "out": "215db5502603",
+      "src": "ee157333391e"
+    },
+    "services.upload_image.fields.device_id.name": {
+      "out": "b32db78620d9",
+      "src": "6ba0bdeccb42"
+    },
+    "services.upload_image.fields.dither_mode.description": {
+      "out": "8e4f53567201",
+      "src": "70483fdfe7ec"
+    },
+    "services.upload_image.fields.dither_mode.name": {
+      "out": "ed8bce595a2d",
+      "src": "35fb13830002"
+    },
+    "services.upload_image.fields.fit_mode.description": {
+      "out": "43bfe09eec5c",
+      "src": "8d2c8735a962"
+    },
+    "services.upload_image.fields.fit_mode.name": {
+      "out": "2eac0bac98fc",
+      "src": "8a59790c9187"
+    },
+    "services.upload_image.fields.image.description": {
+      "out": "3a51963f6e02",
+      "src": "ba6d9fb759b0"
+    },
+    "services.upload_image.fields.image.name": {
+      "out": "375e84034b8f",
+      "src": "1aa4cb0bcca7"
+    },
+    "services.upload_image.fields.measured_palette.description": {
+      "out": "025f11aa9800",
+      "src": "53842124c7af"
+    },
+    "services.upload_image.fields.measured_palette.name": {
+      "out": "708f2b8f834d",
+      "src": "672d38bdeb19"
+    },
+    "services.upload_image.fields.refresh_mode.description": {
+      "out": "af677ca92e0c",
+      "src": "0fe957da240a"
+    },
+    "services.upload_image.fields.refresh_mode.name": {
+      "out": "97584ab5521b",
+      "src": "c72fd253298c"
+    },
+    "services.upload_image.fields.rotation.description": {
+      "out": "f58b8d4fb11e",
+      "src": "b639ab27209e"
+    },
+    "services.upload_image.fields.rotation.name": {
+      "out": "57b5e2fc1bba",
+      "src": "57b5e2fc1bba"
+    },
+    "services.upload_image.fields.tone_compression.description": {
+      "out": "6be7b829aaa4",
+      "src": "6453b45ae0cc"
+    },
+    "services.upload_image.fields.tone_compression.name": {
+      "out": "91bc0fc58b48",
+      "src": "ffaed65f03fa"
+    },
+    "services.upload_image.name": {
+      "out": "3c66c01e1539",
+      "src": "ffe4df6c7ca6"
+    },
+    "services.upload_image.sections.additional_fields.name": {
+      "out": "75b8b3d83662",
+      "src": "092170b2408b"
+    },
+    "services.write_nfc.description": {
+      "out": "2c3f5d1d2105",
+      "src": "3c1f6a6d643e"
+    },
+    "services.write_nfc.fields.content.description": {
+      "out": "17d81bf1d44b",
+      "src": "857d1cf0bf90"
+    },
+    "services.write_nfc.fields.content.name": {
+      "out": "3cc46559245d",
+      "src": "47bd29075f8b"
+    },
+    "services.write_nfc.fields.device_id.description": {
+      "out": "c9d3248db546",
+      "src": "7dec980cb238"
+    },
+    "services.write_nfc.fields.device_id.name": {
+      "out": "b32db78620d9",
+      "src": "6ba0bdeccb42"
+    },
+    "services.write_nfc.fields.mime_type.description": {
+      "out": "d5b1dd414bee",
+      "src": "4eb2b40ec666"
+    },
+    "services.write_nfc.fields.mime_type.name": {
+      "out": "5d5e7aa3f6ee",
+      "src": "849e8a810960"
+    },
+    "services.write_nfc.fields.record_type.description": {
+      "out": "dad34c14e3bc",
+      "src": "936cf634012f"
+    },
+    "services.write_nfc.fields.record_type.name": {
+      "out": "2cb82579c833",
+      "src": "91cf117b1d70"
+    },
+    "services.write_nfc.name": {
+      "out": "c9c85a560a98",
+      "src": "96ea14b97cf7"
+    }
+  },
+  "es": {
+    "config.abort.already_configured": {
+      "out": "dd16eb9b2a75",
+      "src": "c2936e02a0d2"
+    },
+    "config.abort.already_in_progress": {
+      "out": "c2f93a25217c",
+      "src": "985a72ad93a3"
+    },
+    "config.abort.cannot_connect": {
+      "out": "1e70a9f3dc49",
+      "src": "46c9f3b7520f"
+    },
+    "config.abort.no_devices_found": {
+      "out": "937384f4f174",
+      "src": "b8f28e84cf0b"
+    },
+    "config.abort.reauth_successful": {
+      "out": "cb0be5c2d01f",
+      "src": "e5b83989735c"
+    },
+    "config.abort.unknown": {
+      "out": "52f98b7958d0",
+      "src": "d24c41ae530a"
+    },
+    "config.error.cannot_connect": {
+      "out": "1e70a9f3dc49",
+      "src": "46c9f3b7520f"
+    },
+    "config.error.invalid_auth": {
+      "out": "3b1fcaaaaaf0",
+      "src": "4ca089878c5f"
+    },
+    "config.error.invalid_key_format": {
+      "out": "33cfd75d440f",
+      "src": "f7b03dd699df"
+    },
+    "config.error.unknown": {
+      "out": "52f98b7958d0",
+      "src": "d24c41ae530a"
+    },
+    "config.flow_title": {
+      "out": "5e291d7bcb2d",
+      "src": "5e291d7bcb2d"
+    },
+    "config.step.bluetooth_confirm.description": {
+      "out": "9e758bdb4d0a",
+      "src": "bcfd5a24b7d7"
+    },
+    "config.step.encryption_key.data.encryption_key": {
+      "out": "7b8e165b5050",
+      "src": "16b3c9d5573d"
+    },
+    "config.step.encryption_key.data_description.encryption_key": {
+      "out": "7658bd7644c9",
+      "src": "e64cd2e7e647"
+    },
+    "config.step.encryption_key.description": {
+      "out": "150036380590",
+      "src": "664d3f12bfe6"
+    },
+    "config.step.encryption_key.title": {
+      "out": "c11abaf0036c",
+      "src": "c30d1ca158a3"
+    },
+    "config.step.reauth_confirm.data.encryption_key": {
+      "out": "7b8e165b5050",
+      "src": "16b3c9d5573d"
+    },
+    "config.step.reauth_confirm.data_description.encryption_key": {
+      "out": "7658bd7644c9",
+      "src": "e64cd2e7e647"
+    },
+    "config.step.reauth_confirm.description": {
+      "out": "8a24fca49c56",
+      "src": "f53b69d3be84"
+    },
+    "config.step.reauth_confirm.title": {
+      "out": "d7300d1550af",
+      "src": "7e22a752572f"
+    },
+    "config.step.user.data.address": {
+      "out": "1c555eb7f1c0",
+      "src": "6ba0bdeccb42"
+    },
+    "config.step.user.data_description.address": {
+      "out": "e49a18e28bbe",
+      "src": "a083a457cfb1"
+    },
+    "config.step.user.description": {
+      "out": "d5c6d20003a2",
+      "src": "109135454652"
+    },
+    "entity.binary_sensor.update_pending.name": {
+      "out": "770d7498552f",
+      "src": "8e0a4b18ae75"
+    },
+    "entity.event.button.name": {
+      "out": "5c620d69f4ec",
+      "src": "2dcae43716c2"
+    },
+    "entity.event.button.state_attributes.event_type.state.button_down": {
+      "out": "45313946a254",
+      "src": "8352c89d20b4"
+    },
+    "entity.event.button.state_attributes.event_type.state.button_up": {
+      "out": "d16271a00fab",
+      "src": "7f18b4912929"
+    },
+    "entity.event.touch.name": {
+      "out": "837842a1ac38",
+      "src": "c915d14278fc"
+    },
+    "entity.event.touch.state_attributes.event_type.state.touch_down": {
+      "out": "6ae5f5d15da9",
+      "src": "0234a9576230"
+    },
+    "entity.event.touch.state_attributes.event_type.state.touch_move": {
+      "out": "971b5268e9f4",
+      "src": "67aeac815e94"
+    },
+    "entity.event.touch.state_attributes.event_type.state.touch_up": {
+      "out": "15dacc8e94d6",
+      "src": "7c65519d3bb3"
+    },
+    "entity.image.content.name": {
+      "out": "72294391b47e",
+      "src": "047c6db3382a"
+    },
+    "entity.sensor.battery_voltage.name": {
+      "out": "3c077f56f37d",
+      "src": "39d6c91b57ce"
+    },
+    "entity.sensor.last_seen.name": {
+      "out": "a060c6768208",
+      "src": "21fd79c7de52"
+    },
+    "entity.sensor.rssi.name": {
+      "out": "5bb6ab8219af",
+      "src": "2604d15c1187"
+    },
+    "entity.update.firmware.name": {
+      "out": "c2a314c3b32b",
+      "src": "c2a314c3b32b"
+    },
+    "exceptions.authentication_error.message": {
+      "out": "5b02c9b5bc26",
+      "src": "3d9f7c0c6d80"
+    },
+    "exceptions.device_not_found.message": {
+      "out": "429a0d6f8a18",
+      "src": "f244d0d2db8d"
+    },
+    "exceptions.device_sleeping.message": {
+      "out": "fde6d0c5b622",
+      "src": "e95d25bd6fc7"
+    },
+    "exceptions.device_sleeping_ota.message": {
+      "out": "7e66b9304d9a",
+      "src": "430e3a1baa6a"
+    },
+    "exceptions.invalid_device_id.message": {
+      "out": "bd59236488fd",
+      "src": "cc64cc29ceeb"
+    },
+    "exceptions.media_download_error.message": {
+      "out": "afbf6cb62c7e",
+      "src": "5852129dd920"
+    },
+    "exceptions.mime_type_not_applicable.message": {
+      "out": "02b2528c1eb9",
+      "src": "de700f02fbd5"
+    },
+    "exceptions.multiple_errors.message": {
+      "out": "e8f50cf5816c",
+      "src": "f17c68e0a848"
+    },
+    "exceptions.nfc_content_empty.message": {
+      "out": "389e03d6cb91",
+      "src": "b93a1a6ebdc0"
+    },
+    "exceptions.nfc_content_too_long.message": {
+      "out": "0f561eaef7da",
+      "src": "8f580b9c6c76"
+    },
+    "exceptions.nfc_mime_type_invalid.message": {
+      "out": "aa8eb3a440ee",
+      "src": "5a5f44fe332f"
+    },
+    "exceptions.nfc_not_supported.message": {
+      "out": "01a1efefe4ad",
+      "src": "8fdcd0e2bd17"
+    },
+    "exceptions.nfc_write_failed.message": {
+      "out": "1874bbf4736b",
+      "src": "e8186303a52e"
+    },
+    "exceptions.no_buzzers.message": {
+      "out": "3ca4a205bb3a",
+      "src": "9c014dfeac91"
+    },
+    "exceptions.no_leds.message": {
+      "out": "d9efe35eff01",
+      "src": "6a302f8f22ee"
+    },
+    "exceptions.no_nfc.message": {
+      "out": "be8e2893f1a2",
+      "src": "abb1917ad57e"
+    },
+    "exceptions.no_targets_specified.message": {
+      "out": "6e6821bc84e0",
+      "src": "80c472afefe6"
+    },
+    "exceptions.upload_error.message": {
+      "out": "d063ac6d2b60",
+      "src": "75561a03be6e"
+    },
+    "exceptions.url_not_allowed.message": {
+      "out": "fdebaa8d51f1",
+      "src": "33ffb9a9f2c4"
+    },
+    "options.step.init.data.blocks_per_ack": {
+      "out": "b91e673e4faf",
+      "src": "3e2a554e69a4"
+    },
+    "options.step.init.data.max_queue_size": {
+      "out": "1671be9585ae",
+      "src": "297af7027dd0"
+    },
+    "options.step.init.data.missed_cycles": {
+      "out": "bc59bb521ef0",
+      "src": "59b78644491a"
+    },
+    "options.step.init.data.probe_before_queue": {
+      "out": "d405f26fdc62",
+      "src": "02c4211a58b2"
+    },
+    "options.step.init.data.queue_timeout_hours": {
+      "out": "3e8f0ba214cd",
+      "src": "be70fc5cca79"
+    },
+    "options.step.init.data.sleep_mode": {
+      "out": "f3cf6e015b6a",
+      "src": "f925c0e541ce"
+    },
+    "options.step.init.data_description.blocks_per_ack": {
+      "out": "6889f1dbf50f",
+      "src": "3a693b19d3c6"
+    },
+    "options.step.init.data_description.max_queue_size": {
+      "out": "f881059664b0",
+      "src": "50260959ee56"
+    },
+    "options.step.init.data_description.missed_cycles": {
+      "out": "7e06bb92b5e6",
+      "src": "6ce493f4c44d"
+    },
+    "options.step.init.data_description.probe_before_queue": {
+      "out": "3ebce5e98b85",
+      "src": "5d0f2985ffdf"
+    },
+    "options.step.init.data_description.queue_timeout_hours": {
+      "out": "e1654af72ec8",
+      "src": "34895000b491"
+    },
+    "options.step.init.data_description.sleep_mode": {
+      "out": "2a5cd5643b95",
+      "src": "4acfeb65d10d"
+    },
+    "selector.dither_mode.options.atkinson": {
+      "out": "7a8fe6d47b5b",
+      "src": "7a8fe6d47b5b"
+    },
+    "selector.dither_mode.options.burkes": {
+      "out": "1b75087201fb",
+      "src": "1b75087201fb"
+    },
+    "selector.dither_mode.options.floyd_steinberg": {
+      "out": "37969811a3cf",
+      "src": "37969811a3cf"
+    },
+    "selector.dither_mode.options.jarvis_judice_ninke": {
+      "out": "7020241adf78",
+      "src": "7020241adf78"
+    },
+    "selector.dither_mode.options.none": {
+      "out": "9e3fc69d0d9c",
+      "src": "dc937b598926"
+    },
+    "selector.dither_mode.options.ordered": {
+      "out": "d2aba6849adb",
+      "src": "007877479e21"
+    },
+    "selector.dither_mode.options.sierra": {
+      "out": "d5eef8ad210c",
+      "src": "d5eef8ad210c"
+    },
+    "selector.dither_mode.options.sierra_lite": {
+      "out": "20da8cc85f38",
+      "src": "20da8cc85f38"
+    },
+    "selector.dither_mode.options.stucki": {
+      "out": "a17d2b13b6f9",
+      "src": "a17d2b13b6f9"
+    },
+    "selector.fit_mode.options.contain": {
+      "out": "851222f34c5f",
+      "src": "e534a2c2b456"
+    },
+    "selector.fit_mode.options.cover": {
+      "out": "35412ce9814f",
+      "src": "fa8d84566676"
+    },
+    "selector.fit_mode.options.crop": {
+      "out": "b659da7fa50d",
+      "src": "98caf7c43c6f"
+    },
+    "selector.fit_mode.options.stretch": {
+      "out": "28200ccf7067",
+      "src": "a33fbcf83f7b"
+    },
+    "selector.nfc_record_type.options.ha_tag": {
+      "out": "2e30ed3e033c",
+      "src": "d1d47a8fa544"
+    },
+    "selector.nfc_record_type.options.mime": {
+      "out": "675a2649dd2c",
+      "src": "f98d7539e627"
+    },
+    "selector.nfc_record_type.options.text": {
+      "out": "6df3d6661c09",
+      "src": "71988c4d8e08"
+    },
+    "selector.nfc_record_type.options.url": {
+      "out": "e7a241debad5",
+      "src": "e7a241debad5"
+    },
+    "selector.refresh_mode.options.fast": {
+      "out": "76495f26e6c5",
+      "src": "6c582b62e0e5"
+    },
+    "selector.refresh_mode.options.full": {
+      "out": "23e3685fbe6c",
+      "src": "008dacb6d1e8"
+    },
+    "selector.refresh_mode.options.partial": {
+      "out": "154b61b1e9da",
+      "src": "a4d50fb85403"
+    },
+    "selector.sleep_mode.options.auto": {
+      "out": "7557cb15b0a8",
+      "src": "132990bd8ef7"
+    },
+    "selector.sleep_mode.options.off": {
+      "out": "17e645e9a836",
+      "src": "34598efe7b90"
+    },
+    "selector.sleep_mode.options.on": {
+      "out": "a8d3c0a8fea3",
+      "src": "bde131e31c9e"
+    },
+    "services.activate_buzzer.description": {
+      "out": "cc0fc0af56e3",
+      "src": "1898784614cb"
+    },
+    "services.activate_buzzer.fields.device_id.description": {
+      "out": "1abb38711bf0",
+      "src": "7dec980cb238"
+    },
+    "services.activate_buzzer.fields.device_id.name": {
+      "out": "1c555eb7f1c0",
+      "src": "6ba0bdeccb42"
+    },
+    "services.activate_buzzer.fields.duration_ms.description": {
+      "out": "55829e4c8ec4",
+      "src": "cd1bc75ca60c"
+    },
+    "services.activate_buzzer.fields.duration_ms.name": {
+      "out": "d5a804455b33",
+      "src": "4fc52a3c4c55"
+    },
+    "services.activate_buzzer.fields.frequency_hz.description": {
+      "out": "dd6565014d9f",
+      "src": "510fc20311e3"
+    },
+    "services.activate_buzzer.fields.frequency_hz.name": {
+      "out": "e1867c7f9bb3",
+      "src": "16b6668d9831"
+    },
+    "services.activate_buzzer.fields.instance.description": {
+      "out": "a4c148743acd",
+      "src": "f39fa742d55c"
+    },
+    "services.activate_buzzer.fields.instance.name": {
+      "out": "1fcf4383db04",
+      "src": "1f671ddded9e"
+    },
+    "services.activate_buzzer.fields.repeats.description": {
+      "out": "b31ad43cd3ad",
+      "src": "1f88b0fe23ea"
+    },
+    "services.activate_buzzer.fields.repeats.name": {
+      "out": "f79916caa78b",
+      "src": "92ee0233f013"
+    },
+    "services.activate_buzzer.name": {
+      "out": "f4a96e4ec649",
+      "src": "0b80285753b7"
+    },
+    "services.activate_led.description": {
+      "out": "0774a9448d1d",
+      "src": "6cbd645597cc"
+    },
+    "services.activate_led.fields.brightness.description": {
+      "out": "9765bddfe191",
+      "src": "6ad88a28230d"
+    },
+    "services.activate_led.fields.brightness.name": {
+      "out": "97eba63984ea",
+      "src": "ec811d30a89c"
+    },
+    "services.activate_led.fields.color1.description": {
+      "out": "a59a193a8c40",
+      "src": "17f145013241"
+    },
+    "services.activate_led.fields.color1.name": {
+      "out": "571461f36f3a",
+      "src": "571461f36f3a"
+    },
+    "services.activate_led.fields.color2.description": {
+      "out": "07f8706b6fd1",
+      "src": "f2680a4bbe85"
+    },
+    "services.activate_led.fields.color2.name": {
+      "out": "ef792d287872",
+      "src": "ef792d287872"
+    },
+    "services.activate_led.fields.color3.description": {
+      "out": "751df2cbe30a",
+      "src": "b8ecd353b426"
+    },
+    "services.activate_led.fields.color3.name": {
+      "out": "48d54e046d29",
+      "src": "48d54e046d29"
+    },
+    "services.activate_led.fields.device_id.description": {
+      "out": "1abb38711bf0",
+      "src": "7dec980cb238"
+    },
+    "services.activate_led.fields.device_id.name": {
+      "out": "1c555eb7f1c0",
+      "src": "6ba0bdeccb42"
+    },
+    "services.activate_led.fields.flash_count1.description": {
+      "out": "62b7188fc74a",
+      "src": "4ffdadde31c2"
+    },
+    "services.activate_led.fields.flash_count1.name": {
+      "out": "e4eb946b1e4b",
+      "src": "13c6a2e5c22e"
+    },
+    "services.activate_led.fields.flash_count2.description": {
+      "out": "50bba8936ba7",
+      "src": "86dc999a3915"
+    },
+    "services.activate_led.fields.flash_count2.name": {
+      "out": "91cea4d40186",
+      "src": "2be36d8449dc"
+    },
+    "services.activate_led.fields.flash_count3.description": {
+      "out": "26e686815172",
+      "src": "aa40c396a9a4"
+    },
+    "services.activate_led.fields.flash_count3.name": {
+      "out": "65100acca399",
+      "src": "7978910dc6b2"
+    },
+    "services.activate_led.fields.instance.description": {
+      "out": "7bd1d7fc1ee5",
+      "src": "0531b37de90a"
+    },
+    "services.activate_led.fields.instance.name": {
+      "out": "1409af6d11c1",
+      "src": "f942926204c7"
+    },
+    "services.activate_led.fields.inter_delay1.description": {
+      "out": "2598f2131a5c",
+      "src": "1b65dcfcea95"
+    },
+    "services.activate_led.fields.inter_delay1.name": {
+      "out": "aa8a66be3b10",
+      "src": "71452f436c33"
+    },
+    "services.activate_led.fields.inter_delay2.description": {
+      "out": "5b690d8dba57",
+      "src": "181e03f33cbf"
+    },
+    "services.activate_led.fields.inter_delay2.name": {
+      "out": "94408e5f0772",
+      "src": "6a50551e5355"
+    },
+    "services.activate_led.fields.inter_delay3.description": {
+      "out": "740c2cea3a13",
+      "src": "5c5973b586df"
+    },
+    "services.activate_led.fields.inter_delay3.name": {
+      "out": "66c0832efea2",
+      "src": "b0f72903777e"
+    },
+    "services.activate_led.fields.loop_delay1.description": {
+      "out": "6239f73e6493",
+      "src": "2139915c35bc"
+    },
+    "services.activate_led.fields.loop_delay1.name": {
+      "out": "2c2051517f08",
+      "src": "2fb02375bae0"
+    },
+    "services.activate_led.fields.loop_delay2.description": {
+      "out": "5e55d865cd9c",
+      "src": "9a3a8cccb3bb"
+    },
+    "services.activate_led.fields.loop_delay2.name": {
+      "out": "6bcf605e9726",
+      "src": "597cbe87a7ec"
+    },
+    "services.activate_led.fields.loop_delay3.description": {
+      "out": "550e5d5d2e23",
+      "src": "8a965100226c"
+    },
+    "services.activate_led.fields.loop_delay3.name": {
+      "out": "03e6783a3374",
+      "src": "66d787aa1bad"
+    },
+    "services.activate_led.fields.repeats.description": {
+      "out": "04c389babea3",
+      "src": "e40e956e3762"
+    },
+    "services.activate_led.fields.repeats.name": {
+      "out": "f79916caa78b",
+      "src": "92ee0233f013"
+    },
+    "services.activate_led.name": {
+      "out": "6ab28c868c2c",
+      "src": "91933e94cc57"
+    },
+    "services.drawcustom.description": {
+      "out": "ff11d43a9de1",
+      "src": "55f9f3333fc0"
+    },
+    "services.drawcustom.fields.background.description": {
+      "out": "93c03d5777ac",
+      "src": "f5858405d78a"
+    },
+    "services.drawcustom.fields.background.name": {
+      "out": "f0aa9f5d3189",
+      "src": "3e314dafdf7c"
+    },
+    "services.drawcustom.fields.dither.description": {
+      "out": "182bfe9a390d",
+      "src": "d7c737e5d01e"
+    },
+    "services.drawcustom.fields.dither.name": {
+      "out": "4c79b79008bf",
+      "src": "35fb13830002"
+    },
+    "services.drawcustom.fields.dry-run.description": {
+      "out": "71e228b60201",
+      "src": "54f5f06db00c"
+    },
+    "services.drawcustom.fields.dry-run.name": {
+      "out": "23b48c51e67e",
+      "src": "d5da154d9f00"
+    },
+    "services.drawcustom.fields.measured_palette.description": {
+      "out": "7c4bf4976978",
+      "src": "53842124c7af"
+    },
+    "services.drawcustom.fields.measured_palette.name": {
+      "out": "2e8f0e046ee9",
+      "src": "672d38bdeb19"
+    },
+    "services.drawcustom.fields.payload.description": {
+      "out": "1f277869a66c",
+      "src": "a72e3d514ead"
+    },
+    "services.drawcustom.fields.payload.name": {
+      "out": "197c7a8551b9",
+      "src": "99733344956d"
+    },
+    "services.drawcustom.fields.refresh_type.description": {
+      "out": "1c236fb206cb",
+      "src": "d87a3d5c4d06"
+    },
+    "services.drawcustom.fields.refresh_type.name": {
+      "out": "d7e535a49776",
+      "src": "201b25b874bb"
+    },
+    "services.drawcustom.fields.rotate.description": {
+      "out": "1b7401e22dc3",
+      "src": "21e39f93db71"
+    },
+    "services.drawcustom.fields.rotate.name": {
+      "out": "f56c9e94479b",
+      "src": "57b5e2fc1bba"
+    },
+    "services.drawcustom.name": {
+      "out": "9d9d1493716c",
+      "src": "d0df7a6244ea"
+    },
+    "services.upload_image.description": {
+      "out": "5c90f31d0b7a",
+      "src": "24e19354eaa4"
+    },
+    "services.upload_image.fields.device_id.description": {
+      "out": "7142f7889872",
+      "src": "ee157333391e"
+    },
+    "services.upload_image.fields.device_id.name": {
+      "out": "1c555eb7f1c0",
+      "src": "6ba0bdeccb42"
+    },
+    "services.upload_image.fields.dither_mode.description": {
+      "out": "2ff1f6714137",
+      "src": "70483fdfe7ec"
+    },
+    "services.upload_image.fields.dither_mode.name": {
+      "out": "4c79b79008bf",
+      "src": "35fb13830002"
+    },
+    "services.upload_image.fields.fit_mode.description": {
+      "out": "4bcb27af868d",
+      "src": "8d2c8735a962"
+    },
+    "services.upload_image.fields.fit_mode.name": {
+      "out": "66d2c4bb0197",
+      "src": "8a59790c9187"
+    },
+    "services.upload_image.fields.image.description": {
+      "out": "8c4b63c8533f",
+      "src": "ba6d9fb759b0"
+    },
+    "services.upload_image.fields.image.name": {
+      "out": "58d6f29b0633",
+      "src": "1aa4cb0bcca7"
+    },
+    "services.upload_image.fields.measured_palette.description": {
+      "out": "923de416cd8b",
+      "src": "53842124c7af"
+    },
+    "services.upload_image.fields.measured_palette.name": {
+      "out": "2e8f0e046ee9",
+      "src": "672d38bdeb19"
+    },
+    "services.upload_image.fields.refresh_mode.description": {
+      "out": "ed81e0545ff2",
+      "src": "0fe957da240a"
+    },
+    "services.upload_image.fields.refresh_mode.name": {
+      "out": "61221d25a7e7",
+      "src": "c72fd253298c"
+    },
+    "services.upload_image.fields.rotation.description": {
+      "out": "2312f865f3eb",
+      "src": "b639ab27209e"
+    },
+    "services.upload_image.fields.rotation.name": {
+      "out": "f56c9e94479b",
+      "src": "57b5e2fc1bba"
+    },
+    "services.upload_image.fields.tone_compression.description": {
+      "out": "2c98409c9bcf",
+      "src": "6453b45ae0cc"
+    },
+    "services.upload_image.fields.tone_compression.name": {
+      "out": "b3c4094e9866",
+      "src": "ffaed65f03fa"
+    },
+    "services.upload_image.name": {
+      "out": "251f0755f51e",
+      "src": "ffe4df6c7ca6"
+    },
+    "services.upload_image.sections.additional_fields.name": {
+      "out": "952d9c9c77ef",
+      "src": "092170b2408b"
+    },
+    "services.write_nfc.description": {
+      "out": "1206225cdf06",
+      "src": "3c1f6a6d643e"
+    },
+    "services.write_nfc.fields.content.description": {
+      "out": "a62ea9447049",
+      "src": "857d1cf0bf90"
+    },
+    "services.write_nfc.fields.content.name": {
+      "out": "197c7a8551b9",
+      "src": "47bd29075f8b"
+    },
+    "services.write_nfc.fields.device_id.description": {
+      "out": "1abb38711bf0",
+      "src": "7dec980cb238"
+    },
+    "services.write_nfc.fields.device_id.name": {
+      "out": "1c555eb7f1c0",
+      "src": "6ba0bdeccb42"
+    },
+    "services.write_nfc.fields.mime_type.description": {
+      "out": "1812c5bb0384",
+      "src": "4eb2b40ec666"
+    },
+    "services.write_nfc.fields.mime_type.name": {
+      "out": "899f5b786081",
+      "src": "849e8a810960"
+    },
+    "services.write_nfc.fields.record_type.description": {
+      "out": "b33b53833622",
+      "src": "936cf634012f"
+    },
+    "services.write_nfc.fields.record_type.name": {
+      "out": "ffc69bba602f",
+      "src": "91cf117b1d70"
+    },
+    "services.write_nfc.name": {
+      "out": "a1c857ba57fc",
+      "src": "96ea14b97cf7"
+    }
+  },
+  "fr": {
+    "config.abort.already_configured": {
+      "out": "ddcf916e028b",
+      "src": "c2936e02a0d2"
+    },
+    "config.abort.already_in_progress": {
+      "out": "7c2816cd6d80",
+      "src": "985a72ad93a3"
+    },
+    "config.abort.cannot_connect": {
+      "out": "17170dfd78ae",
+      "src": "46c9f3b7520f"
+    },
+    "config.abort.no_devices_found": {
+      "out": "a74e2b5f5a8c",
+      "src": "b8f28e84cf0b"
+    },
+    "config.abort.reauth_successful": {
+      "out": "66f6fc1dae36",
+      "src": "e5b83989735c"
+    },
+    "config.abort.unknown": {
+      "out": "081fa1eabc25",
+      "src": "d24c41ae530a"
+    },
+    "config.error.cannot_connect": {
+      "out": "17170dfd78ae",
+      "src": "46c9f3b7520f"
+    },
+    "config.error.invalid_auth": {
+      "out": "197d22a8b406",
+      "src": "4ca089878c5f"
+    },
+    "config.error.invalid_key_format": {
+      "out": "5649b04c07f4",
+      "src": "f7b03dd699df"
+    },
+    "config.error.unknown": {
+      "out": "081fa1eabc25",
+      "src": "d24c41ae530a"
+    },
+    "config.flow_title": {
+      "out": "5e291d7bcb2d",
+      "src": "5e291d7bcb2d"
+    },
+    "config.step.bluetooth_confirm.description": {
+      "out": "8383206ea254",
+      "src": "bcfd5a24b7d7"
+    },
+    "config.step.encryption_key.data.encryption_key": {
+      "out": "17e907e85e0b",
+      "src": "16b3c9d5573d"
+    },
+    "config.step.encryption_key.data_description.encryption_key": {
+      "out": "fe0b56099a97",
+      "src": "e64cd2e7e647"
+    },
+    "config.step.encryption_key.description": {
+      "out": "0df36bba6c56",
+      "src": "664d3f12bfe6"
+    },
+    "config.step.encryption_key.title": {
+      "out": "3edac433f3d0",
+      "src": "c30d1ca158a3"
+    },
+    "config.step.reauth_confirm.data.encryption_key": {
+      "out": "17e907e85e0b",
+      "src": "16b3c9d5573d"
+    },
+    "config.step.reauth_confirm.data_description.encryption_key": {
+      "out": "fe0b56099a97",
+      "src": "e64cd2e7e647"
+    },
+    "config.step.reauth_confirm.description": {
+      "out": "d1e5f2e357ce",
+      "src": "f53b69d3be84"
+    },
+    "config.step.reauth_confirm.title": {
+      "out": "e8d8fd1d16bd",
+      "src": "7e22a752572f"
+    },
+    "config.step.user.data.address": {
+      "out": "0944613acb42",
+      "src": "6ba0bdeccb42"
+    },
+    "config.step.user.data_description.address": {
+      "out": "43c23b9cad0e",
+      "src": "a083a457cfb1"
+    },
+    "config.step.user.description": {
+      "out": "dbe5232de45c",
+      "src": "109135454652"
+    },
+    "entity.binary_sensor.update_pending.name": {
+      "out": "664c4836055e",
+      "src": "8e0a4b18ae75"
+    },
+    "entity.event.button.name": {
+      "out": "26ed1f392213",
+      "src": "2dcae43716c2"
+    },
+    "entity.event.button.state_attributes.event_type.state.button_down": {
+      "out": "bace38079c90",
+      "src": "8352c89d20b4"
+    },
+    "entity.event.button.state_attributes.event_type.state.button_up": {
+      "out": "4ca6cfa38863",
+      "src": "7f18b4912929"
+    },
+    "entity.event.touch.name": {
+      "out": "3aad1d2fe736",
+      "src": "c915d14278fc"
+    },
+    "entity.event.touch.state_attributes.event_type.state.touch_down": {
+      "out": "80075b7a2494",
+      "src": "0234a9576230"
+    },
+    "entity.event.touch.state_attributes.event_type.state.touch_move": {
+      "out": "5c9d355e128f",
+      "src": "67aeac815e94"
+    },
+    "entity.event.touch.state_attributes.event_type.state.touch_up": {
+      "out": "196cd58bed8c",
+      "src": "7c65519d3bb3"
+    },
+    "entity.image.content.name": {
+      "out": "3011d34c82c6",
+      "src": "047c6db3382a"
+    },
+    "entity.sensor.battery_voltage.name": {
+      "out": "72df7d138a1b",
+      "src": "39d6c91b57ce"
+    },
+    "entity.sensor.last_seen.name": {
+      "out": "fceee0a4da07",
+      "src": "21fd79c7de52"
+    },
+    "entity.sensor.rssi.name": {
+      "out": "a92896600aad",
+      "src": "2604d15c1187"
+    },
+    "entity.update.firmware.name": {
+      "out": "c2a314c3b32b",
+      "src": "c2a314c3b32b"
+    },
+    "exceptions.authentication_error.message": {
+      "out": "b4c0bb1725b5",
+      "src": "3d9f7c0c6d80"
+    },
+    "exceptions.device_not_found.message": {
+      "out": "d749244c1514",
+      "src": "f244d0d2db8d"
+    },
+    "exceptions.device_sleeping.message": {
+      "out": "889ea0aa7ffc",
+      "src": "e95d25bd6fc7"
+    },
+    "exceptions.device_sleeping_ota.message": {
+      "out": "05d2ec6a3e74",
+      "src": "430e3a1baa6a"
+    },
+    "exceptions.invalid_device_id.message": {
+      "out": "4bf835acb87c",
+      "src": "cc64cc29ceeb"
+    },
+    "exceptions.media_download_error.message": {
+      "out": "7d55b66d49f3",
+      "src": "5852129dd920"
+    },
+    "exceptions.mime_type_not_applicable.message": {
+      "out": "a5316efa502d",
+      "src": "de700f02fbd5"
+    },
+    "exceptions.multiple_errors.message": {
+      "out": "2f8e69a4d79e",
+      "src": "f17c68e0a848"
+    },
+    "exceptions.nfc_content_empty.message": {
+      "out": "850fac77feb5",
+      "src": "b93a1a6ebdc0"
+    },
+    "exceptions.nfc_content_too_long.message": {
+      "out": "dd3690534c8a",
+      "src": "8f580b9c6c76"
+    },
+    "exceptions.nfc_mime_type_invalid.message": {
+      "out": "74b56e4a452f",
+      "src": "5a5f44fe332f"
+    },
+    "exceptions.nfc_not_supported.message": {
+      "out": "293b2ad78093",
+      "src": "8fdcd0e2bd17"
+    },
+    "exceptions.nfc_write_failed.message": {
+      "out": "63a5192b8da9",
+      "src": "e8186303a52e"
+    },
+    "exceptions.no_buzzers.message": {
+      "out": "56d1132c4d37",
+      "src": "9c014dfeac91"
+    },
+    "exceptions.no_leds.message": {
+      "out": "d1f16357f872",
+      "src": "6a302f8f22ee"
+    },
+    "exceptions.no_nfc.message": {
+      "out": "f8e4904c0963",
+      "src": "abb1917ad57e"
+    },
+    "exceptions.no_targets_specified.message": {
+      "out": "1fb3bf9319c3",
+      "src": "80c472afefe6"
+    },
+    "exceptions.upload_error.message": {
+      "out": "e9e642fc50a4",
+      "src": "75561a03be6e"
+    },
+    "exceptions.url_not_allowed.message": {
+      "out": "b1f7216a69d7",
+      "src": "33ffb9a9f2c4"
+    },
+    "options.step.init.data.blocks_per_ack": {
+      "out": "3300b9e0cebf",
+      "src": "3e2a554e69a4"
+    },
+    "options.step.init.data.max_queue_size": {
+      "out": "1672db0ce89a",
+      "src": "297af7027dd0"
+    },
+    "options.step.init.data.missed_cycles": {
+      "out": "7c2dcd44d53f",
+      "src": "59b78644491a"
+    },
+    "options.step.init.data.probe_before_queue": {
+      "out": "7326df0d45b5",
+      "src": "02c4211a58b2"
+    },
+    "options.step.init.data.queue_timeout_hours": {
+      "out": "05c55ba4d9dc",
+      "src": "be70fc5cca79"
+    },
+    "options.step.init.data.sleep_mode": {
+      "out": "721a2fa80853",
+      "src": "f925c0e541ce"
+    },
+    "options.step.init.data_description.blocks_per_ack": {
+      "out": "ccf6e5c8e365",
+      "src": "3a693b19d3c6"
+    },
+    "options.step.init.data_description.max_queue_size": {
+      "out": "f1ed4a0e52a1",
+      "src": "50260959ee56"
+    },
+    "options.step.init.data_description.missed_cycles": {
+      "out": "9bf19cd10627",
+      "src": "6ce493f4c44d"
+    },
+    "options.step.init.data_description.probe_before_queue": {
+      "out": "f3a13221e19f",
+      "src": "5d0f2985ffdf"
+    },
+    "options.step.init.data_description.queue_timeout_hours": {
+      "out": "e7e28fb41366",
+      "src": "34895000b491"
+    },
+    "options.step.init.data_description.sleep_mode": {
+      "out": "3aaf61fc6ac2",
+      "src": "4acfeb65d10d"
+    },
+    "selector.dither_mode.options.atkinson": {
+      "out": "7a8fe6d47b5b",
+      "src": "7a8fe6d47b5b"
+    },
+    "selector.dither_mode.options.burkes": {
+      "out": "1b75087201fb",
+      "src": "1b75087201fb"
+    },
+    "selector.dither_mode.options.floyd_steinberg": {
+      "out": "37969811a3cf",
+      "src": "37969811a3cf"
+    },
+    "selector.dither_mode.options.jarvis_judice_ninke": {
+      "out": "7020241adf78",
+      "src": "7020241adf78"
+    },
+    "selector.dither_mode.options.none": {
+      "out": "4679b3b12de0",
+      "src": "dc937b598926"
+    },
+    "selector.dither_mode.options.ordered": {
+      "out": "cdb45168b277",
+      "src": "007877479e21"
+    },
+    "selector.dither_mode.options.sierra": {
+      "out": "d5eef8ad210c",
+      "src": "d5eef8ad210c"
+    },
+    "selector.dither_mode.options.sierra_lite": {
+      "out": "20da8cc85f38",
+      "src": "20da8cc85f38"
+    },
+    "selector.dither_mode.options.stucki": {
+      "out": "a17d2b13b6f9",
+      "src": "a17d2b13b6f9"
+    },
+    "selector.fit_mode.options.contain": {
+      "out": "ee539ab5622c",
+      "src": "e534a2c2b456"
+    },
+    "selector.fit_mode.options.cover": {
+      "out": "f5ce6a5c15ed",
+      "src": "fa8d84566676"
+    },
+    "selector.fit_mode.options.crop": {
+      "out": "950eefa4273c",
+      "src": "98caf7c43c6f"
+    },
+    "selector.fit_mode.options.stretch": {
+      "out": "1718c5d331e3",
+      "src": "a33fbcf83f7b"
+    },
+    "selector.nfc_record_type.options.ha_tag": {
+      "out": "3321c29be0cd",
+      "src": "d1d47a8fa544"
+    },
+    "selector.nfc_record_type.options.mime": {
+      "out": "c4f15166f874",
+      "src": "f98d7539e627"
+    },
+    "selector.nfc_record_type.options.text": {
+      "out": "bbb0bd5ff551",
+      "src": "71988c4d8e08"
+    },
+    "selector.nfc_record_type.options.url": {
+      "out": "e7a241debad5",
+      "src": "e7a241debad5"
+    },
+    "selector.refresh_mode.options.fast": {
+      "out": "7939084e40f0",
+      "src": "6c582b62e0e5"
+    },
+    "selector.refresh_mode.options.full": {
+      "out": "7392885bd96b",
+      "src": "008dacb6d1e8"
+    },
+    "selector.refresh_mode.options.partial": {
+      "out": "e9d830119d27",
+      "src": "a4d50fb85403"
+    },
+    "selector.sleep_mode.options.auto": {
+      "out": "adfa4f4ae4a5",
+      "src": "132990bd8ef7"
+    },
+    "selector.sleep_mode.options.off": {
+      "out": "25be7e94bda2",
+      "src": "34598efe7b90"
+    },
+    "selector.sleep_mode.options.on": {
+      "out": "6ee4373ffd3b",
+      "src": "bde131e31c9e"
+    },
+    "services.activate_buzzer.description": {
+      "out": "cb350aff2b76",
+      "src": "1898784614cb"
+    },
+    "services.activate_buzzer.fields.device_id.description": {
+      "out": "70b3a453ffac",
+      "src": "7dec980cb238"
+    },
+    "services.activate_buzzer.fields.device_id.name": {
+      "out": "0944613acb42",
+      "src": "6ba0bdeccb42"
+    },
+    "services.activate_buzzer.fields.duration_ms.description": {
+      "out": "03a889f7b901",
+      "src": "cd1bc75ca60c"
+    },
+    "services.activate_buzzer.fields.duration_ms.name": {
+      "out": "71d0bad42af1",
+      "src": "4fc52a3c4c55"
+    },
+    "services.activate_buzzer.fields.frequency_hz.description": {
+      "out": "fc0ce13b0f4d",
+      "src": "510fc20311e3"
+    },
+    "services.activate_buzzer.fields.frequency_hz.name": {
+      "out": "12a58326f853",
+      "src": "16b6668d9831"
+    },
+    "services.activate_buzzer.fields.instance.description": {
+      "out": "4366b86eb121",
+      "src": "f39fa742d55c"
+    },
+    "services.activate_buzzer.fields.instance.name": {
+      "out": "78702905a0c4",
+      "src": "1f671ddded9e"
+    },
+    "services.activate_buzzer.fields.repeats.description": {
+      "out": "ac3129830ca9",
+      "src": "1f88b0fe23ea"
+    },
+    "services.activate_buzzer.fields.repeats.name": {
+      "out": "007319cdfdac",
+      "src": "92ee0233f013"
+    },
+    "services.activate_buzzer.name": {
+      "out": "3526c173a0ed",
+      "src": "0b80285753b7"
+    },
+    "services.activate_led.description": {
+      "out": "7cf3c32ec9b0",
+      "src": "6cbd645597cc"
+    },
+    "services.activate_led.fields.brightness.description": {
+      "out": "6a1f93de35ee",
+      "src": "6ad88a28230d"
+    },
+    "services.activate_led.fields.brightness.name": {
+      "out": "5b661b4e3e14",
+      "src": "ec811d30a89c"
+    },
+    "services.activate_led.fields.color1.description": {
+      "out": "13194efc50e6",
+      "src": "17f145013241"
+    },
+    "services.activate_led.fields.color1.name": {
+      "out": "dbaa7ba8e16b",
+      "src": "571461f36f3a"
+    },
+    "services.activate_led.fields.color2.description": {
+      "out": "622a170f52c6",
+      "src": "f2680a4bbe85"
+    },
+    "services.activate_led.fields.color2.name": {
+      "out": "78419b181d48",
+      "src": "ef792d287872"
+    },
+    "services.activate_led.fields.color3.description": {
+      "out": "9b14f0f1e048",
+      "src": "b8ecd353b426"
+    },
+    "services.activate_led.fields.color3.name": {
+      "out": "e95f0c9b603f",
+      "src": "48d54e046d29"
+    },
+    "services.activate_led.fields.device_id.description": {
+      "out": "70b3a453ffac",
+      "src": "7dec980cb238"
+    },
+    "services.activate_led.fields.device_id.name": {
+      "out": "0944613acb42",
+      "src": "6ba0bdeccb42"
+    },
+    "services.activate_led.fields.flash_count1.description": {
+      "out": "e97a2781dc44",
+      "src": "4ffdadde31c2"
+    },
+    "services.activate_led.fields.flash_count1.name": {
+      "out": "82667b563da9",
+      "src": "13c6a2e5c22e"
+    },
+    "services.activate_led.fields.flash_count2.description": {
+      "out": "242d06029b98",
+      "src": "86dc999a3915"
+    },
+    "services.activate_led.fields.flash_count2.name": {
+      "out": "146b4bc2999c",
+      "src": "2be36d8449dc"
+    },
+    "services.activate_led.fields.flash_count3.description": {
+      "out": "fee40813b564",
+      "src": "aa40c396a9a4"
+    },
+    "services.activate_led.fields.flash_count3.name": {
+      "out": "84adaca9b350",
+      "src": "7978910dc6b2"
+    },
+    "services.activate_led.fields.instance.description": {
+      "out": "567d1fc711f0",
+      "src": "0531b37de90a"
+    },
+    "services.activate_led.fields.instance.name": {
+      "out": "b3aa884776b0",
+      "src": "f942926204c7"
+    },
+    "services.activate_led.fields.inter_delay1.description": {
+      "out": "d38792920f2d",
+      "src": "1b65dcfcea95"
+    },
+    "services.activate_led.fields.inter_delay1.name": {
+      "out": "de539a2bfff9",
+      "src": "71452f436c33"
+    },
+    "services.activate_led.fields.inter_delay2.description": {
+      "out": "c551a2d14dd4",
+      "src": "181e03f33cbf"
+    },
+    "services.activate_led.fields.inter_delay2.name": {
+      "out": "ecfe63a4485e",
+      "src": "6a50551e5355"
+    },
+    "services.activate_led.fields.inter_delay3.description": {
+      "out": "99ed5547a43f",
+      "src": "5c5973b586df"
+    },
+    "services.activate_led.fields.inter_delay3.name": {
+      "out": "9b5ba0997ac5",
+      "src": "b0f72903777e"
+    },
+    "services.activate_led.fields.loop_delay1.description": {
+      "out": "cde2861cf6cf",
+      "src": "2139915c35bc"
+    },
+    "services.activate_led.fields.loop_delay1.name": {
+      "out": "db0c8fec1950",
+      "src": "2fb02375bae0"
+    },
+    "services.activate_led.fields.loop_delay2.description": {
+      "out": "be29d941002d",
+      "src": "9a3a8cccb3bb"
+    },
+    "services.activate_led.fields.loop_delay2.name": {
+      "out": "80b40efbb349",
+      "src": "597cbe87a7ec"
+    },
+    "services.activate_led.fields.loop_delay3.description": {
+      "out": "94c29cd76d72",
+      "src": "8a965100226c"
+    },
+    "services.activate_led.fields.loop_delay3.name": {
+      "out": "700ae93133b4",
+      "src": "66d787aa1bad"
+    },
+    "services.activate_led.fields.repeats.description": {
+      "out": "300e7752bf30",
+      "src": "e40e956e3762"
+    },
+    "services.activate_led.fields.repeats.name": {
+      "out": "007319cdfdac",
+      "src": "92ee0233f013"
+    },
+    "services.activate_led.name": {
+      "out": "32186d467e6c",
+      "src": "91933e94cc57"
+    },
+    "services.drawcustom.description": {
+      "out": "fdc353e37a39",
+      "src": "55f9f3333fc0"
+    },
+    "services.drawcustom.fields.background.description": {
+      "out": "471c23f20ddf",
+      "src": "f5858405d78a"
+    },
+    "services.drawcustom.fields.background.name": {
+      "out": "d1aedb1ba5cb",
+      "src": "3e314dafdf7c"
+    },
+    "services.drawcustom.fields.dither.description": {
+      "out": "e72ebaaa3c80",
+      "src": "d7c737e5d01e"
+    },
+    "services.drawcustom.fields.dither.name": {
+      "out": "a67ee5312f9c",
+      "src": "35fb13830002"
+    },
+    "services.drawcustom.fields.dry-run.description": {
+      "out": "fc718f2dda27",
+      "src": "54f5f06db00c"
+    },
+    "services.drawcustom.fields.dry-run.name": {
+      "out": "7adaf883aa86",
+      "src": "d5da154d9f00"
+    },
+    "services.drawcustom.fields.measured_palette.description": {
+      "out": "de4909ff241c",
+      "src": "53842124c7af"
+    },
+    "services.drawcustom.fields.measured_palette.name": {
+      "out": "07a336053344",
+      "src": "672d38bdeb19"
+    },
+    "services.drawcustom.fields.payload.description": {
+      "out": "862878a45569",
+      "src": "a72e3d514ead"
+    },
+    "services.drawcustom.fields.payload.name": {
+      "out": "75718dabda35",
+      "src": "99733344956d"
+    },
+    "services.drawcustom.fields.refresh_type.description": {
+      "out": "e42d5844b694",
+      "src": "d87a3d5c4d06"
+    },
+    "services.drawcustom.fields.refresh_type.name": {
+      "out": "8eb13e60812c",
+      "src": "201b25b874bb"
+    },
+    "services.drawcustom.fields.rotate.description": {
+      "out": "ab79bfdc4410",
+      "src": "21e39f93db71"
+    },
+    "services.drawcustom.fields.rotate.name": {
+      "out": "57b5e2fc1bba",
+      "src": "57b5e2fc1bba"
+    },
+    "services.drawcustom.name": {
+      "out": "09b119dee48e",
+      "src": "d0df7a6244ea"
+    },
+    "services.upload_image.description": {
+      "out": "175050ee7e69",
+      "src": "24e19354eaa4"
+    },
+    "services.upload_image.fields.device_id.description": {
+      "out": "536ac258aace",
+      "src": "ee157333391e"
+    },
+    "services.upload_image.fields.device_id.name": {
+      "out": "0944613acb42",
+      "src": "6ba0bdeccb42"
+    },
+    "services.upload_image.fields.dither_mode.description": {
+      "out": "ebc46edc92f0",
+      "src": "70483fdfe7ec"
+    },
+    "services.upload_image.fields.dither_mode.name": {
+      "out": "a67ee5312f9c",
+      "src": "35fb13830002"
+    },
+    "services.upload_image.fields.fit_mode.description": {
+      "out": "0ed34722a3e7",
+      "src": "8d2c8735a962"
+    },
+    "services.upload_image.fields.fit_mode.name": {
+      "out": "071687ebc260",
+      "src": "8a59790c9187"
+    },
+    "services.upload_image.fields.image.description": {
+      "out": "3e073d65e7ab",
+      "src": "ba6d9fb759b0"
+    },
+    "services.upload_image.fields.image.name": {
+      "out": "1aa4cb0bcca7",
+      "src": "1aa4cb0bcca7"
+    },
+    "services.upload_image.fields.measured_palette.description": {
+      "out": "841b36cd330b",
+      "src": "53842124c7af"
+    },
+    "services.upload_image.fields.measured_palette.name": {
+      "out": "07a336053344",
+      "src": "672d38bdeb19"
+    },
+    "services.upload_image.fields.refresh_mode.description": {
+      "out": "25e346fc6cf0",
+      "src": "0fe957da240a"
+    },
+    "services.upload_image.fields.refresh_mode.name": {
+      "out": "1a15df70f262",
+      "src": "c72fd253298c"
+    },
+    "services.upload_image.fields.rotation.description": {
+      "out": "e5615edff377",
+      "src": "b639ab27209e"
+    },
+    "services.upload_image.fields.rotation.name": {
+      "out": "57b5e2fc1bba",
+      "src": "57b5e2fc1bba"
+    },
+    "services.upload_image.fields.tone_compression.description": {
+      "out": "25944386006f",
+      "src": "6453b45ae0cc"
+    },
+    "services.upload_image.fields.tone_compression.name": {
+      "out": "9d3f4c31fdec",
+      "src": "ffaed65f03fa"
+    },
+    "services.upload_image.name": {
+      "out": "e529df1ddebd",
+      "src": "ffe4df6c7ca6"
+    },
+    "services.upload_image.sections.additional_fields.name": {
+      "out": "70865af370b9",
+      "src": "092170b2408b"
+    },
+    "services.write_nfc.description": {
+      "out": "15a03311e3cf",
+      "src": "3c1f6a6d643e"
+    },
+    "services.write_nfc.fields.content.description": {
+      "out": "8fec9cf5e02c",
+      "src": "857d1cf0bf90"
+    },
+    "services.write_nfc.fields.content.name": {
+      "out": "7a6de5670ea8",
+      "src": "47bd29075f8b"
+    },
+    "services.write_nfc.fields.device_id.description": {
+      "out": "70b3a453ffac",
+      "src": "7dec980cb238"
+    },
+    "services.write_nfc.fields.device_id.name": {
+      "out": "0944613acb42",
+      "src": "6ba0bdeccb42"
+    },
+    "services.write_nfc.fields.mime_type.description": {
+      "out": "4f733613d7c9",
+      "src": "4eb2b40ec666"
+    },
+    "services.write_nfc.fields.mime_type.name": {
+      "out": "5255235b47eb",
+      "src": "849e8a810960"
+    },
+    "services.write_nfc.fields.record_type.description": {
+      "out": "b6aafe6c7a4a",
+      "src": "936cf634012f"
+    },
+    "services.write_nfc.fields.record_type.name": {
+      "out": "b25366adaeab",
+      "src": "91cf117b1d70"
+    },
+    "services.write_nfc.name": {
+      "out": "689db4db448d",
+      "src": "96ea14b97cf7"
+    }
+  },
+  "it": {
+    "config.abort.already_configured": {
+      "out": "c13c1a7a2d55",
+      "src": "c2936e02a0d2"
+    },
+    "config.abort.already_in_progress": {
+      "out": "6d0dce72fc2a",
+      "src": "985a72ad93a3"
+    },
+    "config.abort.cannot_connect": {
+      "out": "b1815fe34325",
+      "src": "46c9f3b7520f"
+    },
+    "config.abort.no_devices_found": {
+      "out": "f82ec533e69a",
+      "src": "b8f28e84cf0b"
+    },
+    "config.abort.reauth_successful": {
+      "out": "619607b89bc8",
+      "src": "e5b83989735c"
+    },
+    "config.abort.unknown": {
+      "out": "9ff3c7db40da",
+      "src": "d24c41ae530a"
+    },
+    "config.error.cannot_connect": {
+      "out": "b1815fe34325",
+      "src": "46c9f3b7520f"
+    },
+    "config.error.invalid_auth": {
+      "out": "81c7605e72e2",
+      "src": "4ca089878c5f"
+    },
+    "config.error.invalid_key_format": {
+      "out": "a938b0921859",
+      "src": "f7b03dd699df"
+    },
+    "config.error.unknown": {
+      "out": "9ff3c7db40da",
+      "src": "d24c41ae530a"
+    },
+    "config.flow_title": {
+      "out": "5e291d7bcb2d",
+      "src": "5e291d7bcb2d"
+    },
+    "config.step.bluetooth_confirm.description": {
+      "out": "e95a8e5fcfbd",
+      "src": "bcfd5a24b7d7"
+    },
+    "config.step.encryption_key.data.encryption_key": {
+      "out": "70bb7c738670",
+      "src": "16b3c9d5573d"
+    },
+    "config.step.encryption_key.data_description.encryption_key": {
+      "out": "4b90641c3604",
+      "src": "e64cd2e7e647"
+    },
+    "config.step.encryption_key.description": {
+      "out": "cffd64e7e489",
+      "src": "664d3f12bfe6"
+    },
+    "config.step.encryption_key.title": {
+      "out": "6b977e1a81dc",
+      "src": "c30d1ca158a3"
+    },
+    "config.step.reauth_confirm.data.encryption_key": {
+      "out": "70bb7c738670",
+      "src": "16b3c9d5573d"
+    },
+    "config.step.reauth_confirm.data_description.encryption_key": {
+      "out": "4b90641c3604",
+      "src": "e64cd2e7e647"
+    },
+    "config.step.reauth_confirm.description": {
+      "out": "81767ea59923",
+      "src": "f53b69d3be84"
+    },
+    "config.step.reauth_confirm.title": {
+      "out": "44ac6fa9791c",
+      "src": "7e22a752572f"
+    },
+    "config.step.user.data.address": {
+      "out": "1c555eb7f1c0",
+      "src": "6ba0bdeccb42"
+    },
+    "config.step.user.data_description.address": {
+      "out": "35dbd7926214",
+      "src": "a083a457cfb1"
+    },
+    "config.step.user.description": {
+      "out": "2b0eb62d4b08",
+      "src": "109135454652"
+    },
+    "entity.binary_sensor.update_pending.name": {
+      "out": "e196fd3b8853",
+      "src": "8e0a4b18ae75"
+    },
+    "entity.event.button.name": {
+      "out": "294e6fa3faaa",
+      "src": "2dcae43716c2"
+    },
+    "entity.event.button.state_attributes.event_type.state.button_down": {
+      "out": "761fe03197e8",
+      "src": "8352c89d20b4"
+    },
+    "entity.event.button.state_attributes.event_type.state.button_up": {
+      "out": "695fbe3c1136",
+      "src": "7f18b4912929"
+    },
+    "entity.event.touch.name": {
+      "out": "ae3b3445c9f9",
+      "src": "c915d14278fc"
+    },
+    "entity.event.touch.state_attributes.event_type.state.touch_down": {
+      "out": "7fb9054714f7",
+      "src": "0234a9576230"
+    },
+    "entity.event.touch.state_attributes.event_type.state.touch_move": {
+      "out": "3cb75222f535",
+      "src": "67aeac815e94"
+    },
+    "entity.event.touch.state_attributes.event_type.state.touch_up": {
+      "out": "1d536c75388c",
+      "src": "7c65519d3bb3"
+    },
+    "entity.image.content.name": {
+      "out": "f00e690fcbf0",
+      "src": "047c6db3382a"
+    },
+    "entity.sensor.battery_voltage.name": {
+      "out": "0226d3e1afe4",
+      "src": "39d6c91b57ce"
+    },
+    "entity.sensor.last_seen.name": {
+      "out": "17d51dae14bd",
+      "src": "21fd79c7de52"
+    },
+    "entity.sensor.rssi.name": {
+      "out": "ab4fcf55cdb0",
+      "src": "2604d15c1187"
+    },
+    "entity.update.firmware.name": {
+      "out": "c2a314c3b32b",
+      "src": "c2a314c3b32b"
+    },
+    "exceptions.authentication_error.message": {
+      "out": "808d4428797d",
+      "src": "3d9f7c0c6d80"
+    },
+    "exceptions.device_not_found.message": {
+      "out": "2a6eb6f25f73",
+      "src": "f244d0d2db8d"
+    },
+    "exceptions.device_sleeping.message": {
+      "out": "8fa146655440",
+      "src": "e95d25bd6fc7"
+    },
+    "exceptions.device_sleeping_ota.message": {
+      "out": "c945b1b2513e",
+      "src": "430e3a1baa6a"
+    },
+    "exceptions.invalid_device_id.message": {
+      "out": "9605015e8c92",
+      "src": "cc64cc29ceeb"
+    },
+    "exceptions.media_download_error.message": {
+      "out": "6e77cf8e55ee",
+      "src": "5852129dd920"
+    },
+    "exceptions.mime_type_not_applicable.message": {
+      "out": "380edc862100",
+      "src": "de700f02fbd5"
+    },
+    "exceptions.multiple_errors.message": {
+      "out": "280310410b47",
+      "src": "f17c68e0a848"
+    },
+    "exceptions.nfc_content_empty.message": {
+      "out": "2c8100dd1c1f",
+      "src": "b93a1a6ebdc0"
+    },
+    "exceptions.nfc_content_too_long.message": {
+      "out": "0c7f5fd42441",
+      "src": "8f580b9c6c76"
+    },
+    "exceptions.nfc_mime_type_invalid.message": {
+      "out": "4f112e5cff47",
+      "src": "5a5f44fe332f"
+    },
+    "exceptions.nfc_not_supported.message": {
+      "out": "4ade687e73f7",
+      "src": "8fdcd0e2bd17"
+    },
+    "exceptions.nfc_write_failed.message": {
+      "out": "310cd7bdf035",
+      "src": "e8186303a52e"
+    },
+    "exceptions.no_buzzers.message": {
+      "out": "1f50fe51f836",
+      "src": "9c014dfeac91"
+    },
+    "exceptions.no_leds.message": {
+      "out": "5b10e3358e2a",
+      "src": "6a302f8f22ee"
+    },
+    "exceptions.no_nfc.message": {
+      "out": "4fa38d63c770",
+      "src": "abb1917ad57e"
+    },
+    "exceptions.no_targets_specified.message": {
+      "out": "458896e84018",
+      "src": "80c472afefe6"
+    },
+    "exceptions.upload_error.message": {
+      "out": "431a9f4a0b8f",
+      "src": "75561a03be6e"
+    },
+    "exceptions.url_not_allowed.message": {
+      "out": "4d728bd5af6b",
+      "src": "33ffb9a9f2c4"
+    },
+    "options.step.init.data.blocks_per_ack": {
+      "out": "179c008aff1b",
+      "src": "3e2a554e69a4"
+    },
+    "options.step.init.data.max_queue_size": {
+      "out": "4ca717893020",
+      "src": "297af7027dd0"
+    },
+    "options.step.init.data.missed_cycles": {
+      "out": "4a1d01172530",
+      "src": "59b78644491a"
+    },
+    "options.step.init.data.probe_before_queue": {
+      "out": "06cdb2854a7b",
+      "src": "02c4211a58b2"
+    },
+    "options.step.init.data.queue_timeout_hours": {
+      "out": "e7e301c02b53",
+      "src": "be70fc5cca79"
+    },
+    "options.step.init.data.sleep_mode": {
+      "out": "5be328b31d89",
+      "src": "f925c0e541ce"
+    },
+    "options.step.init.data_description.blocks_per_ack": {
+      "out": "ae8f8d587584",
+      "src": "3a693b19d3c6"
+    },
+    "options.step.init.data_description.max_queue_size": {
+      "out": "8fcbf102cad8",
+      "src": "50260959ee56"
+    },
+    "options.step.init.data_description.missed_cycles": {
+      "out": "99a606e9e8da",
+      "src": "6ce493f4c44d"
+    },
+    "options.step.init.data_description.probe_before_queue": {
+      "out": "d713e2835e0e",
+      "src": "5d0f2985ffdf"
+    },
+    "options.step.init.data_description.queue_timeout_hours": {
+      "out": "73fb66832b41",
+      "src": "34895000b491"
+    },
+    "options.step.init.data_description.sleep_mode": {
+      "out": "5e9565eff78a",
+      "src": "4acfeb65d10d"
+    },
+    "selector.dither_mode.options.atkinson": {
+      "out": "7a8fe6d47b5b",
+      "src": "7a8fe6d47b5b"
+    },
+    "selector.dither_mode.options.burkes": {
+      "out": "1b75087201fb",
+      "src": "1b75087201fb"
+    },
+    "selector.dither_mode.options.floyd_steinberg": {
+      "out": "37969811a3cf",
+      "src": "37969811a3cf"
+    },
+    "selector.dither_mode.options.jarvis_judice_ninke": {
+      "out": "7020241adf78",
+      "src": "7020241adf78"
+    },
+    "selector.dither_mode.options.none": {
+      "out": "aa201262e9a7",
+      "src": "dc937b598926"
+    },
+    "selector.dither_mode.options.ordered": {
+      "out": "15a0e538e63f",
+      "src": "007877479e21"
+    },
+    "selector.dither_mode.options.sierra": {
+      "out": "d5eef8ad210c",
+      "src": "d5eef8ad210c"
+    },
+    "selector.dither_mode.options.sierra_lite": {
+      "out": "20da8cc85f38",
+      "src": "20da8cc85f38"
+    },
+    "selector.dither_mode.options.stucki": {
+      "out": "a17d2b13b6f9",
+      "src": "a17d2b13b6f9"
+    },
+    "selector.fit_mode.options.contain": {
+      "out": "585ad1b076ef",
+      "src": "e534a2c2b456"
+    },
+    "selector.fit_mode.options.cover": {
+      "out": "4cd0d886b40b",
+      "src": "fa8d84566676"
+    },
+    "selector.fit_mode.options.crop": {
+      "out": "be091ff9470e",
+      "src": "98caf7c43c6f"
+    },
+    "selector.fit_mode.options.stretch": {
+      "out": "266e2e1e0b53",
+      "src": "a33fbcf83f7b"
+    },
+    "selector.nfc_record_type.options.ha_tag": {
+      "out": "b74c1bf15cfa",
+      "src": "d1d47a8fa544"
+    },
+    "selector.nfc_record_type.options.mime": {
+      "out": "6e66b0f9ef4b",
+      "src": "f98d7539e627"
+    },
+    "selector.nfc_record_type.options.text": {
+      "out": "ebb9e60cfec0",
+      "src": "71988c4d8e08"
+    },
+    "selector.nfc_record_type.options.url": {
+      "out": "e7a241debad5",
+      "src": "e7a241debad5"
+    },
+    "selector.refresh_mode.options.fast": {
+      "out": "e9d2bef80d57",
+      "src": "6c582b62e0e5"
+    },
+    "selector.refresh_mode.options.full": {
+      "out": "23e3685fbe6c",
+      "src": "008dacb6d1e8"
+    },
+    "selector.refresh_mode.options.partial": {
+      "out": "12d5e1468ffa",
+      "src": "a4d50fb85403"
+    },
+    "selector.sleep_mode.options.auto": {
+      "out": "fdd0d6ab20c1",
+      "src": "132990bd8ef7"
+    },
+    "selector.sleep_mode.options.off": {
+      "out": "0ee315fa8ffe",
+      "src": "34598efe7b90"
+    },
+    "selector.sleep_mode.options.on": {
+      "out": "95ca5f7d875b",
+      "src": "bde131e31c9e"
+    },
+    "services.activate_buzzer.description": {
+      "out": "a413ecb3c558",
+      "src": "1898784614cb"
+    },
+    "services.activate_buzzer.fields.device_id.description": {
+      "out": "9f827f83022b",
+      "src": "7dec980cb238"
+    },
+    "services.activate_buzzer.fields.device_id.name": {
+      "out": "1c555eb7f1c0",
+      "src": "6ba0bdeccb42"
+    },
+    "services.activate_buzzer.fields.duration_ms.description": {
+      "out": "3e7bfddf5f06",
+      "src": "cd1bc75ca60c"
+    },
+    "services.activate_buzzer.fields.duration_ms.name": {
+      "out": "902f1527bb48",
+      "src": "4fc52a3c4c55"
+    },
+    "services.activate_buzzer.fields.frequency_hz.description": {
+      "out": "a67d894d5dfb",
+      "src": "510fc20311e3"
+    },
+    "services.activate_buzzer.fields.frequency_hz.name": {
+      "out": "b8cff750b1c0",
+      "src": "16b6668d9831"
+    },
+    "services.activate_buzzer.fields.instance.description": {
+      "out": "0ee80131f2bf",
+      "src": "f39fa742d55c"
+    },
+    "services.activate_buzzer.fields.instance.name": {
+      "out": "a7789aec1c65",
+      "src": "1f671ddded9e"
+    },
+    "services.activate_buzzer.fields.repeats.description": {
+      "out": "0d2fc48e2d44",
+      "src": "1f88b0fe23ea"
+    },
+    "services.activate_buzzer.fields.repeats.name": {
+      "out": "d4e1d6b072f6",
+      "src": "92ee0233f013"
+    },
+    "services.activate_buzzer.name": {
+      "out": "e6d5008187db",
+      "src": "0b80285753b7"
+    },
+    "services.activate_led.description": {
+      "out": "a6b9d2ad88f8",
+      "src": "6cbd645597cc"
+    },
+    "services.activate_led.fields.brightness.description": {
+      "out": "a43465c496a1",
+      "src": "6ad88a28230d"
+    },
+    "services.activate_led.fields.brightness.name": {
+      "out": "48f971e2c07b",
+      "src": "ec811d30a89c"
+    },
+    "services.activate_led.fields.color1.description": {
+      "out": "e62825d9c107",
+      "src": "17f145013241"
+    },
+    "services.activate_led.fields.color1.name": {
+      "out": "773570f9f353",
+      "src": "571461f36f3a"
+    },
+    "services.activate_led.fields.color2.description": {
+      "out": "beab1dc344c4",
+      "src": "f2680a4bbe85"
+    },
+    "services.activate_led.fields.color2.name": {
+      "out": "40f82b62eac8",
+      "src": "ef792d287872"
+    },
+    "services.activate_led.fields.color3.description": {
+      "out": "500558932c92",
+      "src": "b8ecd353b426"
+    },
+    "services.activate_led.fields.color3.name": {
+      "out": "809dde2191d5",
+      "src": "48d54e046d29"
+    },
+    "services.activate_led.fields.device_id.description": {
+      "out": "9f827f83022b",
+      "src": "7dec980cb238"
+    },
+    "services.activate_led.fields.device_id.name": {
+      "out": "1c555eb7f1c0",
+      "src": "6ba0bdeccb42"
+    },
+    "services.activate_led.fields.flash_count1.description": {
+      "out": "e216bbe165eb",
+      "src": "4ffdadde31c2"
+    },
+    "services.activate_led.fields.flash_count1.name": {
+      "out": "b516fc047936",
+      "src": "13c6a2e5c22e"
+    },
+    "services.activate_led.fields.flash_count2.description": {
+      "out": "707e0aa8838e",
+      "src": "86dc999a3915"
+    },
+    "services.activate_led.fields.flash_count2.name": {
+      "out": "e2f2bf10635a",
+      "src": "2be36d8449dc"
+    },
+    "services.activate_led.fields.flash_count3.description": {
+      "out": "f04ad3ccd536",
+      "src": "aa40c396a9a4"
+    },
+    "services.activate_led.fields.flash_count3.name": {
+      "out": "eb6bf46ee577",
+      "src": "7978910dc6b2"
+    },
+    "services.activate_led.fields.instance.description": {
+      "out": "39111deb68ff",
+      "src": "0531b37de90a"
+    },
+    "services.activate_led.fields.instance.name": {
+      "out": "297a0e45f33f",
+      "src": "f942926204c7"
+    },
+    "services.activate_led.fields.inter_delay1.description": {
+      "out": "c8113597eb05",
+      "src": "1b65dcfcea95"
+    },
+    "services.activate_led.fields.inter_delay1.name": {
+      "out": "ef84aec45cfe",
+      "src": "71452f436c33"
+    },
+    "services.activate_led.fields.inter_delay2.description": {
+      "out": "4ee4d0be439f",
+      "src": "181e03f33cbf"
+    },
+    "services.activate_led.fields.inter_delay2.name": {
+      "out": "9bd223abcae9",
+      "src": "6a50551e5355"
+    },
+    "services.activate_led.fields.inter_delay3.description": {
+      "out": "2e16218def4a",
+      "src": "5c5973b586df"
+    },
+    "services.activate_led.fields.inter_delay3.name": {
+      "out": "9cb9e0ff88c6",
+      "src": "b0f72903777e"
+    },
+    "services.activate_led.fields.loop_delay1.description": {
+      "out": "5bc1a1d02db9",
+      "src": "2139915c35bc"
+    },
+    "services.activate_led.fields.loop_delay1.name": {
+      "out": "0673ed430035",
+      "src": "2fb02375bae0"
+    },
+    "services.activate_led.fields.loop_delay2.description": {
+      "out": "4d9a25d52b20",
+      "src": "9a3a8cccb3bb"
+    },
+    "services.activate_led.fields.loop_delay2.name": {
+      "out": "0621a110d6d0",
+      "src": "597cbe87a7ec"
+    },
+    "services.activate_led.fields.loop_delay3.description": {
+      "out": "8ec2c7fc9856",
+      "src": "8a965100226c"
+    },
+    "services.activate_led.fields.loop_delay3.name": {
+      "out": "f1a8191e8a38",
+      "src": "66d787aa1bad"
+    },
+    "services.activate_led.fields.repeats.description": {
+      "out": "c40b00948b21",
+      "src": "e40e956e3762"
+    },
+    "services.activate_led.fields.repeats.name": {
+      "out": "d4e1d6b072f6",
+      "src": "92ee0233f013"
+    },
+    "services.activate_led.name": {
+      "out": "fa2687a1fe5f",
+      "src": "91933e94cc57"
+    },
+    "services.drawcustom.description": {
+      "out": "47fba0269f04",
+      "src": "55f9f3333fc0"
+    },
+    "services.drawcustom.fields.background.description": {
+      "out": "198cf58055d1",
+      "src": "f5858405d78a"
+    },
+    "services.drawcustom.fields.background.name": {
+      "out": "2f456b484269",
+      "src": "3e314dafdf7c"
+    },
+    "services.drawcustom.fields.dither.description": {
+      "out": "550aaf201259",
+      "src": "d7c737e5d01e"
+    },
+    "services.drawcustom.fields.dither.name": {
+      "out": "ee0d16496c32",
+      "src": "35fb13830002"
+    },
+    "services.drawcustom.fields.dry-run.description": {
+      "out": "9a21234b3de9",
+      "src": "54f5f06db00c"
+    },
+    "services.drawcustom.fields.dry-run.name": {
+      "out": "964df39f3e64",
+      "src": "d5da154d9f00"
+    },
+    "services.drawcustom.fields.measured_palette.description": {
+      "out": "4c7a8ad652a0",
+      "src": "53842124c7af"
+    },
+    "services.drawcustom.fields.measured_palette.name": {
+      "out": "8fa251e7bc0b",
+      "src": "672d38bdeb19"
+    },
+    "services.drawcustom.fields.payload.description": {
+      "out": "0b8972810d5d",
+      "src": "a72e3d514ead"
+    },
+    "services.drawcustom.fields.payload.name": {
+      "out": "99733344956d",
+      "src": "99733344956d"
+    },
+    "services.drawcustom.fields.refresh_type.description": {
+      "out": "fe3f2e6c5276",
+      "src": "d87a3d5c4d06"
+    },
+    "services.drawcustom.fields.refresh_type.name": {
+      "out": "b7d4ba486600",
+      "src": "201b25b874bb"
+    },
+    "services.drawcustom.fields.rotate.description": {
+      "out": "df6eea223df5",
+      "src": "21e39f93db71"
+    },
+    "services.drawcustom.fields.rotate.name": {
+      "out": "62b6f5179077",
+      "src": "57b5e2fc1bba"
+    },
+    "services.drawcustom.name": {
+      "out": "b9f06b92149e",
+      "src": "d0df7a6244ea"
+    },
+    "services.upload_image.description": {
+      "out": "2f57f84ec342",
+      "src": "24e19354eaa4"
+    },
+    "services.upload_image.fields.device_id.description": {
+      "out": "6bf21aebaa48",
+      "src": "ee157333391e"
+    },
+    "services.upload_image.fields.device_id.name": {
+      "out": "1c555eb7f1c0",
+      "src": "6ba0bdeccb42"
+    },
+    "services.upload_image.fields.dither_mode.description": {
+      "out": "79ae5ade74b7",
+      "src": "70483fdfe7ec"
+    },
+    "services.upload_image.fields.dither_mode.name": {
+      "out": "ee0d16496c32",
+      "src": "35fb13830002"
+    },
+    "services.upload_image.fields.fit_mode.description": {
+      "out": "72e5ba8df574",
+      "src": "8d2c8735a962"
+    },
+    "services.upload_image.fields.fit_mode.name": {
+      "out": "2a4895e491ee",
+      "src": "8a59790c9187"
+    },
+    "services.upload_image.fields.image.description": {
+      "out": "987c77c4697b",
+      "src": "ba6d9fb759b0"
+    },
+    "services.upload_image.fields.image.name": {
+      "out": "850b6f310354",
+      "src": "1aa4cb0bcca7"
+    },
+    "services.upload_image.fields.measured_palette.description": {
+      "out": "9205f39bb14a",
+      "src": "53842124c7af"
+    },
+    "services.upload_image.fields.measured_palette.name": {
+      "out": "8fa251e7bc0b",
+      "src": "672d38bdeb19"
+    },
+    "services.upload_image.fields.refresh_mode.description": {
+      "out": "f7cae6b3137e",
+      "src": "0fe957da240a"
+    },
+    "services.upload_image.fields.refresh_mode.name": {
+      "out": "46f4b72b828f",
+      "src": "c72fd253298c"
+    },
+    "services.upload_image.fields.rotation.description": {
+      "out": "1d02884e134b",
+      "src": "b639ab27209e"
+    },
+    "services.upload_image.fields.rotation.name": {
+      "out": "62b6f5179077",
+      "src": "57b5e2fc1bba"
+    },
+    "services.upload_image.fields.tone_compression.description": {
+      "out": "6ab18fa9195d",
+      "src": "6453b45ae0cc"
+    },
+    "services.upload_image.fields.tone_compression.name": {
+      "out": "0972768e5378",
+      "src": "ffaed65f03fa"
+    },
+    "services.upload_image.name": {
+      "out": "2e6d6a1bf842",
+      "src": "ffe4df6c7ca6"
+    },
+    "services.upload_image.sections.additional_fields.name": {
+      "out": "0f5d04b54d2d",
+      "src": "092170b2408b"
+    },
+    "services.write_nfc.description": {
+      "out": "b508906e0996",
+      "src": "3c1f6a6d643e"
+    },
+    "services.write_nfc.fields.content.description": {
+      "out": "02b3b37b86ae",
+      "src": "857d1cf0bf90"
+    },
+    "services.write_nfc.fields.content.name": {
+      "out": "18a65b799b07",
+      "src": "47bd29075f8b"
+    },
+    "services.write_nfc.fields.device_id.description": {
+      "out": "9f827f83022b",
+      "src": "7dec980cb238"
+    },
+    "services.write_nfc.fields.device_id.name": {
+      "out": "1c555eb7f1c0",
+      "src": "6ba0bdeccb42"
+    },
+    "services.write_nfc.fields.mime_type.description": {
+      "out": "ae7e1983f50f",
+      "src": "4eb2b40ec666"
+    },
+    "services.write_nfc.fields.mime_type.name": {
+      "out": "899f5b786081",
+      "src": "849e8a810960"
+    },
+    "services.write_nfc.fields.record_type.description": {
+      "out": "263aed09ac2e",
+      "src": "936cf634012f"
+    },
+    "services.write_nfc.fields.record_type.name": {
+      "out": "662375a7e514",
+      "src": "91cf117b1d70"
+    },
+    "services.write_nfc.name": {
+      "out": "d81775704492",
+      "src": "96ea14b97cf7"
+    }
+  },
+  "nl": {
+    "config.abort.already_configured": {
+      "out": "aa766e4ba66a",
+      "src": "c2936e02a0d2"
+    },
+    "config.abort.already_in_progress": {
+      "out": "56ce1a1bae02",
+      "src": "985a72ad93a3"
+    },
+    "config.abort.cannot_connect": {
+      "out": "9c4ba67ae02b",
+      "src": "46c9f3b7520f"
+    },
+    "config.abort.no_devices_found": {
+      "out": "a087efe1501f",
+      "src": "b8f28e84cf0b"
+    },
+    "config.abort.reauth_successful": {
+      "out": "446ac0c8d0c8",
+      "src": "e5b83989735c"
+    },
+    "config.abort.unknown": {
+      "out": "76ed6ea944be",
+      "src": "d24c41ae530a"
+    },
+    "config.error.cannot_connect": {
+      "out": "9c4ba67ae02b",
+      "src": "46c9f3b7520f"
+    },
+    "config.error.invalid_auth": {
+      "out": "562f0ab41c80",
+      "src": "4ca089878c5f"
+    },
+    "config.error.invalid_key_format": {
+      "out": "fb96f7c89bbb",
+      "src": "f7b03dd699df"
+    },
+    "config.error.unknown": {
+      "out": "76ed6ea944be",
+      "src": "d24c41ae530a"
+    },
+    "config.flow_title": {
+      "out": "5e291d7bcb2d",
+      "src": "5e291d7bcb2d"
+    },
+    "config.step.bluetooth_confirm.description": {
+      "out": "ee83de2aa708",
+      "src": "bcfd5a24b7d7"
+    },
+    "config.step.encryption_key.data.encryption_key": {
+      "out": "c2dca326c3c2",
+      "src": "16b3c9d5573d"
+    },
+    "config.step.encryption_key.data_description.encryption_key": {
+      "out": "e197482d00f4",
+      "src": "e64cd2e7e647"
+    },
+    "config.step.encryption_key.description": {
+      "out": "1cc64666b277",
+      "src": "664d3f12bfe6"
+    },
+    "config.step.encryption_key.title": {
+      "out": "ee6db52b2455",
+      "src": "c30d1ca158a3"
+    },
+    "config.step.reauth_confirm.data.encryption_key": {
+      "out": "c2dca326c3c2",
+      "src": "16b3c9d5573d"
+    },
+    "config.step.reauth_confirm.data_description.encryption_key": {
+      "out": "e197482d00f4",
+      "src": "e64cd2e7e647"
+    },
+    "config.step.reauth_confirm.description": {
+      "out": "2730fdf8f651",
+      "src": "f53b69d3be84"
+    },
+    "config.step.reauth_confirm.title": {
+      "out": "fd504e9866ef",
+      "src": "7e22a752572f"
+    },
+    "config.step.user.data.address": {
+      "out": "0e0a54c681e2",
+      "src": "6ba0bdeccb42"
+    },
+    "config.step.user.data_description.address": {
+      "out": "d87bfbe38a0b",
+      "src": "a083a457cfb1"
+    },
+    "config.step.user.description": {
+      "out": "0d218629fbba",
+      "src": "109135454652"
+    },
+    "entity.binary_sensor.update_pending.name": {
+      "out": "87e6e1582bf5",
+      "src": "8e0a4b18ae75"
+    },
+    "entity.event.button.name": {
+      "out": "f65cca5119e6",
+      "src": "2dcae43716c2"
+    },
+    "entity.event.button.state_attributes.event_type.state.button_down": {
+      "out": "7a938bcacaff",
+      "src": "8352c89d20b4"
+    },
+    "entity.event.button.state_attributes.event_type.state.button_up": {
+      "out": "90a22edf3186",
+      "src": "7f18b4912929"
+    },
+    "entity.event.touch.name": {
+      "out": "fef3b06a2cfe",
+      "src": "c915d14278fc"
+    },
+    "entity.event.touch.state_attributes.event_type.state.touch_down": {
+      "out": "221538405f03",
+      "src": "0234a9576230"
+    },
+    "entity.event.touch.state_attributes.event_type.state.touch_move": {
+      "out": "38da7e46e73e",
+      "src": "67aeac815e94"
+    },
+    "entity.event.touch.state_attributes.event_type.state.touch_up": {
+      "out": "06350e237c0b",
+      "src": "7c65519d3bb3"
+    },
+    "entity.image.content.name": {
+      "out": "57803eaaea84",
+      "src": "047c6db3382a"
+    },
+    "entity.sensor.battery_voltage.name": {
+      "out": "356d1e3e9340",
+      "src": "39d6c91b57ce"
+    },
+    "entity.sensor.last_seen.name": {
+      "out": "f0a73567f3b8",
+      "src": "21fd79c7de52"
+    },
+    "entity.sensor.rssi.name": {
+      "out": "10239c973206",
+      "src": "2604d15c1187"
+    },
+    "entity.update.firmware.name": {
+      "out": "c2a314c3b32b",
+      "src": "c2a314c3b32b"
+    },
+    "exceptions.authentication_error.message": {
+      "out": "967e5cf30a74",
+      "src": "3d9f7c0c6d80"
+    },
+    "exceptions.device_not_found.message": {
+      "out": "a80f90799c7a",
+      "src": "f244d0d2db8d"
+    },
+    "exceptions.device_sleeping.message": {
+      "out": "a96a02bbfa1f",
+      "src": "e95d25bd6fc7"
+    },
+    "exceptions.device_sleeping_ota.message": {
+      "out": "9b4f8a1e1050",
+      "src": "430e3a1baa6a"
+    },
+    "exceptions.invalid_device_id.message": {
+      "out": "f590c38ce79e",
+      "src": "cc64cc29ceeb"
+    },
+    "exceptions.media_download_error.message": {
+      "out": "8c3fa9a46030",
+      "src": "5852129dd920"
+    },
+    "exceptions.mime_type_not_applicable.message": {
+      "out": "86016faebbc7",
+      "src": "de700f02fbd5"
+    },
+    "exceptions.multiple_errors.message": {
+      "out": "8cefc6cf7040",
+      "src": "f17c68e0a848"
+    },
+    "exceptions.nfc_content_empty.message": {
+      "out": "ace5922fd5da",
+      "src": "b93a1a6ebdc0"
+    },
+    "exceptions.nfc_content_too_long.message": {
+      "out": "83247e1197f1",
+      "src": "8f580b9c6c76"
+    },
+    "exceptions.nfc_mime_type_invalid.message": {
+      "out": "3a09b518e947",
+      "src": "5a5f44fe332f"
+    },
+    "exceptions.nfc_not_supported.message": {
+      "out": "0430ac7f5b31",
+      "src": "8fdcd0e2bd17"
+    },
+    "exceptions.nfc_write_failed.message": {
+      "out": "3e780f88aaff",
+      "src": "e8186303a52e"
+    },
+    "exceptions.no_buzzers.message": {
+      "out": "c5057ceb2373",
+      "src": "9c014dfeac91"
+    },
+    "exceptions.no_leds.message": {
+      "out": "81d3916a53c5",
+      "src": "6a302f8f22ee"
+    },
+    "exceptions.no_nfc.message": {
+      "out": "dbb1b404f1c2",
+      "src": "abb1917ad57e"
+    },
+    "exceptions.no_targets_specified.message": {
+      "out": "ab7b84944fc6",
+      "src": "80c472afefe6"
+    },
+    "exceptions.upload_error.message": {
+      "out": "a760962cc17d",
+      "src": "75561a03be6e"
+    },
+    "exceptions.url_not_allowed.message": {
+      "out": "ba50f1abf1df",
+      "src": "33ffb9a9f2c4"
+    },
+    "options.step.init.data.blocks_per_ack": {
+      "out": "43e2e40d805c",
+      "src": "3e2a554e69a4"
+    },
+    "options.step.init.data.max_queue_size": {
+      "out": "42ea708451c3",
+      "src": "297af7027dd0"
+    },
+    "options.step.init.data.missed_cycles": {
+      "out": "9b47b875581d",
+      "src": "59b78644491a"
+    },
+    "options.step.init.data.probe_before_queue": {
+      "out": "f16ccd3fdc78",
+      "src": "02c4211a58b2"
+    },
+    "options.step.init.data.queue_timeout_hours": {
+      "out": "508ac26fb092",
+      "src": "be70fc5cca79"
+    },
+    "options.step.init.data.sleep_mode": {
+      "out": "167caa0388d7",
+      "src": "f925c0e541ce"
+    },
+    "options.step.init.data_description.blocks_per_ack": {
+      "out": "c5927e4cfb54",
+      "src": "3a693b19d3c6"
+    },
+    "options.step.init.data_description.max_queue_size": {
+      "out": "31b81d274785",
+      "src": "50260959ee56"
+    },
+    "options.step.init.data_description.missed_cycles": {
+      "out": "6400ec6f90f1",
+      "src": "6ce493f4c44d"
+    },
+    "options.step.init.data_description.probe_before_queue": {
+      "out": "f7fdd86c6ce2",
+      "src": "5d0f2985ffdf"
+    },
+    "options.step.init.data_description.queue_timeout_hours": {
+      "out": "3502922f215b",
+      "src": "34895000b491"
+    },
+    "options.step.init.data_description.sleep_mode": {
+      "out": "1435771ca996",
+      "src": "4acfeb65d10d"
+    },
+    "selector.dither_mode.options.atkinson": {
+      "out": "7a8fe6d47b5b",
+      "src": "7a8fe6d47b5b"
+    },
+    "selector.dither_mode.options.burkes": {
+      "out": "1b75087201fb",
+      "src": "1b75087201fb"
+    },
+    "selector.dither_mode.options.floyd_steinberg": {
+      "out": "37969811a3cf",
+      "src": "37969811a3cf"
+    },
+    "selector.dither_mode.options.jarvis_judice_ninke": {
+      "out": "7020241adf78",
+      "src": "7020241adf78"
+    },
+    "selector.dither_mode.options.none": {
+      "out": "ed0a2968058c",
+      "src": "dc937b598926"
+    },
+    "selector.dither_mode.options.ordered": {
+      "out": "99d8a323481b",
+      "src": "007877479e21"
+    },
+    "selector.dither_mode.options.sierra": {
+      "out": "d5eef8ad210c",
+      "src": "d5eef8ad210c"
+    },
+    "selector.dither_mode.options.sierra_lite": {
+      "out": "20da8cc85f38",
+      "src": "20da8cc85f38"
+    },
+    "selector.dither_mode.options.stucki": {
+      "out": "a17d2b13b6f9",
+      "src": "a17d2b13b6f9"
+    },
+    "selector.fit_mode.options.contain": {
+      "out": "de3a1ffc7435",
+      "src": "e534a2c2b456"
+    },
+    "selector.fit_mode.options.cover": {
+      "out": "5ca49d49cd51",
+      "src": "fa8d84566676"
+    },
+    "selector.fit_mode.options.crop": {
+      "out": "a85716c00d58",
+      "src": "98caf7c43c6f"
+    },
+    "selector.fit_mode.options.stretch": {
+      "out": "685b79a8b265",
+      "src": "a33fbcf83f7b"
+    },
+    "selector.nfc_record_type.options.ha_tag": {
+      "out": "01776527bd03",
+      "src": "d1d47a8fa544"
+    },
+    "selector.nfc_record_type.options.mime": {
+      "out": "9af5416cb9cd",
+      "src": "f98d7539e627"
+    },
+    "selector.nfc_record_type.options.text": {
+      "out": "5d07abcd8c8c",
+      "src": "71988c4d8e08"
+    },
+    "selector.nfc_record_type.options.url": {
+      "out": "e7a241debad5",
+      "src": "e7a241debad5"
+    },
+    "selector.refresh_mode.options.fast": {
+      "out": "ad679974a7a5",
+      "src": "6c582b62e0e5"
+    },
+    "selector.refresh_mode.options.full": {
+      "out": "81c8eab8fd06",
+      "src": "008dacb6d1e8"
+    },
+    "selector.refresh_mode.options.partial": {
+      "out": "772714cd8f4b",
+      "src": "a4d50fb85403"
+    },
+    "selector.sleep_mode.options.auto": {
+      "out": "b46220271764",
+      "src": "132990bd8ef7"
+    },
+    "selector.sleep_mode.options.off": {
+      "out": "25f5a2fddc29",
+      "src": "34598efe7b90"
+    },
+    "selector.sleep_mode.options.on": {
+      "out": "175efbe05d06",
+      "src": "bde131e31c9e"
+    },
+    "services.activate_buzzer.description": {
+      "out": "788a623c5546",
+      "src": "1898784614cb"
+    },
+    "services.activate_buzzer.fields.device_id.description": {
+      "out": "56d438ed7456",
+      "src": "7dec980cb238"
+    },
+    "services.activate_buzzer.fields.device_id.name": {
+      "out": "0e0a54c681e2",
+      "src": "6ba0bdeccb42"
+    },
+    "services.activate_buzzer.fields.duration_ms.description": {
+      "out": "8e62f9b72f37",
+      "src": "cd1bc75ca60c"
+    },
+    "services.activate_buzzer.fields.duration_ms.name": {
+      "out": "c8d7586e9596",
+      "src": "4fc52a3c4c55"
+    },
+    "services.activate_buzzer.fields.frequency_hz.description": {
+      "out": "587a11c9c7f4",
+      "src": "510fc20311e3"
+    },
+    "services.activate_buzzer.fields.frequency_hz.name": {
+      "out": "b3d5bc3dee52",
+      "src": "16b6668d9831"
+    },
+    "services.activate_buzzer.fields.instance.description": {
+      "out": "88738842300a",
+      "src": "f39fa742d55c"
+    },
+    "services.activate_buzzer.fields.instance.name": {
+      "out": "3aa09216cff5",
+      "src": "1f671ddded9e"
+    },
+    "services.activate_buzzer.fields.repeats.description": {
+      "out": "d668cbb966c4",
+      "src": "1f88b0fe23ea"
+    },
+    "services.activate_buzzer.fields.repeats.name": {
+      "out": "2f873dc8d821",
+      "src": "92ee0233f013"
+    },
+    "services.activate_buzzer.name": {
+      "out": "60a8b788ef3d",
+      "src": "0b80285753b7"
+    },
+    "services.activate_led.description": {
+      "out": "e6e7dd1a7d6f",
+      "src": "6cbd645597cc"
+    },
+    "services.activate_led.fields.brightness.description": {
+      "out": "e9f37a595f90",
+      "src": "6ad88a28230d"
+    },
+    "services.activate_led.fields.brightness.name": {
+      "out": "00a84b5b30ee",
+      "src": "ec811d30a89c"
+    },
+    "services.activate_led.fields.color1.description": {
+      "out": "0a7048f4763f",
+      "src": "17f145013241"
+    },
+    "services.activate_led.fields.color1.name": {
+      "out": "da96a9564a87",
+      "src": "571461f36f3a"
+    },
+    "services.activate_led.fields.color2.description": {
+      "out": "8dc119ec9576",
+      "src": "f2680a4bbe85"
+    },
+    "services.activate_led.fields.color2.name": {
+      "out": "6349757961d6",
+      "src": "ef792d287872"
+    },
+    "services.activate_led.fields.color3.description": {
+      "out": "ca30a2364126",
+      "src": "b8ecd353b426"
+    },
+    "services.activate_led.fields.color3.name": {
+      "out": "33a1cd2bce3d",
+      "src": "48d54e046d29"
+    },
+    "services.activate_led.fields.device_id.description": {
+      "out": "56d438ed7456",
+      "src": "7dec980cb238"
+    },
+    "services.activate_led.fields.device_id.name": {
+      "out": "0e0a54c681e2",
+      "src": "6ba0bdeccb42"
+    },
+    "services.activate_led.fields.flash_count1.description": {
+      "out": "8c89be5fd0bf",
+      "src": "4ffdadde31c2"
+    },
+    "services.activate_led.fields.flash_count1.name": {
+      "out": "18d05fbbd928",
+      "src": "13c6a2e5c22e"
+    },
+    "services.activate_led.fields.flash_count2.description": {
+      "out": "a3f055da9e3d",
+      "src": "86dc999a3915"
+    },
+    "services.activate_led.fields.flash_count2.name": {
+      "out": "0d805251f0d3",
+      "src": "2be36d8449dc"
+    },
+    "services.activate_led.fields.flash_count3.description": {
+      "out": "0d647003889f",
+      "src": "aa40c396a9a4"
+    },
+    "services.activate_led.fields.flash_count3.name": {
+      "out": "8875cf264a7f",
+      "src": "7978910dc6b2"
+    },
+    "services.activate_led.fields.instance.description": {
+      "out": "98e39da0a40b",
+      "src": "0531b37de90a"
+    },
+    "services.activate_led.fields.instance.name": {
+      "out": "c6a37cccc41d",
+      "src": "f942926204c7"
+    },
+    "services.activate_led.fields.inter_delay1.description": {
+      "out": "6f3ba4ed2856",
+      "src": "1b65dcfcea95"
+    },
+    "services.activate_led.fields.inter_delay1.name": {
+      "out": "f141c6aeaef4",
+      "src": "71452f436c33"
+    },
+    "services.activate_led.fields.inter_delay2.description": {
+      "out": "227f3163a24b",
+      "src": "181e03f33cbf"
+    },
+    "services.activate_led.fields.inter_delay2.name": {
+      "out": "a9219c337347",
+      "src": "6a50551e5355"
+    },
+    "services.activate_led.fields.inter_delay3.description": {
+      "out": "ca27997486cc",
+      "src": "5c5973b586df"
+    },
+    "services.activate_led.fields.inter_delay3.name": {
+      "out": "34403326b62b",
+      "src": "b0f72903777e"
+    },
+    "services.activate_led.fields.loop_delay1.description": {
+      "out": "525cfeb38939",
+      "src": "2139915c35bc"
+    },
+    "services.activate_led.fields.loop_delay1.name": {
+      "out": "0cdde8c262c8",
+      "src": "2fb02375bae0"
+    },
+    "services.activate_led.fields.loop_delay2.description": {
+      "out": "2263042ae7d4",
+      "src": "9a3a8cccb3bb"
+    },
+    "services.activate_led.fields.loop_delay2.name": {
+      "out": "dd67b82f52f7",
+      "src": "597cbe87a7ec"
+    },
+    "services.activate_led.fields.loop_delay3.description": {
+      "out": "1c41f2a212e0",
+      "src": "8a965100226c"
+    },
+    "services.activate_led.fields.loop_delay3.name": {
+      "out": "74838e0b2bb8",
+      "src": "66d787aa1bad"
+    },
+    "services.activate_led.fields.repeats.description": {
+      "out": "fc191baa4995",
+      "src": "e40e956e3762"
+    },
+    "services.activate_led.fields.repeats.name": {
+      "out": "2f873dc8d821",
+      "src": "92ee0233f013"
+    },
+    "services.activate_led.name": {
+      "out": "bbc3fd64a081",
+      "src": "91933e94cc57"
+    },
+    "services.drawcustom.description": {
+      "out": "c3b0fa08c0e2",
+      "src": "55f9f3333fc0"
+    },
+    "services.drawcustom.fields.background.description": {
+      "out": "92dbf860d682",
+      "src": "f5858405d78a"
+    },
+    "services.drawcustom.fields.background.name": {
+      "out": "7d18ba3d4e8c",
+      "src": "3e314dafdf7c"
+    },
+    "services.drawcustom.fields.dither.description": {
+      "out": "43cc6a955e43",
+      "src": "d7c737e5d01e"
+    },
+    "services.drawcustom.fields.dither.name": {
+      "out": "65e62f3eabaf",
+      "src": "35fb13830002"
+    },
+    "services.drawcustom.fields.dry-run.description": {
+      "out": "30bd2c82753a",
+      "src": "54f5f06db00c"
+    },
+    "services.drawcustom.fields.dry-run.name": {
+      "out": "af699edeea2d",
+      "src": "d5da154d9f00"
+    },
+    "services.drawcustom.fields.measured_palette.description": {
+      "out": "17fc3b253a69",
+      "src": "53842124c7af"
+    },
+    "services.drawcustom.fields.measured_palette.name": {
+      "out": "cf0f0ae71e1c",
+      "src": "672d38bdeb19"
+    },
+    "services.drawcustom.fields.payload.description": {
+      "out": "b7eea1893c26",
+      "src": "a72e3d514ead"
+    },
+    "services.drawcustom.fields.payload.name": {
+      "out": "99733344956d",
+      "src": "99733344956d"
+    },
+    "services.drawcustom.fields.refresh_type.description": {
+      "out": "0bc3dd0c97cd",
+      "src": "d87a3d5c4d06"
+    },
+    "services.drawcustom.fields.refresh_type.name": {
+      "out": "7706d57c7878",
+      "src": "201b25b874bb"
+    },
+    "services.drawcustom.fields.rotate.description": {
+      "out": "454fda2bb671",
+      "src": "21e39f93db71"
+    },
+    "services.drawcustom.fields.rotate.name": {
+      "out": "54cde2c5d0dc",
+      "src": "57b5e2fc1bba"
+    },
+    "services.drawcustom.name": {
+      "out": "983cc0c2b23d",
+      "src": "d0df7a6244ea"
+    },
+    "services.upload_image.description": {
+      "out": "e0ff495d7a08",
+      "src": "24e19354eaa4"
+    },
+    "services.upload_image.fields.device_id.description": {
+      "out": "d5bb31349f9d",
+      "src": "ee157333391e"
+    },
+    "services.upload_image.fields.device_id.name": {
+      "out": "0e0a54c681e2",
+      "src": "6ba0bdeccb42"
+    },
+    "services.upload_image.fields.dither_mode.description": {
+      "out": "5f34f6b8bc82",
+      "src": "70483fdfe7ec"
+    },
+    "services.upload_image.fields.dither_mode.name": {
+      "out": "65e62f3eabaf",
+      "src": "35fb13830002"
+    },
+    "services.upload_image.fields.fit_mode.description": {
+      "out": "ae8000aba281",
+      "src": "8d2c8735a962"
+    },
+    "services.upload_image.fields.fit_mode.name": {
+      "out": "a5383a529d47",
+      "src": "8a59790c9187"
+    },
+    "services.upload_image.fields.image.description": {
+      "out": "15cb21b21c2c",
+      "src": "ba6d9fb759b0"
+    },
+    "services.upload_image.fields.image.name": {
+      "out": "b68d3009a8a8",
+      "src": "1aa4cb0bcca7"
+    },
+    "services.upload_image.fields.measured_palette.description": {
+      "out": "49598c65f3d4",
+      "src": "53842124c7af"
+    },
+    "services.upload_image.fields.measured_palette.name": {
+      "out": "cf0f0ae71e1c",
+      "src": "672d38bdeb19"
+    },
+    "services.upload_image.fields.refresh_mode.description": {
+      "out": "f79a2bbbc325",
+      "src": "0fe957da240a"
+    },
+    "services.upload_image.fields.refresh_mode.name": {
+      "out": "1bb55bc32fdb",
+      "src": "c72fd253298c"
+    },
+    "services.upload_image.fields.rotation.description": {
+      "out": "fb8c07da429a",
+      "src": "b639ab27209e"
+    },
+    "services.upload_image.fields.rotation.name": {
+      "out": "54cde2c5d0dc",
+      "src": "57b5e2fc1bba"
+    },
+    "services.upload_image.fields.tone_compression.description": {
+      "out": "4948f89d2185",
+      "src": "6453b45ae0cc"
+    },
+    "services.upload_image.fields.tone_compression.name": {
+      "out": "da7fa5a3a2c3",
+      "src": "ffaed65f03fa"
+    },
+    "services.upload_image.name": {
+      "out": "99c8b455db2e",
+      "src": "ffe4df6c7ca6"
+    },
+    "services.upload_image.sections.additional_fields.name": {
+      "out": "05cb4850f703",
+      "src": "092170b2408b"
+    },
+    "services.write_nfc.description": {
+      "out": "142e6f991dec",
+      "src": "3c1f6a6d643e"
+    },
+    "services.write_nfc.fields.content.description": {
+      "out": "65e31beafe43",
+      "src": "857d1cf0bf90"
+    },
+    "services.write_nfc.fields.content.name": {
+      "out": "0286255c9d0d",
+      "src": "47bd29075f8b"
+    },
+    "services.write_nfc.fields.device_id.description": {
+      "out": "56d438ed7456",
+      "src": "7dec980cb238"
+    },
+    "services.write_nfc.fields.device_id.name": {
+      "out": "0e0a54c681e2",
+      "src": "6ba0bdeccb42"
+    },
+    "services.write_nfc.fields.mime_type.description": {
+      "out": "0340c82247f4",
+      "src": "4eb2b40ec666"
+    },
+    "services.write_nfc.fields.mime_type.name": {
+      "out": "217809ebc697",
+      "src": "849e8a810960"
+    },
+    "services.write_nfc.fields.record_type.description": {
+      "out": "0023968493d7",
+      "src": "936cf634012f"
+    },
+    "services.write_nfc.fields.record_type.name": {
+      "out": "1654122245d3",
+      "src": "91cf117b1d70"
+    },
+    "services.write_nfc.name": {
+      "out": "74d126940437",
+      "src": "96ea14b97cf7"
+    }
+  },
+  "pl": {
+    "config.abort.already_configured": {
+      "out": "97c0139dfd70",
+      "src": "c2936e02a0d2"
+    },
+    "config.abort.already_in_progress": {
+      "out": "1b0116d4e2ce",
+      "src": "985a72ad93a3"
+    },
+    "config.abort.cannot_connect": {
+      "out": "c05eb31368c5",
+      "src": "46c9f3b7520f"
+    },
+    "config.abort.no_devices_found": {
+      "out": "d5583c81f32e",
+      "src": "b8f28e84cf0b"
+    },
+    "config.abort.reauth_successful": {
+      "out": "4e97976f368e",
+      "src": "e5b83989735c"
+    },
+    "config.abort.unknown": {
+      "out": "16c896774461",
+      "src": "d24c41ae530a"
+    },
+    "config.error.cannot_connect": {
+      "out": "c05eb31368c5",
+      "src": "46c9f3b7520f"
+    },
+    "config.error.invalid_auth": {
+      "out": "272c54a36da4",
+      "src": "4ca089878c5f"
+    },
+    "config.error.invalid_key_format": {
+      "out": "8256cdb88d1d",
+      "src": "f7b03dd699df"
+    },
+    "config.error.unknown": {
+      "out": "16c896774461",
+      "src": "d24c41ae530a"
+    },
+    "config.flow_title": {
+      "out": "5e291d7bcb2d",
+      "src": "5e291d7bcb2d"
+    },
+    "config.step.bluetooth_confirm.description": {
+      "out": "d1b7b3a598f6",
+      "src": "bcfd5a24b7d7"
+    },
+    "config.step.encryption_key.data.encryption_key": {
+      "out": "461667a14ec0",
+      "src": "16b3c9d5573d"
+    },
+    "config.step.encryption_key.data_description.encryption_key": {
+      "out": "091198a90d57",
+      "src": "e64cd2e7e647"
+    },
+    "config.step.encryption_key.description": {
+      "out": "004a00e79430",
+      "src": "664d3f12bfe6"
+    },
+    "config.step.encryption_key.title": {
+      "out": "d30cd9ea1714",
+      "src": "c30d1ca158a3"
+    },
+    "config.step.reauth_confirm.data.encryption_key": {
+      "out": "461667a14ec0",
+      "src": "16b3c9d5573d"
+    },
+    "config.step.reauth_confirm.data_description.encryption_key": {
+      "out": "091198a90d57",
+      "src": "e64cd2e7e647"
+    },
+    "config.step.reauth_confirm.description": {
+      "out": "2a769e50539d",
+      "src": "f53b69d3be84"
+    },
+    "config.step.reauth_confirm.title": {
+      "out": "ec53e40e2bae",
+      "src": "7e22a752572f"
+    },
+    "config.step.user.data.address": {
+      "out": "5c72d15d094f",
+      "src": "6ba0bdeccb42"
+    },
+    "config.step.user.data_description.address": {
+      "out": "0e05c8a3dd11",
+      "src": "a083a457cfb1"
+    },
+    "config.step.user.description": {
+      "out": "29d3b3fd16aa",
+      "src": "109135454652"
+    },
+    "entity.binary_sensor.update_pending.name": {
+      "out": "6fad1ebd0512",
+      "src": "8e0a4b18ae75"
+    },
+    "entity.event.button.name": {
+      "out": "97c874f78dd0",
+      "src": "2dcae43716c2"
+    },
+    "entity.event.button.state_attributes.event_type.state.button_down": {
+      "out": "ccd0b5875ef8",
+      "src": "8352c89d20b4"
+    },
+    "entity.event.button.state_attributes.event_type.state.button_up": {
+      "out": "b9ac9ecb4a44",
+      "src": "7f18b4912929"
+    },
+    "entity.event.touch.name": {
+      "out": "b415304a8343",
+      "src": "c915d14278fc"
+    },
+    "entity.event.touch.state_attributes.event_type.state.touch_down": {
+      "out": "a398ea808da6",
+      "src": "0234a9576230"
+    },
+    "entity.event.touch.state_attributes.event_type.state.touch_move": {
+      "out": "2650f44b98db",
+      "src": "67aeac815e94"
+    },
+    "entity.event.touch.state_attributes.event_type.state.touch_up": {
+      "out": "592faa55ad1a",
+      "src": "7c65519d3bb3"
+    },
+    "entity.image.content.name": {
+      "out": "1fbb4876113e",
+      "src": "047c6db3382a"
+    },
+    "entity.sensor.battery_voltage.name": {
+      "out": "b0054cb59b34",
+      "src": "39d6c91b57ce"
+    },
+    "entity.sensor.last_seen.name": {
+      "out": "ab7234aa45fa",
+      "src": "21fd79c7de52"
+    },
+    "entity.sensor.rssi.name": {
+      "out": "11168c1d9026",
+      "src": "2604d15c1187"
+    },
+    "entity.update.firmware.name": {
+      "out": "a4d7d2f2d26a",
+      "src": "c2a314c3b32b"
+    },
+    "exceptions.authentication_error.message": {
+      "out": "b7f02c4bb3f9",
+      "src": "3d9f7c0c6d80"
+    },
+    "exceptions.device_not_found.message": {
+      "out": "3701c74aad7c",
+      "src": "f244d0d2db8d"
+    },
+    "exceptions.device_sleeping.message": {
+      "out": "2216c5b0a968",
+      "src": "e95d25bd6fc7"
+    },
+    "exceptions.device_sleeping_ota.message": {
+      "out": "0192d49a67dd",
+      "src": "430e3a1baa6a"
+    },
+    "exceptions.invalid_device_id.message": {
+      "out": "8aa03e853d19",
+      "src": "cc64cc29ceeb"
+    },
+    "exceptions.media_download_error.message": {
+      "out": "7deddd9f19d7",
+      "src": "5852129dd920"
+    },
+    "exceptions.mime_type_not_applicable.message": {
+      "out": "bd333cd592af",
+      "src": "de700f02fbd5"
+    },
+    "exceptions.multiple_errors.message": {
+      "out": "b5d5ed102c46",
+      "src": "f17c68e0a848"
+    },
+    "exceptions.nfc_content_empty.message": {
+      "out": "54f20d9c8dd7",
+      "src": "b93a1a6ebdc0"
+    },
+    "exceptions.nfc_content_too_long.message": {
+      "out": "cc979f81eef6",
+      "src": "8f580b9c6c76"
+    },
+    "exceptions.nfc_mime_type_invalid.message": {
+      "out": "d7d4581b998f",
+      "src": "5a5f44fe332f"
+    },
+    "exceptions.nfc_not_supported.message": {
+      "out": "9de7b8ec4029",
+      "src": "8fdcd0e2bd17"
+    },
+    "exceptions.nfc_write_failed.message": {
+      "out": "3db2600787a6",
+      "src": "e8186303a52e"
+    },
+    "exceptions.no_buzzers.message": {
+      "out": "ede3df71a984",
+      "src": "9c014dfeac91"
+    },
+    "exceptions.no_leds.message": {
+      "out": "45037de77499",
+      "src": "6a302f8f22ee"
+    },
+    "exceptions.no_nfc.message": {
+      "out": "3fbd00e69614",
+      "src": "abb1917ad57e"
+    },
+    "exceptions.no_targets_specified.message": {
+      "out": "9753955e1882",
+      "src": "80c472afefe6"
+    },
+    "exceptions.upload_error.message": {
+      "out": "781b6268b30d",
+      "src": "75561a03be6e"
+    },
+    "exceptions.url_not_allowed.message": {
+      "out": "6ee8fc0b163f",
+      "src": "33ffb9a9f2c4"
+    },
+    "options.step.init.data.blocks_per_ack": {
+      "out": "c908f1878f2b",
+      "src": "3e2a554e69a4"
+    },
+    "options.step.init.data.max_queue_size": {
+      "out": "c4c1a87f69e5",
+      "src": "297af7027dd0"
+    },
+    "options.step.init.data.missed_cycles": {
+      "out": "cae4faced2df",
+      "src": "59b78644491a"
+    },
+    "options.step.init.data.probe_before_queue": {
+      "out": "a918722b4938",
+      "src": "02c4211a58b2"
+    },
+    "options.step.init.data.queue_timeout_hours": {
+      "out": "b18b431f5913",
+      "src": "be70fc5cca79"
+    },
+    "options.step.init.data.sleep_mode": {
+      "out": "ebb1d30f6d9f",
+      "src": "f925c0e541ce"
+    },
+    "options.step.init.data_description.blocks_per_ack": {
+      "out": "238540d4d0e0",
+      "src": "3a693b19d3c6"
+    },
+    "options.step.init.data_description.max_queue_size": {
+      "out": "086aafdfcfef",
+      "src": "50260959ee56"
+    },
+    "options.step.init.data_description.missed_cycles": {
+      "out": "6dca59616d2e",
+      "src": "6ce493f4c44d"
+    },
+    "options.step.init.data_description.probe_before_queue": {
+      "out": "9628e8e06bee",
+      "src": "5d0f2985ffdf"
+    },
+    "options.step.init.data_description.queue_timeout_hours": {
+      "out": "fd7e9853fded",
+      "src": "34895000b491"
+    },
+    "options.step.init.data_description.sleep_mode": {
+      "out": "7520ea638004",
+      "src": "4acfeb65d10d"
+    },
+    "selector.dither_mode.options.atkinson": {
+      "out": "7a8fe6d47b5b",
+      "src": "7a8fe6d47b5b"
+    },
+    "selector.dither_mode.options.burkes": {
+      "out": "1b75087201fb",
+      "src": "1b75087201fb"
+    },
+    "selector.dither_mode.options.floyd_steinberg": {
+      "out": "37969811a3cf",
+      "src": "37969811a3cf"
+    },
+    "selector.dither_mode.options.jarvis_judice_ninke": {
+      "out": "7020241adf78",
+      "src": "7020241adf78"
+    },
+    "selector.dither_mode.options.none": {
+      "out": "b30f40d8dbce",
+      "src": "dc937b598926"
+    },
+    "selector.dither_mode.options.ordered": {
+      "out": "433e5990e88d",
+      "src": "007877479e21"
+    },
+    "selector.dither_mode.options.sierra": {
+      "out": "d5eef8ad210c",
+      "src": "d5eef8ad210c"
+    },
+    "selector.dither_mode.options.sierra_lite": {
+      "out": "20da8cc85f38",
+      "src": "20da8cc85f38"
+    },
+    "selector.dither_mode.options.stucki": {
+      "out": "a17d2b13b6f9",
+      "src": "a17d2b13b6f9"
+    },
+    "selector.fit_mode.options.contain": {
+      "out": "10c79152695e",
+      "src": "e534a2c2b456"
+    },
+    "selector.fit_mode.options.cover": {
+      "out": "ad6eb90d9619",
+      "src": "fa8d84566676"
+    },
+    "selector.fit_mode.options.crop": {
+      "out": "74ce2120b6ba",
+      "src": "98caf7c43c6f"
+    },
+    "selector.fit_mode.options.stretch": {
+      "out": "673801477566",
+      "src": "a33fbcf83f7b"
+    },
+    "selector.nfc_record_type.options.ha_tag": {
+      "out": "b74c1bf15cfa",
+      "src": "d1d47a8fa544"
+    },
+    "selector.nfc_record_type.options.mime": {
+      "out": "4b9a862de3f3",
+      "src": "f98d7539e627"
+    },
+    "selector.nfc_record_type.options.text": {
+      "out": "5d07abcd8c8c",
+      "src": "71988c4d8e08"
+    },
+    "selector.nfc_record_type.options.url": {
+      "out": "e7a241debad5",
+      "src": "e7a241debad5"
+    },
+    "selector.refresh_mode.options.fast": {
+      "out": "6107d2336cb1",
+      "src": "6c582b62e0e5"
+    },
+    "selector.refresh_mode.options.full": {
+      "out": "1f965d7d73ad",
+      "src": "008dacb6d1e8"
+    },
+    "selector.refresh_mode.options.partial": {
+      "out": "059ce04698ef",
+      "src": "a4d50fb85403"
+    },
+    "selector.sleep_mode.options.auto": {
+      "out": "e13075cc902e",
+      "src": "132990bd8ef7"
+    },
+    "selector.sleep_mode.options.off": {
+      "out": "81b5639bd853",
+      "src": "34598efe7b90"
+    },
+    "selector.sleep_mode.options.on": {
+      "out": "23a265677316",
+      "src": "bde131e31c9e"
+    },
+    "services.activate_buzzer.description": {
+      "out": "7fe759fa3bf6",
+      "src": "1898784614cb"
+    },
+    "services.activate_buzzer.fields.device_id.description": {
+      "out": "59b92f8722df",
+      "src": "7dec980cb238"
+    },
+    "services.activate_buzzer.fields.device_id.name": {
+      "out": "5c72d15d094f",
+      "src": "6ba0bdeccb42"
+    },
+    "services.activate_buzzer.fields.duration_ms.description": {
+      "out": "a064bb175973",
+      "src": "cd1bc75ca60c"
+    },
+    "services.activate_buzzer.fields.duration_ms.name": {
+      "out": "119496feb778",
+      "src": "4fc52a3c4c55"
+    },
+    "services.activate_buzzer.fields.frequency_hz.description": {
+      "out": "b81ffe0280b1",
+      "src": "510fc20311e3"
+    },
+    "services.activate_buzzer.fields.frequency_hz.name": {
+      "out": "4c4e8557c086",
+      "src": "16b6668d9831"
+    },
+    "services.activate_buzzer.fields.instance.description": {
+      "out": "a5372770f8a7",
+      "src": "f39fa742d55c"
+    },
+    "services.activate_buzzer.fields.instance.name": {
+      "out": "7ef53bf746ba",
+      "src": "1f671ddded9e"
+    },
+    "services.activate_buzzer.fields.repeats.description": {
+      "out": "4f62a790b90f",
+      "src": "1f88b0fe23ea"
+    },
+    "services.activate_buzzer.fields.repeats.name": {
+      "out": "df33d7880448",
+      "src": "92ee0233f013"
+    },
+    "services.activate_buzzer.name": {
+      "out": "81cf6025de0d",
+      "src": "0b80285753b7"
+    },
+    "services.activate_led.description": {
+      "out": "a98172f5fdf3",
+      "src": "6cbd645597cc"
+    },
+    "services.activate_led.fields.brightness.description": {
+      "out": "91cb414b24fc",
+      "src": "6ad88a28230d"
+    },
+    "services.activate_led.fields.brightness.name": {
+      "out": "787b2a6f2462",
+      "src": "ec811d30a89c"
+    },
+    "services.activate_led.fields.color1.description": {
+      "out": "45e4e737e9e5",
+      "src": "17f145013241"
+    },
+    "services.activate_led.fields.color1.name": {
+      "out": "e77cf52832d6",
+      "src": "571461f36f3a"
+    },
+    "services.activate_led.fields.color2.description": {
+      "out": "4e2ff0ee6649",
+      "src": "f2680a4bbe85"
+    },
+    "services.activate_led.fields.color2.name": {
+      "out": "5259747029ef",
+      "src": "ef792d287872"
+    },
+    "services.activate_led.fields.color3.description": {
+      "out": "e6d2dbc5c597",
+      "src": "b8ecd353b426"
+    },
+    "services.activate_led.fields.color3.name": {
+      "out": "fb8bc6bfa982",
+      "src": "48d54e046d29"
+    },
+    "services.activate_led.fields.device_id.description": {
+      "out": "59b92f8722df",
+      "src": "7dec980cb238"
+    },
+    "services.activate_led.fields.device_id.name": {
+      "out": "5c72d15d094f",
+      "src": "6ba0bdeccb42"
+    },
+    "services.activate_led.fields.flash_count1.description": {
+      "out": "4cf58bce582d",
+      "src": "4ffdadde31c2"
+    },
+    "services.activate_led.fields.flash_count1.name": {
+      "out": "a8223e2f25a3",
+      "src": "13c6a2e5c22e"
+    },
+    "services.activate_led.fields.flash_count2.description": {
+      "out": "dc390ce4aeb1",
+      "src": "86dc999a3915"
+    },
+    "services.activate_led.fields.flash_count2.name": {
+      "out": "562919c1fed9",
+      "src": "2be36d8449dc"
+    },
+    "services.activate_led.fields.flash_count3.description": {
+      "out": "a9d417ea8ce9",
+      "src": "aa40c396a9a4"
+    },
+    "services.activate_led.fields.flash_count3.name": {
+      "out": "1a992ea28e0e",
+      "src": "7978910dc6b2"
+    },
+    "services.activate_led.fields.instance.description": {
+      "out": "23b7d4723e5f",
+      "src": "0531b37de90a"
+    },
+    "services.activate_led.fields.instance.name": {
+      "out": "6ec3c2dc06ac",
+      "src": "f942926204c7"
+    },
+    "services.activate_led.fields.inter_delay1.description": {
+      "out": "1b4fe47e4b68",
+      "src": "1b65dcfcea95"
+    },
+    "services.activate_led.fields.inter_delay1.name": {
+      "out": "e5172a98cd14",
+      "src": "71452f436c33"
+    },
+    "services.activate_led.fields.inter_delay2.description": {
+      "out": "f5d792954f0d",
+      "src": "181e03f33cbf"
+    },
+    "services.activate_led.fields.inter_delay2.name": {
+      "out": "1f5f71ce46bf",
+      "src": "6a50551e5355"
+    },
+    "services.activate_led.fields.inter_delay3.description": {
+      "out": "ba7c678a8bf1",
+      "src": "5c5973b586df"
+    },
+    "services.activate_led.fields.inter_delay3.name": {
+      "out": "f3b41f142a2b",
+      "src": "b0f72903777e"
+    },
+    "services.activate_led.fields.loop_delay1.description": {
+      "out": "3a5f0c4fff5e",
+      "src": "2139915c35bc"
+    },
+    "services.activate_led.fields.loop_delay1.name": {
+      "out": "2a3864dea098",
+      "src": "2fb02375bae0"
+    },
+    "services.activate_led.fields.loop_delay2.description": {
+      "out": "339c1bbe3e1c",
+      "src": "9a3a8cccb3bb"
+    },
+    "services.activate_led.fields.loop_delay2.name": {
+      "out": "5b817619a14d",
+      "src": "597cbe87a7ec"
+    },
+    "services.activate_led.fields.loop_delay3.description": {
+      "out": "df58d76abd54",
+      "src": "8a965100226c"
+    },
+    "services.activate_led.fields.loop_delay3.name": {
+      "out": "d2ef03a35a26",
+      "src": "66d787aa1bad"
+    },
+    "services.activate_led.fields.repeats.description": {
+      "out": "fa5c34282405",
+      "src": "e40e956e3762"
+    },
+    "services.activate_led.fields.repeats.name": {
+      "out": "df33d7880448",
+      "src": "92ee0233f013"
+    },
+    "services.activate_led.name": {
+      "out": "50820b2d0e96",
+      "src": "91933e94cc57"
+    },
+    "services.drawcustom.description": {
+      "out": "91ba56da32b5",
+      "src": "55f9f3333fc0"
+    },
+    "services.drawcustom.fields.background.description": {
+      "out": "4792411fced4",
+      "src": "f5858405d78a"
+    },
+    "services.drawcustom.fields.background.name": {
+      "out": "09e61720b37b",
+      "src": "3e314dafdf7c"
+    },
+    "services.drawcustom.fields.dither.description": {
+      "out": "05ca87404b5a",
+      "src": "d7c737e5d01e"
+    },
+    "services.drawcustom.fields.dither.name": {
+      "out": "22762d93021c",
+      "src": "35fb13830002"
+    },
+    "services.drawcustom.fields.dry-run.description": {
+      "out": "d2603aa6f73a",
+      "src": "54f5f06db00c"
+    },
+    "services.drawcustom.fields.dry-run.name": {
+      "out": "1a6e5991510a",
+      "src": "d5da154d9f00"
+    },
+    "services.drawcustom.fields.measured_palette.description": {
+      "out": "86118979b5c5",
+      "src": "53842124c7af"
+    },
+    "services.drawcustom.fields.measured_palette.name": {
+      "out": "0dc89a1bd99a",
+      "src": "672d38bdeb19"
+    },
+    "services.drawcustom.fields.payload.description": {
+      "out": "42d856db003c",
+      "src": "a72e3d514ead"
+    },
+    "services.drawcustom.fields.payload.name": {
+      "out": "79cfa503bcf0",
+      "src": "99733344956d"
+    },
+    "services.drawcustom.fields.refresh_type.description": {
+      "out": "d4752cef1b7b",
+      "src": "d87a3d5c4d06"
+    },
+    "services.drawcustom.fields.refresh_type.name": {
+      "out": "447179c803cf",
+      "src": "201b25b874bb"
+    },
+    "services.drawcustom.fields.rotate.description": {
+      "out": "b2417d015c10",
+      "src": "21e39f93db71"
+    },
+    "services.drawcustom.fields.rotate.name": {
+      "out": "01f2743fbfe3",
+      "src": "57b5e2fc1bba"
+    },
+    "services.drawcustom.name": {
+      "out": "e3bfe60f32f2",
+      "src": "d0df7a6244ea"
+    },
+    "services.upload_image.description": {
+      "out": "804be76a6be5",
+      "src": "24e19354eaa4"
+    },
+    "services.upload_image.fields.device_id.description": {
+      "out": "6a2a8fa3f62b",
+      "src": "ee157333391e"
+    },
+    "services.upload_image.fields.device_id.name": {
+      "out": "5c72d15d094f",
+      "src": "6ba0bdeccb42"
+    },
+    "services.upload_image.fields.dither_mode.description": {
+      "out": "6dac7aedfa6f",
+      "src": "70483fdfe7ec"
+    },
+    "services.upload_image.fields.dither_mode.name": {
+      "out": "22762d93021c",
+      "src": "35fb13830002"
+    },
+    "services.upload_image.fields.fit_mode.description": {
+      "out": "56bc2cec177d",
+      "src": "8d2c8735a962"
+    },
+    "services.upload_image.fields.fit_mode.name": {
+      "out": "634e0197affc",
+      "src": "8a59790c9187"
+    },
+    "services.upload_image.fields.image.description": {
+      "out": "4d826c5920f1",
+      "src": "ba6d9fb759b0"
+    },
+    "services.upload_image.fields.image.name": {
+      "out": "98732be95aba",
+      "src": "1aa4cb0bcca7"
+    },
+    "services.upload_image.fields.measured_palette.description": {
+      "out": "88f42f4c1f04",
+      "src": "53842124c7af"
+    },
+    "services.upload_image.fields.measured_palette.name": {
+      "out": "0dc89a1bd99a",
+      "src": "672d38bdeb19"
+    },
+    "services.upload_image.fields.refresh_mode.description": {
+      "out": "2c1e87687bda",
+      "src": "0fe957da240a"
+    },
+    "services.upload_image.fields.refresh_mode.name": {
+      "out": "9fe0a274b5c7",
+      "src": "c72fd253298c"
+    },
+    "services.upload_image.fields.rotation.description": {
+      "out": "41acbe171017",
+      "src": "b639ab27209e"
+    },
+    "services.upload_image.fields.rotation.name": {
+      "out": "01f2743fbfe3",
+      "src": "57b5e2fc1bba"
+    },
+    "services.upload_image.fields.tone_compression.description": {
+      "out": "7b56fb88a56e",
+      "src": "6453b45ae0cc"
+    },
+    "services.upload_image.fields.tone_compression.name": {
+      "out": "b303ed82470b",
+      "src": "ffaed65f03fa"
+    },
+    "services.upload_image.name": {
+      "out": "39ed4b94ad28",
+      "src": "ffe4df6c7ca6"
+    },
+    "services.upload_image.sections.additional_fields.name": {
+      "out": "479054da3881",
+      "src": "092170b2408b"
+    },
+    "services.write_nfc.description": {
+      "out": "370e3aca0845",
+      "src": "3c1f6a6d643e"
+    },
+    "services.write_nfc.fields.content.description": {
+      "out": "6dc827ae64f8",
+      "src": "857d1cf0bf90"
+    },
+    "services.write_nfc.fields.content.name": {
+      "out": "3fb7430d89a9",
+      "src": "47bd29075f8b"
+    },
+    "services.write_nfc.fields.device_id.description": {
+      "out": "59b92f8722df",
+      "src": "7dec980cb238"
+    },
+    "services.write_nfc.fields.device_id.name": {
+      "out": "5c72d15d094f",
+      "src": "6ba0bdeccb42"
+    },
+    "services.write_nfc.fields.mime_type.description": {
+      "out": "629fc23445d5",
+      "src": "4eb2b40ec666"
+    },
+    "services.write_nfc.fields.mime_type.name": {
+      "out": "ccd03106d237",
+      "src": "849e8a810960"
+    },
+    "services.write_nfc.fields.record_type.description": {
+      "out": "51348cf060a0",
+      "src": "936cf634012f"
+    },
+    "services.write_nfc.fields.record_type.name": {
+      "out": "39567fc896b3",
+      "src": "91cf117b1d70"
+    },
+    "services.write_nfc.name": {
+      "out": "fe0467e9a56d",
+      "src": "96ea14b97cf7"
+    }
+  },
+  "pt-BR": {
+    "config.abort.already_configured": {
+      "out": "dd3b80abffdd",
+      "src": "c2936e02a0d2"
+    },
+    "config.abort.already_in_progress": {
+      "out": "75b4c720d7cf",
+      "src": "985a72ad93a3"
+    },
+    "config.abort.cannot_connect": {
+      "out": "49e6f1def75f",
+      "src": "46c9f3b7520f"
+    },
+    "config.abort.no_devices_found": {
+      "out": "99b93bd5fcb6",
+      "src": "b8f28e84cf0b"
+    },
+    "config.abort.reauth_successful": {
+      "out": "c3a3779b59e8",
+      "src": "e5b83989735c"
+    },
+    "config.abort.unknown": {
+      "out": "ad9544920db5",
+      "src": "d24c41ae530a"
+    },
+    "config.error.cannot_connect": {
+      "out": "49e6f1def75f",
+      "src": "46c9f3b7520f"
+    },
+    "config.error.invalid_auth": {
+      "out": "80c2dd42d824",
+      "src": "4ca089878c5f"
+    },
+    "config.error.invalid_key_format": {
+      "out": "5ad480a7dbf9",
+      "src": "f7b03dd699df"
+    },
+    "config.error.unknown": {
+      "out": "ad9544920db5",
+      "src": "d24c41ae530a"
+    },
+    "config.flow_title": {
+      "out": "5e291d7bcb2d",
+      "src": "5e291d7bcb2d"
+    },
+    "config.step.bluetooth_confirm.description": {
+      "out": "9e758bdb4d0a",
+      "src": "bcfd5a24b7d7"
+    },
+    "config.step.encryption_key.data.encryption_key": {
+      "out": "30473842fa0d",
+      "src": "16b3c9d5573d"
+    },
+    "config.step.encryption_key.data_description.encryption_key": {
+      "out": "a4242d7514ce",
+      "src": "e64cd2e7e647"
+    },
+    "config.step.encryption_key.description": {
+      "out": "38525fe63015",
+      "src": "664d3f12bfe6"
+    },
+    "config.step.encryption_key.title": {
+      "out": "60f576819b33",
+      "src": "c30d1ca158a3"
+    },
+    "config.step.reauth_confirm.data.encryption_key": {
+      "out": "30473842fa0d",
+      "src": "16b3c9d5573d"
+    },
+    "config.step.reauth_confirm.data_description.encryption_key": {
+      "out": "a4242d7514ce",
+      "src": "e64cd2e7e647"
+    },
+    "config.step.reauth_confirm.description": {
+      "out": "d329f39cdde5",
+      "src": "f53b69d3be84"
+    },
+    "config.step.reauth_confirm.title": {
+      "out": "a434d6e7a842",
+      "src": "7e22a752572f"
+    },
+    "config.step.user.data.address": {
+      "out": "1c555eb7f1c0",
+      "src": "6ba0bdeccb42"
+    },
+    "config.step.user.data_description.address": {
+      "out": "68fbf6a80aac",
+      "src": "a083a457cfb1"
+    },
+    "config.step.user.description": {
+      "out": "b90ef1e43fe2",
+      "src": "109135454652"
+    },
+    "entity.binary_sensor.update_pending.name": {
+      "out": "ead340a37e92",
+      "src": "8e0a4b18ae75"
+    },
+    "entity.event.button.name": {
+      "out": "4111fd0385ea",
+      "src": "2dcae43716c2"
+    },
+    "entity.event.button.state_attributes.event_type.state.button_down": {
+      "out": "1d1f3249eb2c",
+      "src": "8352c89d20b4"
+    },
+    "entity.event.button.state_attributes.event_type.state.button_up": {
+      "out": "881d0dec6932",
+      "src": "7f18b4912929"
+    },
+    "entity.event.touch.name": {
+      "out": "837842a1ac38",
+      "src": "c915d14278fc"
+    },
+    "entity.event.touch.state_attributes.event_type.state.touch_down": {
+      "out": "eed1a75d8672",
+      "src": "0234a9576230"
+    },
+    "entity.event.touch.state_attributes.event_type.state.touch_move": {
+      "out": "14b0a47ffaef",
+      "src": "67aeac815e94"
+    },
+    "entity.event.touch.state_attributes.event_type.state.touch_up": {
+      "out": "fb2fc38bb228",
+      "src": "7c65519d3bb3"
+    },
+    "entity.image.content.name": {
+      "out": "5711fb229b61",
+      "src": "047c6db3382a"
+    },
+    "entity.sensor.battery_voltage.name": {
+      "out": "9558199749f3",
+      "src": "39d6c91b57ce"
+    },
+    "entity.sensor.last_seen.name": {
+      "out": "a060c6768208",
+      "src": "21fd79c7de52"
+    },
+    "entity.sensor.rssi.name": {
+      "out": "e56501a19190",
+      "src": "2604d15c1187"
+    },
+    "entity.update.firmware.name": {
+      "out": "c2a314c3b32b",
+      "src": "c2a314c3b32b"
+    },
+    "exceptions.authentication_error.message": {
+      "out": "09ff0363aa17",
+      "src": "3d9f7c0c6d80"
+    },
+    "exceptions.device_not_found.message": {
+      "out": "dd2fad6c9806",
+      "src": "f244d0d2db8d"
+    },
+    "exceptions.device_sleeping.message": {
+      "out": "fca193a03cca",
+      "src": "e95d25bd6fc7"
+    },
+    "exceptions.device_sleeping_ota.message": {
+      "out": "b0d5ab4a0e7e",
+      "src": "430e3a1baa6a"
+    },
+    "exceptions.invalid_device_id.message": {
+      "out": "f001b2f55b3b",
+      "src": "cc64cc29ceeb"
+    },
+    "exceptions.media_download_error.message": {
+      "out": "a3c0a46506c3",
+      "src": "5852129dd920"
+    },
+    "exceptions.mime_type_not_applicable.message": {
+      "out": "4dba9dc9cf06",
+      "src": "de700f02fbd5"
+    },
+    "exceptions.multiple_errors.message": {
+      "out": "be3dca23ac69",
+      "src": "f17c68e0a848"
+    },
+    "exceptions.nfc_content_empty.message": {
+      "out": "18796d161a54",
+      "src": "b93a1a6ebdc0"
+    },
+    "exceptions.nfc_content_too_long.message": {
+      "out": "c00d4010d19d",
+      "src": "8f580b9c6c76"
+    },
+    "exceptions.nfc_mime_type_invalid.message": {
+      "out": "ab146b824727",
+      "src": "5a5f44fe332f"
+    },
+    "exceptions.nfc_not_supported.message": {
+      "out": "4fae039f6bde",
+      "src": "8fdcd0e2bd17"
+    },
+    "exceptions.nfc_write_failed.message": {
+      "out": "549fdf773195",
+      "src": "e8186303a52e"
+    },
+    "exceptions.no_buzzers.message": {
+      "out": "79675db97ead",
+      "src": "9c014dfeac91"
+    },
+    "exceptions.no_leds.message": {
+      "out": "5ea1a19390b6",
+      "src": "6a302f8f22ee"
+    },
+    "exceptions.no_nfc.message": {
+      "out": "9f2692ab0584",
+      "src": "abb1917ad57e"
+    },
+    "exceptions.no_targets_specified.message": {
+      "out": "82b619c1673b",
+      "src": "80c472afefe6"
+    },
+    "exceptions.upload_error.message": {
+      "out": "1462256b83ef",
+      "src": "75561a03be6e"
+    },
+    "exceptions.url_not_allowed.message": {
+      "out": "7a9528bffb26",
+      "src": "33ffb9a9f2c4"
+    },
+    "options.step.init.data.blocks_per_ack": {
+      "out": "b3fa9ef0928e",
+      "src": "3e2a554e69a4"
+    },
+    "options.step.init.data.max_queue_size": {
+      "out": "8a1bef728edd",
+      "src": "297af7027dd0"
+    },
+    "options.step.init.data.missed_cycles": {
+      "out": "8c13f06661c0",
+      "src": "59b78644491a"
+    },
+    "options.step.init.data.probe_before_queue": {
+      "out": "096e2800d348",
+      "src": "02c4211a58b2"
+    },
+    "options.step.init.data.queue_timeout_hours": {
+      "out": "bcc4fff0e185",
+      "src": "be70fc5cca79"
+    },
+    "options.step.init.data.sleep_mode": {
+      "out": "f22b93baf411",
+      "src": "f925c0e541ce"
+    },
+    "options.step.init.data_description.blocks_per_ack": {
+      "out": "d4310ef82bb5",
+      "src": "3a693b19d3c6"
+    },
+    "options.step.init.data_description.max_queue_size": {
+      "out": "f154752824d5",
+      "src": "50260959ee56"
+    },
+    "options.step.init.data_description.missed_cycles": {
+      "out": "5c01b85067e3",
+      "src": "6ce493f4c44d"
+    },
+    "options.step.init.data_description.probe_before_queue": {
+      "out": "9320c008fc80",
+      "src": "5d0f2985ffdf"
+    },
+    "options.step.init.data_description.queue_timeout_hours": {
+      "out": "f4d40da4fe5b",
+      "src": "34895000b491"
+    },
+    "options.step.init.data_description.sleep_mode": {
+      "out": "f75a06dbe12d",
+      "src": "4acfeb65d10d"
+    },
+    "selector.dither_mode.options.atkinson": {
+      "out": "7a8fe6d47b5b",
+      "src": "7a8fe6d47b5b"
+    },
+    "selector.dither_mode.options.burkes": {
+      "out": "1b75087201fb",
+      "src": "1b75087201fb"
+    },
+    "selector.dither_mode.options.floyd_steinberg": {
+      "out": "37969811a3cf",
+      "src": "37969811a3cf"
+    },
+    "selector.dither_mode.options.jarvis_judice_ninke": {
+      "out": "7020241adf78",
+      "src": "7020241adf78"
+    },
+    "selector.dither_mode.options.none": {
+      "out": "496a53a0f11e",
+      "src": "dc937b598926"
+    },
+    "selector.dither_mode.options.ordered": {
+      "out": "d2aba6849adb",
+      "src": "007877479e21"
+    },
+    "selector.dither_mode.options.sierra": {
+      "out": "d5eef8ad210c",
+      "src": "d5eef8ad210c"
+    },
+    "selector.dither_mode.options.sierra_lite": {
+      "out": "20da8cc85f38",
+      "src": "20da8cc85f38"
+    },
+    "selector.dither_mode.options.stucki": {
+      "out": "a17d2b13b6f9",
+      "src": "a17d2b13b6f9"
+    },
+    "selector.fit_mode.options.contain": {
+      "out": "a190afc4b4ad",
+      "src": "e534a2c2b456"
+    },
+    "selector.fit_mode.options.cover": {
+      "out": "236ed490ad06",
+      "src": "fa8d84566676"
+    },
+    "selector.fit_mode.options.crop": {
+      "out": "2f04fbd94be9",
+      "src": "98caf7c43c6f"
+    },
+    "selector.fit_mode.options.stretch": {
+      "out": "63031bd7189f",
+      "src": "a33fbcf83f7b"
+    },
+    "selector.nfc_record_type.options.ha_tag": {
+      "out": "865fe819376c",
+      "src": "d1d47a8fa544"
+    },
+    "selector.nfc_record_type.options.mime": {
+      "out": "c2bd593b48e2",
+      "src": "f98d7539e627"
+    },
+    "selector.nfc_record_type.options.text": {
+      "out": "6df3d6661c09",
+      "src": "71988c4d8e08"
+    },
+    "selector.nfc_record_type.options.url": {
+      "out": "e7a241debad5",
+      "src": "e7a241debad5"
+    },
+    "selector.refresh_mode.options.fast": {
+      "out": "76495f26e6c5",
+      "src": "6c582b62e0e5"
+    },
+    "selector.refresh_mode.options.full": {
+      "out": "23e3685fbe6c",
+      "src": "008dacb6d1e8"
+    },
+    "selector.refresh_mode.options.partial": {
+      "out": "154b61b1e9da",
+      "src": "a4d50fb85403"
+    },
+    "selector.sleep_mode.options.auto": {
+      "out": "7557cb15b0a8",
+      "src": "132990bd8ef7"
+    },
+    "selector.sleep_mode.options.off": {
+      "out": "e0730e1a1194",
+      "src": "34598efe7b90"
+    },
+    "selector.sleep_mode.options.on": {
+      "out": "8d06f622b89e",
+      "src": "bde131e31c9e"
+    },
+    "services.activate_buzzer.description": {
+      "out": "d4c30266033a",
+      "src": "1898784614cb"
+    },
+    "services.activate_buzzer.fields.device_id.description": {
+      "out": "8533aacf2904",
+      "src": "7dec980cb238"
+    },
+    "services.activate_buzzer.fields.device_id.name": {
+      "out": "1c555eb7f1c0",
+      "src": "6ba0bdeccb42"
+    },
+    "services.activate_buzzer.fields.duration_ms.description": {
+      "out": "c8b37eb09106",
+      "src": "cd1bc75ca60c"
+    },
+    "services.activate_buzzer.fields.duration_ms.name": {
+      "out": "6cecb49a79df",
+      "src": "4fc52a3c4c55"
+    },
+    "services.activate_buzzer.fields.frequency_hz.description": {
+      "out": "7b1bb1eec059",
+      "src": "510fc20311e3"
+    },
+    "services.activate_buzzer.fields.frequency_hz.name": {
+      "out": "4ccef85f69f6",
+      "src": "16b6668d9831"
+    },
+    "services.activate_buzzer.fields.instance.description": {
+      "out": "5eb44e6b6ba0",
+      "src": "f39fa742d55c"
+    },
+    "services.activate_buzzer.fields.instance.name": {
+      "out": "7ce81db09421",
+      "src": "1f671ddded9e"
+    },
+    "services.activate_buzzer.fields.repeats.description": {
+      "out": "3dfd2b7ef116",
+      "src": "1f88b0fe23ea"
+    },
+    "services.activate_buzzer.fields.repeats.name": {
+      "out": "49ddd1cb9a27",
+      "src": "92ee0233f013"
+    },
+    "services.activate_buzzer.name": {
+      "out": "1d809ae66dbe",
+      "src": "0b80285753b7"
+    },
+    "services.activate_led.description": {
+      "out": "dae0b6106c90",
+      "src": "6cbd645597cc"
+    },
+    "services.activate_led.fields.brightness.description": {
+      "out": "345a664f32bb",
+      "src": "6ad88a28230d"
+    },
+    "services.activate_led.fields.brightness.name": {
+      "out": "ff070ada77b9",
+      "src": "ec811d30a89c"
+    },
+    "services.activate_led.fields.color1.description": {
+      "out": "9fc052573aad",
+      "src": "17f145013241"
+    },
+    "services.activate_led.fields.color1.name": {
+      "out": "067701d4a113",
+      "src": "571461f36f3a"
+    },
+    "services.activate_led.fields.color2.description": {
+      "out": "7068c896d0ec",
+      "src": "f2680a4bbe85"
+    },
+    "services.activate_led.fields.color2.name": {
+      "out": "87ad039b4534",
+      "src": "ef792d287872"
+    },
+    "services.activate_led.fields.color3.description": {
+      "out": "7586f57fab74",
+      "src": "b8ecd353b426"
+    },
+    "services.activate_led.fields.color3.name": {
+      "out": "474cb86742e3",
+      "src": "48d54e046d29"
+    },
+    "services.activate_led.fields.device_id.description": {
+      "out": "8533aacf2904",
+      "src": "7dec980cb238"
+    },
+    "services.activate_led.fields.device_id.name": {
+      "out": "1c555eb7f1c0",
+      "src": "6ba0bdeccb42"
+    },
+    "services.activate_led.fields.flash_count1.description": {
+      "out": "7f7ee6fc1e31",
+      "src": "4ffdadde31c2"
+    },
+    "services.activate_led.fields.flash_count1.name": {
+      "out": "ed6275c95d0e",
+      "src": "13c6a2e5c22e"
+    },
+    "services.activate_led.fields.flash_count2.description": {
+      "out": "36efb7bd06be",
+      "src": "86dc999a3915"
+    },
+    "services.activate_led.fields.flash_count2.name": {
+      "out": "85892035b1b3",
+      "src": "2be36d8449dc"
+    },
+    "services.activate_led.fields.flash_count3.description": {
+      "out": "ff6b585a7816",
+      "src": "aa40c396a9a4"
+    },
+    "services.activate_led.fields.flash_count3.name": {
+      "out": "6c9301e03578",
+      "src": "7978910dc6b2"
+    },
+    "services.activate_led.fields.instance.description": {
+      "out": "85f9f142ab02",
+      "src": "0531b37de90a"
+    },
+    "services.activate_led.fields.instance.name": {
+      "out": "698c0545eb19",
+      "src": "f942926204c7"
+    },
+    "services.activate_led.fields.inter_delay1.description": {
+      "out": "70fe714133bf",
+      "src": "1b65dcfcea95"
+    },
+    "services.activate_led.fields.inter_delay1.name": {
+      "out": "2e08efa9b344",
+      "src": "71452f436c33"
+    },
+    "services.activate_led.fields.inter_delay2.description": {
+      "out": "044b3d76c5b8",
+      "src": "181e03f33cbf"
+    },
+    "services.activate_led.fields.inter_delay2.name": {
+      "out": "5f094e45de54",
+      "src": "6a50551e5355"
+    },
+    "services.activate_led.fields.inter_delay3.description": {
+      "out": "df4e5697770e",
+      "src": "5c5973b586df"
+    },
+    "services.activate_led.fields.inter_delay3.name": {
+      "out": "ef688ac09ca2",
+      "src": "b0f72903777e"
+    },
+    "services.activate_led.fields.loop_delay1.description": {
+      "out": "96add63966d7",
+      "src": "2139915c35bc"
+    },
+    "services.activate_led.fields.loop_delay1.name": {
+      "out": "43a959caaa5a",
+      "src": "2fb02375bae0"
+    },
+    "services.activate_led.fields.loop_delay2.description": {
+      "out": "09eb9a85c5a6",
+      "src": "9a3a8cccb3bb"
+    },
+    "services.activate_led.fields.loop_delay2.name": {
+      "out": "49cfb3d3f05e",
+      "src": "597cbe87a7ec"
+    },
+    "services.activate_led.fields.loop_delay3.description": {
+      "out": "b619bbb5324c",
+      "src": "8a965100226c"
+    },
+    "services.activate_led.fields.loop_delay3.name": {
+      "out": "164a38e4e4d7",
+      "src": "66d787aa1bad"
+    },
+    "services.activate_led.fields.repeats.description": {
+      "out": "3ef2e5bd1fb0",
+      "src": "e40e956e3762"
+    },
+    "services.activate_led.fields.repeats.name": {
+      "out": "49ddd1cb9a27",
+      "src": "92ee0233f013"
+    },
+    "services.activate_led.name": {
+      "out": "f7f571044e1e",
+      "src": "91933e94cc57"
+    },
+    "services.drawcustom.description": {
+      "out": "d08dc809f528",
+      "src": "55f9f3333fc0"
+    },
+    "services.drawcustom.fields.background.description": {
+      "out": "ae7d4384b96f",
+      "src": "f5858405d78a"
+    },
+    "services.drawcustom.fields.background.name": {
+      "out": "4c1191f0c8bf",
+      "src": "3e314dafdf7c"
+    },
+    "services.drawcustom.fields.dither.description": {
+      "out": "f9bdeb9d8284",
+      "src": "d7c737e5d01e"
+    },
+    "services.drawcustom.fields.dither.name": {
+      "out": "576d270bd2f5",
+      "src": "35fb13830002"
+    },
+    "services.drawcustom.fields.dry-run.description": {
+      "out": "9c323228c60d",
+      "src": "54f5f06db00c"
+    },
+    "services.drawcustom.fields.dry-run.name": {
+      "out": "0b66acd48cad",
+      "src": "d5da154d9f00"
+    },
+    "services.drawcustom.fields.measured_palette.description": {
+      "out": "c23788096043",
+      "src": "53842124c7af"
+    },
+    "services.drawcustom.fields.measured_palette.name": {
+      "out": "2e8f0e046ee9",
+      "src": "672d38bdeb19"
+    },
+    "services.drawcustom.fields.payload.description": {
+      "out": "dc2db307984f",
+      "src": "a72e3d514ead"
+    },
+    "services.drawcustom.fields.payload.name": {
+      "out": "5fc119964393",
+      "src": "99733344956d"
+    },
+    "services.drawcustom.fields.refresh_type.description": {
+      "out": "710bea91a9c3",
+      "src": "d87a3d5c4d06"
+    },
+    "services.drawcustom.fields.refresh_type.name": {
+      "out": "721e465fbff3",
+      "src": "201b25b874bb"
+    },
+    "services.drawcustom.fields.rotate.description": {
+      "out": "e49ff8cca2d0",
+      "src": "21e39f93db71"
+    },
+    "services.drawcustom.fields.rotate.name": {
+      "out": "ae0506abfa72",
+      "src": "57b5e2fc1bba"
+    },
+    "services.drawcustom.name": {
+      "out": "9c4313360381",
+      "src": "d0df7a6244ea"
+    },
+    "services.upload_image.description": {
+      "out": "86df30f38eee",
+      "src": "24e19354eaa4"
+    },
+    "services.upload_image.fields.device_id.description": {
+      "out": "a15b5b9e9f53",
+      "src": "ee157333391e"
+    },
+    "services.upload_image.fields.device_id.name": {
+      "out": "1c555eb7f1c0",
+      "src": "6ba0bdeccb42"
+    },
+    "services.upload_image.fields.dither_mode.description": {
+      "out": "c6e7107bf8f8",
+      "src": "70483fdfe7ec"
+    },
+    "services.upload_image.fields.dither_mode.name": {
+      "out": "576d270bd2f5",
+      "src": "35fb13830002"
+    },
+    "services.upload_image.fields.fit_mode.description": {
+      "out": "2ee4880a2a81",
+      "src": "8d2c8735a962"
+    },
+    "services.upload_image.fields.fit_mode.name": {
+      "out": "66d2c4bb0197",
+      "src": "8a59790c9187"
+    },
+    "services.upload_image.fields.image.description": {
+      "out": "cec3c20c95f6",
+      "src": "ba6d9fb759b0"
+    },
+    "services.upload_image.fields.image.name": {
+      "out": "8fc6b8b69804",
+      "src": "1aa4cb0bcca7"
+    },
+    "services.upload_image.fields.measured_palette.description": {
+      "out": "9d7cd76b1b3f",
+      "src": "53842124c7af"
+    },
+    "services.upload_image.fields.measured_palette.name": {
+      "out": "2e8f0e046ee9",
+      "src": "672d38bdeb19"
+    },
+    "services.upload_image.fields.refresh_mode.description": {
+      "out": "2fb68afd6acf",
+      "src": "0fe957da240a"
+    },
+    "services.upload_image.fields.refresh_mode.name": {
+      "out": "6fae77d3314e",
+      "src": "c72fd253298c"
+    },
+    "services.upload_image.fields.rotation.description": {
+      "out": "051cc317049a",
+      "src": "b639ab27209e"
+    },
+    "services.upload_image.fields.rotation.name": {
+      "out": "ae0506abfa72",
+      "src": "57b5e2fc1bba"
+    },
+    "services.upload_image.fields.tone_compression.description": {
+      "out": "d7fbbc46e817",
+      "src": "6453b45ae0cc"
+    },
+    "services.upload_image.fields.tone_compression.name": {
+      "out": "c0a153bdc251",
+      "src": "ffaed65f03fa"
+    },
+    "services.upload_image.name": {
+      "out": "20a0a35690fa",
+      "src": "ffe4df6c7ca6"
+    },
+    "services.upload_image.sections.additional_fields.name": {
+      "out": "06c23075d12f",
+      "src": "092170b2408b"
+    },
+    "services.write_nfc.description": {
+      "out": "6d899b3ffaff",
+      "src": "3c1f6a6d643e"
+    },
+    "services.write_nfc.fields.content.description": {
+      "out": "21ecbcb21d0d",
+      "src": "857d1cf0bf90"
+    },
+    "services.write_nfc.fields.content.name": {
+      "out": "5fc119964393",
+      "src": "47bd29075f8b"
+    },
+    "services.write_nfc.fields.device_id.description": {
+      "out": "8533aacf2904",
+      "src": "7dec980cb238"
+    },
+    "services.write_nfc.fields.device_id.name": {
+      "out": "1c555eb7f1c0",
+      "src": "6ba0bdeccb42"
+    },
+    "services.write_nfc.fields.mime_type.description": {
+      "out": "00adeea09ddb",
+      "src": "4eb2b40ec666"
+    },
+    "services.write_nfc.fields.mime_type.name": {
+      "out": "899f5b786081",
+      "src": "849e8a810960"
+    },
+    "services.write_nfc.fields.record_type.description": {
+      "out": "c05864f36cb1",
+      "src": "936cf634012f"
+    },
+    "services.write_nfc.fields.record_type.name": {
+      "out": "ffc69bba602f",
+      "src": "91cf117b1d70"
+    },
+    "services.write_nfc.name": {
+      "out": "16fb8440ce6b",
+      "src": "96ea14b97cf7"
+    }
+  }
+}

--- a/.github/translation-state.json
+++ b/.github/translation-state.json
@@ -5081,6 +5081,732 @@
       "src": "96ea14b97cf7"
     }
   },
+  "pt": {
+    "config\u0000abort\u0000already_configured": {
+      "out": "dd3b80abffdd",
+      "src": "c2936e02a0d2"
+    },
+    "config\u0000abort\u0000already_in_progress": {
+      "out": "5c1b27c55792",
+      "src": "985a72ad93a3"
+    },
+    "config\u0000abort\u0000cannot_connect": {
+      "out": "b7925ed3a740",
+      "src": "46c9f3b7520f"
+    },
+    "config\u0000abort\u0000no_devices_found": {
+      "out": "99b93bd5fcb6",
+      "src": "b8f28e84cf0b"
+    },
+    "config\u0000abort\u0000reauth_successful": {
+      "out": "c3a3779b59e8",
+      "src": "e5b83989735c"
+    },
+    "config\u0000abort\u0000unknown": {
+      "out": "ad9544920db5",
+      "src": "d24c41ae530a"
+    },
+    "config\u0000error\u0000cannot_connect": {
+      "out": "b7925ed3a740",
+      "src": "46c9f3b7520f"
+    },
+    "config\u0000error\u0000invalid_auth": {
+      "out": "80c2dd42d824",
+      "src": "4ca089878c5f"
+    },
+    "config\u0000error\u0000invalid_key_format": {
+      "out": "9fd1ae7d6800",
+      "src": "f7b03dd699df"
+    },
+    "config\u0000error\u0000unknown": {
+      "out": "ad9544920db5",
+      "src": "d24c41ae530a"
+    },
+    "config\u0000flow_title": {
+      "out": "5e291d7bcb2d",
+      "src": "5e291d7bcb2d"
+    },
+    "config\u0000step\u0000bluetooth_confirm\u0000description": {
+      "out": "9e758bdb4d0a",
+      "src": "bcfd5a24b7d7"
+    },
+    "config\u0000step\u0000encryption_key\u0000data\u0000encryption_key": {
+      "out": "5e30d3742c92",
+      "src": "16b3c9d5573d"
+    },
+    "config\u0000step\u0000encryption_key\u0000data_description\u0000encryption_key": {
+      "out": "4767aba1e652",
+      "src": "e64cd2e7e647"
+    },
+    "config\u0000step\u0000encryption_key\u0000description": {
+      "out": "3fa11c38479b",
+      "src": "664d3f12bfe6"
+    },
+    "config\u0000step\u0000encryption_key\u0000title": {
+      "out": "23874a8cd09c",
+      "src": "c30d1ca158a3"
+    },
+    "config\u0000step\u0000reauth_confirm\u0000data\u0000encryption_key": {
+      "out": "5e30d3742c92",
+      "src": "16b3c9d5573d"
+    },
+    "config\u0000step\u0000reauth_confirm\u0000data_description\u0000encryption_key": {
+      "out": "4767aba1e652",
+      "src": "e64cd2e7e647"
+    },
+    "config\u0000step\u0000reauth_confirm\u0000description": {
+      "out": "7ee83d745abe",
+      "src": "f53b69d3be84"
+    },
+    "config\u0000step\u0000reauth_confirm\u0000title": {
+      "out": "a434d6e7a842",
+      "src": "7e22a752572f"
+    },
+    "config\u0000step\u0000user\u0000data\u0000address": {
+      "out": "1c555eb7f1c0",
+      "src": "6ba0bdeccb42"
+    },
+    "config\u0000step\u0000user\u0000data_description\u0000address": {
+      "out": "e3136b1adeed",
+      "src": "a083a457cfb1"
+    },
+    "config\u0000step\u0000user\u0000description": {
+      "out": "b90ef1e43fe2",
+      "src": "109135454652"
+    },
+    "entity\u0000binary_sensor\u0000update_pending\u0000name": {
+      "out": "ead340a37e92",
+      "src": "8e0a4b18ae75"
+    },
+    "entity\u0000event\u0000button\u0000name": {
+      "out": "4111fd0385ea",
+      "src": "2dcae43716c2"
+    },
+    "entity\u0000event\u0000button\u0000state_attributes\u0000event_type\u0000state\u0000button_down": {
+      "out": "1d1f3249eb2c",
+      "src": "8352c89d20b4"
+    },
+    "entity\u0000event\u0000button\u0000state_attributes\u0000event_type\u0000state\u0000button_up": {
+      "out": "4d2af96bc451",
+      "src": "7f18b4912929"
+    },
+    "entity\u0000event\u0000touch\u0000name": {
+      "out": "837842a1ac38",
+      "src": "c915d14278fc"
+    },
+    "entity\u0000event\u0000touch\u0000state_attributes\u0000event_type\u0000state\u0000touch_down": {
+      "out": "a64b044c7afc",
+      "src": "0234a9576230"
+    },
+    "entity\u0000event\u0000touch\u0000state_attributes\u0000event_type\u0000state\u0000touch_move": {
+      "out": "786c9e985556",
+      "src": "67aeac815e94"
+    },
+    "entity\u0000event\u0000touch\u0000state_attributes\u0000event_type\u0000state\u0000touch_up": {
+      "out": "877d610bc8d6",
+      "src": "7c65519d3bb3"
+    },
+    "entity\u0000image\u0000content\u0000name": {
+      "out": "379eeded820c",
+      "src": "047c6db3382a"
+    },
+    "entity\u0000sensor\u0000battery_voltage\u0000name": {
+      "out": "9558199749f3",
+      "src": "39d6c91b57ce"
+    },
+    "entity\u0000sensor\u0000last_seen\u0000name": {
+      "out": "a060c6768208",
+      "src": "21fd79c7de52"
+    },
+    "entity\u0000sensor\u0000rssi\u0000name": {
+      "out": "e56501a19190",
+      "src": "2604d15c1187"
+    },
+    "entity\u0000update\u0000firmware\u0000name": {
+      "out": "c2a314c3b32b",
+      "src": "c2a314c3b32b"
+    },
+    "exceptions\u0000authentication_error\u0000message": {
+      "out": "19b11cedb540",
+      "src": "3d9f7c0c6d80"
+    },
+    "exceptions\u0000device_not_found\u0000message": {
+      "out": "dd2fad6c9806",
+      "src": "f244d0d2db8d"
+    },
+    "exceptions\u0000device_sleeping\u0000message": {
+      "out": "68290bbca9f8",
+      "src": "e95d25bd6fc7"
+    },
+    "exceptions\u0000device_sleeping_ota\u0000message": {
+      "out": "55a286024f3c",
+      "src": "430e3a1baa6a"
+    },
+    "exceptions\u0000invalid_device_id\u0000message": {
+      "out": "f001b2f55b3b",
+      "src": "cc64cc29ceeb"
+    },
+    "exceptions\u0000media_download_error\u0000message": {
+      "out": "2a58887dea26",
+      "src": "5852129dd920"
+    },
+    "exceptions\u0000mime_type_not_applicable\u0000message": {
+      "out": "c08862a5cd36",
+      "src": "de700f02fbd5"
+    },
+    "exceptions\u0000multiple_errors\u0000message": {
+      "out": "145c56dd9649",
+      "src": "f17c68e0a848"
+    },
+    "exceptions\u0000nfc_content_empty\u0000message": {
+      "out": "18796d161a54",
+      "src": "b93a1a6ebdc0"
+    },
+    "exceptions\u0000nfc_content_too_long\u0000message": {
+      "out": "bbc90e8af04e",
+      "src": "8f580b9c6c76"
+    },
+    "exceptions\u0000nfc_mime_type_invalid\u0000message": {
+      "out": "ab146b824727",
+      "src": "5a5f44fe332f"
+    },
+    "exceptions\u0000nfc_not_supported\u0000message": {
+      "out": "3bc026663d86",
+      "src": "8fdcd0e2bd17"
+    },
+    "exceptions\u0000nfc_write_failed\u0000message": {
+      "out": "e032cc0feb72",
+      "src": "e8186303a52e"
+    },
+    "exceptions\u0000no_buzzers\u0000message": {
+      "out": "79675db97ead",
+      "src": "9c014dfeac91"
+    },
+    "exceptions\u0000no_leds\u0000message": {
+      "out": "5ea1a19390b6",
+      "src": "6a302f8f22ee"
+    },
+    "exceptions\u0000no_nfc\u0000message": {
+      "out": "9f2692ab0584",
+      "src": "abb1917ad57e"
+    },
+    "exceptions\u0000no_targets_specified\u0000message": {
+      "out": "82b619c1673b",
+      "src": "80c472afefe6"
+    },
+    "exceptions\u0000upload_error\u0000message": {
+      "out": "34ab7a45dc33",
+      "src": "75561a03be6e"
+    },
+    "exceptions\u0000url_not_allowed\u0000message": {
+      "out": "ff9646286a09",
+      "src": "33ffb9a9f2c4"
+    },
+    "options\u0000step\u0000init\u0000data\u0000blocks_per_ack": {
+      "out": "ae0e734c291f",
+      "src": "3e2a554e69a4"
+    },
+    "options\u0000step\u0000init\u0000data\u0000max_queue_size": {
+      "out": "9d9b7e034092",
+      "src": "297af7027dd0"
+    },
+    "options\u0000step\u0000init\u0000data\u0000missed_cycles": {
+      "out": "8c13f06661c0",
+      "src": "59b78644491a"
+    },
+    "options\u0000step\u0000init\u0000data\u0000probe_before_queue": {
+      "out": "1f9cead201f8",
+      "src": "02c4211a58b2"
+    },
+    "options\u0000step\u0000init\u0000data\u0000queue_timeout_hours": {
+      "out": "bcc4fff0e185",
+      "src": "be70fc5cca79"
+    },
+    "options\u0000step\u0000init\u0000data\u0000sleep_mode": {
+      "out": "57e4d4e87e37",
+      "src": "f925c0e541ce"
+    },
+    "options\u0000step\u0000init\u0000data_description\u0000blocks_per_ack": {
+      "out": "4c255e9a4fe1",
+      "src": "3a693b19d3c6"
+    },
+    "options\u0000step\u0000init\u0000data_description\u0000max_queue_size": {
+      "out": "1f37a740bb93",
+      "src": "50260959ee56"
+    },
+    "options\u0000step\u0000init\u0000data_description\u0000missed_cycles": {
+      "out": "15772cccf539",
+      "src": "6ce493f4c44d"
+    },
+    "options\u0000step\u0000init\u0000data_description\u0000probe_before_queue": {
+      "out": "601d5de72a1a",
+      "src": "5d0f2985ffdf"
+    },
+    "options\u0000step\u0000init\u0000data_description\u0000queue_timeout_hours": {
+      "out": "05d0517db9c9",
+      "src": "34895000b491"
+    },
+    "options\u0000step\u0000init\u0000data_description\u0000sleep_mode": {
+      "out": "f75a06dbe12d",
+      "src": "4acfeb65d10d"
+    },
+    "selector\u0000dither_mode\u0000options\u0000atkinson": {
+      "out": "7a8fe6d47b5b",
+      "src": "7a8fe6d47b5b"
+    },
+    "selector\u0000dither_mode\u0000options\u0000burkes": {
+      "out": "1b75087201fb",
+      "src": "1b75087201fb"
+    },
+    "selector\u0000dither_mode\u0000options\u0000floyd_steinberg": {
+      "out": "37969811a3cf",
+      "src": "37969811a3cf"
+    },
+    "selector\u0000dither_mode\u0000options\u0000jarvis_judice_ninke": {
+      "out": "7020241adf78",
+      "src": "7020241adf78"
+    },
+    "selector\u0000dither_mode\u0000options\u0000none": {
+      "out": "496a53a0f11e",
+      "src": "dc937b598926"
+    },
+    "selector\u0000dither_mode\u0000options\u0000ordered": {
+      "out": "d2aba6849adb",
+      "src": "007877479e21"
+    },
+    "selector\u0000dither_mode\u0000options\u0000sierra": {
+      "out": "d5eef8ad210c",
+      "src": "d5eef8ad210c"
+    },
+    "selector\u0000dither_mode\u0000options\u0000sierra_lite": {
+      "out": "20da8cc85f38",
+      "src": "20da8cc85f38"
+    },
+    "selector\u0000dither_mode\u0000options\u0000stucki": {
+      "out": "a17d2b13b6f9",
+      "src": "a17d2b13b6f9"
+    },
+    "selector\u0000fit_mode\u0000options\u0000contain": {
+      "out": "a190afc4b4ad",
+      "src": "e534a2c2b456"
+    },
+    "selector\u0000fit_mode\u0000options\u0000cover": {
+      "out": "236ed490ad06",
+      "src": "fa8d84566676"
+    },
+    "selector\u0000fit_mode\u0000options\u0000crop": {
+      "out": "2f04fbd94be9",
+      "src": "98caf7c43c6f"
+    },
+    "selector\u0000fit_mode\u0000options\u0000stretch": {
+      "out": "63031bd7189f",
+      "src": "a33fbcf83f7b"
+    },
+    "selector\u0000nfc_record_type\u0000options\u0000ha_tag": {
+      "out": "865fe819376c",
+      "src": "d1d47a8fa544"
+    },
+    "selector\u0000nfc_record_type\u0000options\u0000mime": {
+      "out": "37ca9e725a29",
+      "src": "f98d7539e627"
+    },
+    "selector\u0000nfc_record_type\u0000options\u0000text": {
+      "out": "6df3d6661c09",
+      "src": "71988c4d8e08"
+    },
+    "selector\u0000nfc_record_type\u0000options\u0000url": {
+      "out": "e7a241debad5",
+      "src": "e7a241debad5"
+    },
+    "selector\u0000refresh_mode\u0000options\u0000fast": {
+      "out": "76495f26e6c5",
+      "src": "6c582b62e0e5"
+    },
+    "selector\u0000refresh_mode\u0000options\u0000full": {
+      "out": "23e3685fbe6c",
+      "src": "008dacb6d1e8"
+    },
+    "selector\u0000refresh_mode\u0000options\u0000partial": {
+      "out": "154b61b1e9da",
+      "src": "a4d50fb85403"
+    },
+    "selector\u0000sleep_mode\u0000options\u0000auto": {
+      "out": "7557cb15b0a8",
+      "src": "132990bd8ef7"
+    },
+    "selector\u0000sleep_mode\u0000options\u0000off": {
+      "out": "ba2d03af8703",
+      "src": "34598efe7b90"
+    },
+    "selector\u0000sleep_mode\u0000options\u0000on": {
+      "out": "91c07f2beaee",
+      "src": "bde131e31c9e"
+    },
+    "services\u0000activate_buzzer\u0000description": {
+      "out": "04810c1128bb",
+      "src": "1898784614cb"
+    },
+    "services\u0000activate_buzzer\u0000fields\u0000device_id\u0000description": {
+      "out": "8533aacf2904",
+      "src": "7dec980cb238"
+    },
+    "services\u0000activate_buzzer\u0000fields\u0000device_id\u0000name": {
+      "out": "1c555eb7f1c0",
+      "src": "6ba0bdeccb42"
+    },
+    "services\u0000activate_buzzer\u0000fields\u0000duration_ms\u0000description": {
+      "out": "c8b37eb09106",
+      "src": "cd1bc75ca60c"
+    },
+    "services\u0000activate_buzzer\u0000fields\u0000duration_ms\u0000name": {
+      "out": "6cecb49a79df",
+      "src": "4fc52a3c4c55"
+    },
+    "services\u0000activate_buzzer\u0000fields\u0000frequency_hz\u0000description": {
+      "out": "7b1bb1eec059",
+      "src": "510fc20311e3"
+    },
+    "services\u0000activate_buzzer\u0000fields\u0000frequency_hz\u0000name": {
+      "out": "4ccef85f69f6",
+      "src": "16b6668d9831"
+    },
+    "services\u0000activate_buzzer\u0000fields\u0000instance\u0000description": {
+      "out": "5eb44e6b6ba0",
+      "src": "f39fa742d55c"
+    },
+    "services\u0000activate_buzzer\u0000fields\u0000instance\u0000name": {
+      "out": "7ce81db09421",
+      "src": "1f671ddded9e"
+    },
+    "services\u0000activate_buzzer\u0000fields\u0000repeats\u0000description": {
+      "out": "3dfd2b7ef116",
+      "src": "1f88b0fe23ea"
+    },
+    "services\u0000activate_buzzer\u0000fields\u0000repeats\u0000name": {
+      "out": "49ddd1cb9a27",
+      "src": "92ee0233f013"
+    },
+    "services\u0000activate_buzzer\u0000name": {
+      "out": "1d809ae66dbe",
+      "src": "0b80285753b7"
+    },
+    "services\u0000activate_led\u0000description": {
+      "out": "59bb4f5a7e5b",
+      "src": "6cbd645597cc"
+    },
+    "services\u0000activate_led\u0000fields\u0000brightness\u0000description": {
+      "out": "345a664f32bb",
+      "src": "6ad88a28230d"
+    },
+    "services\u0000activate_led\u0000fields\u0000brightness\u0000name": {
+      "out": "ff070ada77b9",
+      "src": "ec811d30a89c"
+    },
+    "services\u0000activate_led\u0000fields\u0000color1\u0000description": {
+      "out": "9fc052573aad",
+      "src": "17f145013241"
+    },
+    "services\u0000activate_led\u0000fields\u0000color1\u0000name": {
+      "out": "067701d4a113",
+      "src": "571461f36f3a"
+    },
+    "services\u0000activate_led\u0000fields\u0000color2\u0000description": {
+      "out": "d1170de50398",
+      "src": "f2680a4bbe85"
+    },
+    "services\u0000activate_led\u0000fields\u0000color2\u0000name": {
+      "out": "87ad039b4534",
+      "src": "ef792d287872"
+    },
+    "services\u0000activate_led\u0000fields\u0000color3\u0000description": {
+      "out": "533b4dfaad9f",
+      "src": "b8ecd353b426"
+    },
+    "services\u0000activate_led\u0000fields\u0000color3\u0000name": {
+      "out": "474cb86742e3",
+      "src": "48d54e046d29"
+    },
+    "services\u0000activate_led\u0000fields\u0000device_id\u0000description": {
+      "out": "8533aacf2904",
+      "src": "7dec980cb238"
+    },
+    "services\u0000activate_led\u0000fields\u0000device_id\u0000name": {
+      "out": "1c555eb7f1c0",
+      "src": "6ba0bdeccb42"
+    },
+    "services\u0000activate_led\u0000fields\u0000flash_count1\u0000description": {
+      "out": "12c74c15567f",
+      "src": "4ffdadde31c2"
+    },
+    "services\u0000activate_led\u0000fields\u0000flash_count1\u0000name": {
+      "out": "ed6275c95d0e",
+      "src": "13c6a2e5c22e"
+    },
+    "services\u0000activate_led\u0000fields\u0000flash_count2\u0000description": {
+      "out": "511d52f36bb9",
+      "src": "86dc999a3915"
+    },
+    "services\u0000activate_led\u0000fields\u0000flash_count2\u0000name": {
+      "out": "85892035b1b3",
+      "src": "2be36d8449dc"
+    },
+    "services\u0000activate_led\u0000fields\u0000flash_count3\u0000description": {
+      "out": "d07d90def31e",
+      "src": "aa40c396a9a4"
+    },
+    "services\u0000activate_led\u0000fields\u0000flash_count3\u0000name": {
+      "out": "6c9301e03578",
+      "src": "7978910dc6b2"
+    },
+    "services\u0000activate_led\u0000fields\u0000instance\u0000description": {
+      "out": "85f9f142ab02",
+      "src": "0531b37de90a"
+    },
+    "services\u0000activate_led\u0000fields\u0000instance\u0000name": {
+      "out": "698c0545eb19",
+      "src": "f942926204c7"
+    },
+    "services\u0000activate_led\u0000fields\u0000inter_delay1\u0000description": {
+      "out": "acdf59fcf8ba",
+      "src": "1b65dcfcea95"
+    },
+    "services\u0000activate_led\u0000fields\u0000inter_delay1\u0000name": {
+      "out": "2e08efa9b344",
+      "src": "71452f436c33"
+    },
+    "services\u0000activate_led\u0000fields\u0000inter_delay2\u0000description": {
+      "out": "4ade059df03a",
+      "src": "181e03f33cbf"
+    },
+    "services\u0000activate_led\u0000fields\u0000inter_delay2\u0000name": {
+      "out": "5f094e45de54",
+      "src": "6a50551e5355"
+    },
+    "services\u0000activate_led\u0000fields\u0000inter_delay3\u0000description": {
+      "out": "df4e5697770e",
+      "src": "5c5973b586df"
+    },
+    "services\u0000activate_led\u0000fields\u0000inter_delay3\u0000name": {
+      "out": "ef688ac09ca2",
+      "src": "b0f72903777e"
+    },
+    "services\u0000activate_led\u0000fields\u0000loop_delay1\u0000description": {
+      "out": "96add63966d7",
+      "src": "2139915c35bc"
+    },
+    "services\u0000activate_led\u0000fields\u0000loop_delay1\u0000name": {
+      "out": "43a959caaa5a",
+      "src": "2fb02375bae0"
+    },
+    "services\u0000activate_led\u0000fields\u0000loop_delay2\u0000description": {
+      "out": "09eb9a85c5a6",
+      "src": "9a3a8cccb3bb"
+    },
+    "services\u0000activate_led\u0000fields\u0000loop_delay2\u0000name": {
+      "out": "49cfb3d3f05e",
+      "src": "597cbe87a7ec"
+    },
+    "services\u0000activate_led\u0000fields\u0000loop_delay3\u0000description": {
+      "out": "b619bbb5324c",
+      "src": "8a965100226c"
+    },
+    "services\u0000activate_led\u0000fields\u0000loop_delay3\u0000name": {
+      "out": "164a38e4e4d7",
+      "src": "66d787aa1bad"
+    },
+    "services\u0000activate_led\u0000fields\u0000repeats\u0000description": {
+      "out": "fc5ee301c18b",
+      "src": "e40e956e3762"
+    },
+    "services\u0000activate_led\u0000fields\u0000repeats\u0000name": {
+      "out": "49ddd1cb9a27",
+      "src": "92ee0233f013"
+    },
+    "services\u0000activate_led\u0000name": {
+      "out": "f7f571044e1e",
+      "src": "91933e94cc57"
+    },
+    "services\u0000drawcustom\u0000description": {
+      "out": "feccfaa98173",
+      "src": "55f9f3333fc0"
+    },
+    "services\u0000drawcustom\u0000fields\u0000background\u0000description": {
+      "out": "ae7d4384b96f",
+      "src": "f5858405d78a"
+    },
+    "services\u0000drawcustom\u0000fields\u0000background\u0000name": {
+      "out": "4c1191f0c8bf",
+      "src": "3e314dafdf7c"
+    },
+    "services\u0000drawcustom\u0000fields\u0000dither\u0000description": {
+      "out": "f9bdeb9d8284",
+      "src": "d7c737e5d01e"
+    },
+    "services\u0000drawcustom\u0000fields\u0000dither\u0000name": {
+      "out": "576d270bd2f5",
+      "src": "35fb13830002"
+    },
+    "services\u0000drawcustom\u0000fields\u0000dry-run\u0000description": {
+      "out": "bc1be1e1422a",
+      "src": "54f5f06db00c"
+    },
+    "services\u0000drawcustom\u0000fields\u0000dry-run\u0000name": {
+      "out": "0b66acd48cad",
+      "src": "d5da154d9f00"
+    },
+    "services\u0000drawcustom\u0000fields\u0000measured_palette\u0000description": {
+      "out": "a70081429603",
+      "src": "53842124c7af"
+    },
+    "services\u0000drawcustom\u0000fields\u0000measured_palette\u0000name": {
+      "out": "2e8f0e046ee9",
+      "src": "672d38bdeb19"
+    },
+    "services\u0000drawcustom\u0000fields\u0000payload\u0000description": {
+      "out": "dc2db307984f",
+      "src": "a72e3d514ead"
+    },
+    "services\u0000drawcustom\u0000fields\u0000payload\u0000name": {
+      "out": "fb1bf1494983",
+      "src": "99733344956d"
+    },
+    "services\u0000drawcustom\u0000fields\u0000refresh_type\u0000description": {
+      "out": "47214ef9413c",
+      "src": "d87a3d5c4d06"
+    },
+    "services\u0000drawcustom\u0000fields\u0000refresh_type\u0000name": {
+      "out": "721e465fbff3",
+      "src": "201b25b874bb"
+    },
+    "services\u0000drawcustom\u0000fields\u0000rotate\u0000description": {
+      "out": "3e22aeb09723",
+      "src": "21e39f93db71"
+    },
+    "services\u0000drawcustom\u0000fields\u0000rotate\u0000name": {
+      "out": "ae0506abfa72",
+      "src": "57b5e2fc1bba"
+    },
+    "services\u0000drawcustom\u0000name": {
+      "out": "9c4313360381",
+      "src": "d0df7a6244ea"
+    },
+    "services\u0000upload_image\u0000description": {
+      "out": "7b60359fea5b",
+      "src": "24e19354eaa4"
+    },
+    "services\u0000upload_image\u0000fields\u0000device_id\u0000description": {
+      "out": "28c8a70eeb47",
+      "src": "ee157333391e"
+    },
+    "services\u0000upload_image\u0000fields\u0000device_id\u0000name": {
+      "out": "1c555eb7f1c0",
+      "src": "6ba0bdeccb42"
+    },
+    "services\u0000upload_image\u0000fields\u0000dither_mode\u0000description": {
+      "out": "15dd4623733a",
+      "src": "70483fdfe7ec"
+    },
+    "services\u0000upload_image\u0000fields\u0000dither_mode\u0000name": {
+      "out": "576d270bd2f5",
+      "src": "35fb13830002"
+    },
+    "services\u0000upload_image\u0000fields\u0000fit_mode\u0000description": {
+      "out": "f789820e1b04",
+      "src": "8d2c8735a962"
+    },
+    "services\u0000upload_image\u0000fields\u0000fit_mode\u0000name": {
+      "out": "66d2c4bb0197",
+      "src": "8a59790c9187"
+    },
+    "services\u0000upload_image\u0000fields\u0000image\u0000description": {
+      "out": "9d305a7541b4",
+      "src": "ba6d9fb759b0"
+    },
+    "services\u0000upload_image\u0000fields\u0000image\u0000name": {
+      "out": "8fc6b8b69804",
+      "src": "1aa4cb0bcca7"
+    },
+    "services\u0000upload_image\u0000fields\u0000measured_palette\u0000description": {
+      "out": "302694fbfe69",
+      "src": "53842124c7af"
+    },
+    "services\u0000upload_image\u0000fields\u0000measured_palette\u0000name": {
+      "out": "2e8f0e046ee9",
+      "src": "672d38bdeb19"
+    },
+    "services\u0000upload_image\u0000fields\u0000refresh_mode\u0000description": {
+      "out": "c95e6952e934",
+      "src": "0fe957da240a"
+    },
+    "services\u0000upload_image\u0000fields\u0000refresh_mode\u0000name": {
+      "out": "6fae77d3314e",
+      "src": "c72fd253298c"
+    },
+    "services\u0000upload_image\u0000fields\u0000rotation\u0000description": {
+      "out": "5b3b8110be8c",
+      "src": "b639ab27209e"
+    },
+    "services\u0000upload_image\u0000fields\u0000rotation\u0000name": {
+      "out": "ae0506abfa72",
+      "src": "57b5e2fc1bba"
+    },
+    "services\u0000upload_image\u0000fields\u0000tone_compression\u0000description": {
+      "out": "f425afe972db",
+      "src": "6453b45ae0cc"
+    },
+    "services\u0000upload_image\u0000fields\u0000tone_compression\u0000name": {
+      "out": "5b7274955c25",
+      "src": "ffaed65f03fa"
+    },
+    "services\u0000upload_image\u0000name": {
+      "out": "9c76eeac5490",
+      "src": "ffe4df6c7ca6"
+    },
+    "services\u0000upload_image\u0000sections\u0000additional_fields\u0000name": {
+      "out": "06c23075d12f",
+      "src": "092170b2408b"
+    },
+    "services\u0000write_nfc\u0000description": {
+      "out": "86305afffc85",
+      "src": "3c1f6a6d643e"
+    },
+    "services\u0000write_nfc\u0000fields\u0000content\u0000description": {
+      "out": "ed5387b129b8",
+      "src": "857d1cf0bf90"
+    },
+    "services\u0000write_nfc\u0000fields\u0000content\u0000name": {
+      "out": "5fc119964393",
+      "src": "47bd29075f8b"
+    },
+    "services\u0000write_nfc\u0000fields\u0000device_id\u0000description": {
+      "out": "8533aacf2904",
+      "src": "7dec980cb238"
+    },
+    "services\u0000write_nfc\u0000fields\u0000device_id\u0000name": {
+      "out": "1c555eb7f1c0",
+      "src": "6ba0bdeccb42"
+    },
+    "services\u0000write_nfc\u0000fields\u0000mime_type\u0000description": {
+      "out": "4b0fb5174cfd",
+      "src": "4eb2b40ec666"
+    },
+    "services\u0000write_nfc\u0000fields\u0000mime_type\u0000name": {
+      "out": "899f5b786081",
+      "src": "849e8a810960"
+    },
+    "services\u0000write_nfc\u0000fields\u0000record_type\u0000description": {
+      "out": "164114875f86",
+      "src": "936cf634012f"
+    },
+    "services\u0000write_nfc\u0000fields\u0000record_type\u0000name": {
+      "out": "18f51289ed88",
+      "src": "91cf117b1d70"
+    },
+    "services\u0000write_nfc\u0000name": {
+      "out": "39b2a7664821",
+      "src": "96ea14b97cf7"
+    }
+  },
   "pt-BR": {
     "config\u0000abort\u0000already_configured": {
       "out": "dd3b80abffdd",

--- a/.github/workflows/translate.yml
+++ b/.github/workflows/translate.yml
@@ -1,0 +1,114 @@
+name: Translate Strings
+
+on:
+  # Only when the English source actually changes. Any other push is a no-op
+  # anyway, since the script would find nothing missing.
+  push:
+    branches:
+      - main
+      - feat/clean-port
+    paths:
+      - 'custom_components/opendisplay/translations/en.json'
+
+  # Allow manual trigger, optionally scoped to specific languages
+  workflow_dispatch:
+    inputs:
+      languages:
+        description: 'Comma-separated language codes (blank = all)'
+        required: false
+        default: ''
+
+permissions:
+  contents: write
+  pull-requests: write
+  # Lets the built-in GITHUB_TOKEN call GitHub Models. No API key, no billing.
+  models: read
+
+jobs:
+  translate:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Translate missing strings
+        id: translate
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          python3 scripts/translate.py \
+            ${{ inputs.languages && format('--languages {0}', inputs.languages) || '' }}
+
+      - name: Verify generated files
+        if: steps.translate.outputs.changed == 'true'
+        run: python3 scripts/verify_translations.py
+
+      - name: Close existing automated PR
+        if: steps.translate.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          existing_prs=$(gh pr list --repo "${{ github.repository }}" --head "automated/translations" --state open --json number --jq '.[].number')
+          for pr_number in $existing_prs; do
+            echo "Closing existing PR #$pr_number"
+            gh pr close "$pr_number" --repo "${{ github.repository }}" --comment "Superseded by a newer automated update."
+          done
+
+      - name: Create Pull Request
+        if: steps.translate.outputs.changed == 'true'
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          # Target whichever branch triggered this run
+          base: ${{ github.ref_name }}
+          commit-message: 'chore: update translations'
+          title: 'chore: update translations'
+          body: |
+            `translations/en.json` changed, so the strings that were missing from
+            each language have been machine-translated using GitHub Models.
+            Existing translations were not re-sent to the model.
+
+            ## Changes
+
+            ${{ steps.translate.outputs.summary }}
+
+            ## Review notes
+
+            - Placeholders such as `{name}` and `{number}` are validated
+              automatically: any translation that drops, renames, or adds one is
+              rejected rather than committed.
+            - Translations avoid the familiar/polite distinction (German du/Sie,
+              French tu/vous, ...) by using impersonal phrasing. Anything that
+              slipped through is flagged as a warning in the workflow log.
+            - Manual corrections are preserved. If you fix a translation by hand,
+              this workflow will not overwrite it, even when the English source
+              changes later. It reports it under "Needs review" instead.
+
+            ---
+
+            *This PR was automatically created by the translate workflow*
+          branch: 'automated/translations'
+          delete-branch: true
+          add-paths: |
+            custom_components/opendisplay/translations/
+            .github/translation-state.json
+          labels: |
+            automated
+            translations
+
+      - name: Summary
+        run: |
+          if [ "${{ steps.translate.outputs.changed }}" == "true" ]; then
+            echo "Translations updated - PR opened against ${{ github.ref_name }}" >> $GITHUB_STEP_SUMMARY
+            echo "${{ steps.translate.outputs.summary }}" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "No missing translations - nothing to do" >> $GITHUB_STEP_SUMMARY
+          fi

--- a/README.md
+++ b/README.md
@@ -93,6 +93,32 @@ Devices should be automatically discovered after installation.
   color: "black"
 ```
 
+## Translations
+
+The integration is available in Czech, Dutch, English, French, German, Italian,
+Polish, Portuguese (European and Brazilian), and Spanish.
+
+English is written by hand. **Every other language is machine-translated** and
+has not been reviewed by a native speaker, so expect the occasional awkward or
+plainly wrong phrasing. Corrections are very welcome, and they stick:
+
+- Edit the relevant file in `custom_components/opendisplay/translations/` and
+  open a pull request. There is no need to touch anything else.
+- **Your wording will not be overwritten.** The translation workflow records a
+  fingerprint of what it generated, so it can tell its own output from a human
+  edit. Once you have corrected a string it is treated as yours. If the English
+  source later changes, the workflow flags the string for review rather than
+  replacing your version.
+- Only strings that are missing, or whose English source was reworded, are ever
+  sent to a model.
+
+To add a language, add its code and name to `LANGUAGES` in
+`scripts/translate.py` and open a pull request; the workflow fills in the file.
+
+Translations deliberately avoid the familiar/polite distinction (German du/Sie,
+French tu/vous, and so on) by using impersonal phrasing such as infinitives for
+instructions. Please keep that style when correcting a string.
+
 ## Contributing
 - Feature requests and bug reports are welcome! Please open an issue on GitHub
 - Pull requests are encouraged

--- a/custom_components/opendisplay/strings.json
+++ b/custom_components/opendisplay/strings.json
@@ -184,7 +184,7 @@
       "message": "Failed to upload to the display: {error}"
     },
     "url_not_allowed": {
-      "message": "URL `{url}` is not allowed. Add it to `allowlist_external_urls` in your configuration.yaml."
+      "message": "URL `{url}` is not allowed. Add it to `allowlist_external_urls` in configuration.yaml."
     }
   },
   "selector": {

--- a/custom_components/opendisplay/translations/cs.json
+++ b/custom_components/opendisplay/translations/cs.json
@@ -1,0 +1,429 @@
+{
+  "config": {
+    "abort": {
+      "already_configured": "Zařízení je již nakonfigurováno",
+      "already_in_progress": "Konfigurační proces již probíhá",
+      "cannot_connect": "Nepodařilo se připojit",
+      "no_devices_found": "Na síti nebyla nalezena žádná zařízení",
+      "reauth_successful": "Znovuověření bylo úspěšné",
+      "unknown": "Neočekávaná chyba"
+    },
+    "error": {
+      "cannot_connect": "Nepodařilo se připojit",
+      "invalid_auth": "Neplatná autentizace",
+      "invalid_key_format": "Šifrovací klíč musí mít přesně 32 hexadecimálních znaků (0-9, a-f).",
+      "unknown": "Neočekávaná chyba"
+    },
+    "flow_title": "{name}",
+    "step": {
+      "bluetooth_confirm": {
+        "description": "Nastavit {name}?"
+      },
+      "encryption_key": {
+        "data": {
+          "encryption_key": "Šifrovací klíč"
+        },
+        "data_description": {
+          "encryption_key": "Zadat 32znakový hexadecimální AES-128 šifrovací klíč pro toto zařízení."
+        },
+        "description": "{name} vyžaduje šifrovací klíč pro připojení.",
+        "title": "Vyžadováno šifrování"
+      },
+      "reauth_confirm": {
+        "data": {
+          "encryption_key": "Šifrovací klíč"
+        },
+        "data_description": {
+          "encryption_key": "Zadat 32znakový hexadecimální AES-128 šifrovací klíč pro toto zařízení."
+        },
+        "description": "Autentizace pro {name} selhala. Zadat správný šifrovací klíč, nebo ponechat prázdné, pokud bylo šifrování na zařízení vypnuto.",
+        "title": "Vyžadováno znovuověření"
+      },
+      "user": {
+        "data": {
+          "address": "Zařízení"
+        },
+        "data_description": {
+          "address": "Vybrat Bluetooth zařízení k nastavení."
+        },
+        "description": "Vybrat zařízení k nastavení"
+      }
+    }
+  },
+  "entity": {
+    "binary_sensor": {
+      "update_pending": {
+        "name": "Čeká na aktualizaci"
+      }
+    },
+    "event": {
+      "button": {
+        "name": "Tlačítko {number}",
+        "state_attributes": {
+          "event_type": {
+            "state": {
+              "button_down": "Tlačítko stisknuto",
+              "button_up": "Tlačítko uvolněno"
+            }
+          }
+        }
+      },
+      "touch": {
+        "name": "Dotyk {number}",
+        "state_attributes": {
+          "event_type": {
+            "state": {
+              "touch_down": "Dotyk zahájen",
+              "touch_move": "Pohyb dotyku",
+              "touch_up": "Dotyk ukončen"
+            }
+          }
+        }
+      }
+    },
+    "image": {
+      "content": {
+        "name": "Obsah displeje"
+      }
+    },
+    "sensor": {
+      "battery_voltage": {
+        "name": "Napětí baterie"
+      },
+      "last_seen": {
+        "name": "Naposledy viděno"
+      },
+      "rssi": {
+        "name": "Síla signálu (RSSI)"
+      }
+    },
+    "update": {
+      "firmware": {
+        "name": "Firmware"
+      }
+    }
+  },
+  "exceptions": {
+    "authentication_error": {
+      "message": "Autentizace selhala. Aktualizovat šifrovací klíč."
+    },
+    "device_not_found": {
+      "message": "Bluetooth zařízení s adresou `{address}` nebylo nalezeno."
+    },
+    "device_sleeping": {
+      "message": "Zařízení `{device_id}` je v režimu spánku a nelze jej okamžitě kontaktovat. Probudit a zkusit znovu."
+    },
+    "device_sleeping_ota": {
+      "message": "Zařízení je v režimu spánku a nelze jej nyní aktualizovat. Probudit (stisknout tlačítko nebo počkat na další plánovanou kontrolu) a znovu spustit aktualizaci."
+    },
+    "invalid_device_id": {
+      "message": "Zařízení `{device_id}` není platné OpenDisplay zařízení."
+    },
+    "media_download_error": {
+      "message": "Nepodařilo se stáhnout média: {error}"
+    },
+    "mime_type_not_applicable": {
+      "message": "Pole mime_type platí pouze pro MIME záznamy. Nastavit record_type na mime, nebo mime_type vynechat."
+    },
+    "multiple_errors": {
+      "message": "Došlo k chybám u jednoho nebo více zařízení:\n{errors}"
+    },
+    "nfc_content_empty": {
+      "message": "Obsah NFC nesmí být prázdný."
+    },
+    "nfc_content_too_long": {
+      "message": "Obsah NFC je příliš velký ({size} bajtů). Maximální velikost je {max} bajtů."
+    },
+    "nfc_mime_type_invalid": {
+      "message": "MIME typ `{mime_type}` je neplatný. Musí mít 1-255 bajtů při kódování UTF-8."
+    },
+    "nfc_not_supported": {
+      "message": "Zařízení `{device_id}` neodpovědělo na zápis NFC. Je možné, že jeho firmware nepodporuje zápis NFC tagů; zkusit aktualizovat na nejnovější firmware."
+    },
+    "nfc_write_failed": {
+      "message": "Nepodařilo se zapsat NFC tag: {error}"
+    },
+    "no_buzzers": {
+      "message": "Zařízení `{device_id}` nemá nakonfigurovaný bzučák."
+    },
+    "no_leds": {
+      "message": "Zařízení `{device_id}` nemá nakonfigurované LED diody."
+    },
+    "no_nfc": {
+      "message": "Zařízení `{device_id}` nemá nakonfigurovaný NFC čip."
+    },
+    "no_targets_specified": {
+      "message": "Nebyly specifikovány cílové zařízení."
+    },
+    "upload_error": {
+      "message": "Nepodařilo se nahrát na displej: {error}"
+    },
+    "url_not_allowed": {
+      "message": "URL `{url}` není povolena. Přidejte ji do `allowlist_external_urls` v configuration.yaml."
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "data": {
+          "blocks_per_ack": "Bloky odeslané na jedno potvrzení",
+          "max_queue_size": "Maximální počet snímků v přenosu",
+          "missed_cycles": "Počet vynechaných probuzení před označením za nedostupné",
+          "probe_before_queue": "Zkusit připojení před zařazením do fronty",
+          "queue_timeout_hours": "Časový limit obsahu ve frontě (hodiny)",
+          "sleep_mode": "Způsob hlubokého spánku"
+        },
+        "data_description": {
+          "blocks_per_ack": "Kolik obrazových snímků zařízení přijme, než pošle jedno potvrzení během rychlého (posuvného) přenosu. Vyšší hodnoty snižují počet zpětných cest; efektivní hodnota je omezena zařízením a maximálním počtem snímků v přenosu.",
+          "max_queue_size": "Maximální počet obrazových snímků současně v přenosu během rychlého (posuvného) uploadu. Vyšší hodnoty zvyšují propustnost na pomalých (proxy) spojích. Nastavit na 1 pro vypnutí rychlého přenosu a použití klasického uploadu po jednom snímku.",
+          "missed_cycles": "Kolik očekávaných probuzení může zařízení vynechat, než jsou jeho entity označeny jako nedostupné.",
+          "probe_before_queue": "Před zařazením obrázku do fronty pro spící zařízení provést rychlý pokus o připojení, pokud je zařízení ve skutečnosti vzhůru (vynechané reklamy, stále zapnuté rádio). Přidává maximálně několik sekund, pokud je zařízení opravdu v režimu spánku.",
+          "queue_timeout_hours": "Jak dlouho obsah ve frontě pro spící zařízení čeká na probuzení, než vyprší.",
+          "sleep_mode": "Automaticky sleduje vlastní napájecí konfiguraci zařízení (bateriové napájení s povoleným hlubokým spánkem). Vynutit zapnutí nebo vypnutí pro přepsání."
+        }
+      }
+    }
+  },
+  "selector": {
+    "dither_mode": {
+      "options": {
+        "atkinson": "Atkinson",
+        "burkes": "Burkes",
+        "floyd_steinberg": "Floyd-Steinberg",
+        "jarvis_judice_ninke": "Jarvis, Judice & Ninke",
+        "none": "Žádný",
+        "ordered": "Řazený",
+        "sierra": "Sierra",
+        "sierra_lite": "Sierra Lite",
+        "stucki": "Stucki"
+      }
+    },
+    "fit_mode": {
+      "options": {
+        "contain": "Obsahovat",
+        "cover": "Zakrytí",
+        "crop": "Oříznout",
+        "stretch": "Roztáhnout"
+      }
+    },
+    "nfc_record_type": {
+      "options": {
+        "ha_tag": "Home Assistant tag",
+        "mime": "MIME data (např. vCard)",
+        "text": "Text",
+        "url": "URL"
+      }
+    },
+    "refresh_mode": {
+      "options": {
+        "fast": "Rychlý",
+        "full": "Úplný",
+        "partial": "Částečný"
+      }
+    },
+    "sleep_mode": {
+      "options": {
+        "auto": "Automatický (následuje zařízení)",
+        "off": "Vynutit vypnutí",
+        "on": "Vynutit zapnutí"
+      }
+    }
+  },
+  "services": {
+    "activate_buzzer": {
+      "description": "Spustí tón bzučáku na zařízení OpenDisplay.",
+      "fields": {
+        "device_id": {
+          "description": "Zařízení OpenDisplay.",
+          "name": "Zařízení"
+        },
+        "duration_ms": {
+          "description": "Doba trvání tónu v milisekundách (5-1275).",
+          "name": "Doba trvání"
+        },
+        "frequency_hz": {
+          "description": "Frekvence tónu v Hz (0 = ticho, 400-12000).",
+          "name": "Frekvence"
+        },
+        "instance": {
+          "description": "Index instance bzučáku (od 0).",
+          "name": "Instance bzučáku"
+        },
+        "repeats": {
+          "description": "Počet opakování tónu (1-255).",
+          "name": "Opakování"
+        }
+      },
+      "name": "Aktivovat bzučák"
+    },
+    "activate_led": {
+      "description": "Spustí vzor blikání LED na zařízení OpenDisplay.",
+      "fields": {
+        "brightness": {
+          "description": "Jas LED (1-16).",
+          "name": "Jas"
+        },
+        "color1": {
+          "description": "Barva prvního kroku.",
+          "name": "Barva 1"
+        },
+        "color2": {
+          "description": "Barva druhého kroku (vynechat nebo nastavit počet bliknutí na 0 pro přeskočení).",
+          "name": "Barva 2"
+        },
+        "color3": {
+          "description": "Barva třetího kroku (vynechat nebo nastavit počet bliknutí na 0 pro přeskočení).",
+          "name": "Barva 3"
+        },
+        "device_id": {
+          "description": "Zařízení OpenDisplay.",
+          "name": "Zařízení"
+        },
+        "flash_count1": {
+          "description": "Počet bliknutí v prvním kroku (0 přeskočí tento krok).",
+          "name": "Počet bliknutí 1"
+        },
+        "flash_count2": {
+          "description": "Počet bliknutí ve druhém kroku (0 přeskočí tento krok).",
+          "name": "Počet bliknutí 2"
+        },
+        "flash_count3": {
+          "description": "Počet bliknutí ve třetím kroku (0 přeskočí tento krok).",
+          "name": "Počet bliknutí 3"
+        },
+        "instance": {
+          "description": "Index instance LED (od 0).",
+          "name": "Instance LED"
+        },
+        "inter_delay1": {
+          "description": "Prodleva po prvním kroku před dalším.",
+          "name": "Prodleva kroku 1"
+        },
+        "inter_delay2": {
+          "description": "Prodleva po druhém kroku před dalším.",
+          "name": "Prodleva kroku 2"
+        },
+        "inter_delay3": {
+          "description": "Prodleva po třetím kroku před opakováním.",
+          "name": "Prodleva kroku 3"
+        },
+        "loop_delay1": {
+          "description": "Prodleva mezi bliknutími v prvním kroku.",
+          "name": "Prodleva bliknutí 1"
+        },
+        "loop_delay2": {
+          "description": "Prodleva mezi bliknutími ve druhém kroku.",
+          "name": "Prodleva bliknutí 2"
+        },
+        "loop_delay3": {
+          "description": "Prodleva mezi bliknutími ve třetím kroku.",
+          "name": "Prodleva bliknutí 3"
+        },
+        "repeats": {
+          "description": "Počet opakování celého vzoru (0 = nekonečno).",
+          "name": "Opakování"
+        }
+      },
+      "name": "Aktivovat LED"
+    },
+    "drawcustom": {
+      "description": "Nakreslí vlastní obrázek na jedno nebo více zařízení OpenDisplay.",
+      "fields": {
+        "background": {
+          "description": "Barva pozadí.",
+          "name": "Barva pozadí"
+        },
+        "dither": {
+          "description": "Algoritmus ditheringu pro převod barevné palety.",
+          "name": "Režim ditheringu"
+        },
+        "dry-run": {
+          "description": "Vygenerovat obrázek bez nahrání do zařízení.",
+          "name": "Zkušební běh"
+        },
+        "measured_palette": {
+          "description": "Použít naměřenou barevnou paletu panelu, pokud je dostupná. Vypnout pro dithering proti teoretické paletě. Bez efektu na panelech bez naměřených dat.",
+          "name": "Použít naměřenou paletu"
+        },
+        "payload": {
+          "description": "Pole kreslících prvků.",
+          "name": "Obsah"
+        },
+        "refresh_type": {
+          "description": "Režim obnovy displeje. Částečná aktualizace mění jen změněnou oblast bez blikání; automaticky přepne na úplnou obnovu, pokud není možná.",
+          "name": "Typ obnovy"
+        },
+        "rotate": {
+          "description": "Otočení po směru hodinových ručiček ve stupních.",
+          "name": "Rotace"
+        }
+      },
+      "name": "Nakreslit vlastní obrázek"
+    },
+    "upload_image": {
+      "description": "Nahraje obrázek do zařízení OpenDisplay.",
+      "fields": {
+        "device_id": {
+          "description": "Zařízení OpenDisplay, do kterého se obrázek nahraje.",
+          "name": "Zařízení"
+        },
+        "dither_mode": {
+          "description": "Algoritmus ditheringu pro převod obrázku na barevnou paletu displeje.",
+          "name": "Režim ditheringu"
+        },
+        "fit_mode": {
+          "description": "Způsob přizpůsobení obrázku rozměrům displeje.",
+          "name": "Režim přizpůsobení"
+        },
+        "image": {
+          "description": "Obrázek k nahrání na displej. Vybrat mediální položku nebo zadat přímou URL obrázku (URL musí být přidána do allowlist_external_urls).",
+          "name": "Obrázek"
+        },
+        "measured_palette": {
+          "description": "Použít naměřenou barevnou paletu panelu, pokud je k dispozici. Vypnout pro dithering podle teoretické barevné schématu. Bez vlivu na panely bez naměřených dat.",
+          "name": "Použít naměřenou paletu"
+        },
+        "refresh_mode": {
+          "description": "Režim obnovy displeje. Plná obnova odstraní duchy, ale je pomalejší. Rychlá obnova není podporována na všech displejích. Částečná aktualizace mění pouze změněnou oblast bez blikání (B/W panely s částečnou podporou; automaticky přepne na plnou obnovu, pokud není možná).",
+          "name": "Režim obnovy"
+        },
+        "rotation": {
+          "description": "Úhel otočení ve stupních, aplikovaný po směru hodinových ručiček.",
+          "name": "Otočení"
+        },
+        "tone_compression": {
+          "description": "Síla komprese dynamického rozsahu. Nechat prázdné pro automatické nastavení.",
+          "name": "Komprese tónu"
+        }
+      },
+      "name": "Nahrát obrázek",
+      "sections": {
+        "additional_fields": {
+          "name": "Další možnosti"
+        }
+      }
+    },
+    "write_nfc": {
+      "description": "Zapíše NDEF záznam (URL, text nebo MIME data jako vCard) do NFC čipu zařízení OpenDisplay.",
+      "fields": {
+        "content": {
+          "description": "Data k zápisu. Pro URL záznam URL; pro textový záznam text; pro MIME záznam surová data; pro Home Assistant tag ID tagu. Omezeno na 512 bajtů při kódování UTF-8.",
+          "name": "Obsah"
+        },
+        "device_id": {
+          "description": "Zařízení OpenDisplay.",
+          "name": "Zařízení"
+        },
+        "mime_type": {
+          "description": "MIME typ obsahu. Platí pouze pro MIME záznamy; výchozí hodnota je text/vcard.",
+          "name": "MIME typ"
+        },
+        "record_type": {
+          "description": "Typ NDEF záznamu k zápisu. Home Assistant tag zapíše URL tagu Home Assistant; jeho naskenování v doprovodné aplikaci spustí tag_scanned a automaticky zaregistruje tag při prvním skenu.",
+          "name": "Typ záznamu"
+        }
+      },
+      "name": "Zapsat NFC tag"
+    }
+  }
+}

--- a/custom_components/opendisplay/translations/de.json
+++ b/custom_components/opendisplay/translations/de.json
@@ -1,0 +1,429 @@
+{
+  "config": {
+    "abort": {
+      "already_configured": "Gerät ist bereits konfiguriert",
+      "already_in_progress": "Konfigurationsvorgang läuft bereits",
+      "cannot_connect": "Verbindung fehlgeschlagen",
+      "no_devices_found": "Keine Geräte im Netzwerk gefunden",
+      "reauth_successful": "Re-Authentifizierung war erfolgreich",
+      "unknown": "Unerwarteter Fehler"
+    },
+    "error": {
+      "cannot_connect": "Verbindung fehlgeschlagen",
+      "invalid_auth": "Ungültige Authentifizierung",
+      "invalid_key_format": "Der Verschlüsselungsschlüssel muss genau 32 hexadezimale Zeichen (0-9, a-f) enthalten.",
+      "unknown": "Unerwarteter Fehler"
+    },
+    "flow_title": "{name}",
+    "step": {
+      "bluetooth_confirm": {
+        "description": "{name} einrichten?"
+      },
+      "encryption_key": {
+        "data": {
+          "encryption_key": "Verschlüsselungsschlüssel"
+        },
+        "data_description": {
+          "encryption_key": "Den 32-stelligen hexadezimalen AES-128-Verschlüsselungsschlüssel für dieses Gerät eingeben."
+        },
+        "description": "{name} benötigt einen Verschlüsselungsschlüssel zur Verbindung.",
+        "title": "Verschlüsselung erforderlich"
+      },
+      "reauth_confirm": {
+        "data": {
+          "encryption_key": "Verschlüsselungsschlüssel"
+        },
+        "data_description": {
+          "encryption_key": "Den 32-stelligen hexadezimalen AES-128-Verschlüsselungsschlüssel für dieses Gerät eingeben."
+        },
+        "description": "Authentifizierung für {name} fehlgeschlagen. Den korrekten Verschlüsselungsschlüssel eingeben oder leer lassen, wenn die Verschlüsselung auf dem Gerät deaktiviert wurde.",
+        "title": "Re-Authentifizierung erforderlich"
+      },
+      "user": {
+        "data": {
+          "address": "Gerät"
+        },
+        "data_description": {
+          "address": "Bluetooth-Gerät zur Einrichtung auswählen."
+        },
+        "description": "Gerät zur Einrichtung auswählen"
+      }
+    }
+  },
+  "entity": {
+    "binary_sensor": {
+      "update_pending": {
+        "name": "Update ausstehend"
+      }
+    },
+    "event": {
+      "button": {
+        "name": "Taste {number}",
+        "state_attributes": {
+          "event_type": {
+            "state": {
+              "button_down": "Taste gedrückt",
+              "button_up": "Taste losgelassen"
+            }
+          }
+        }
+      },
+      "touch": {
+        "name": "Berührung {number}",
+        "state_attributes": {
+          "event_type": {
+            "state": {
+              "touch_down": "Berührung gedrückt",
+              "touch_move": "Berührung bewegt",
+              "touch_up": "Berührung losgelassen"
+            }
+          }
+        }
+      }
+    },
+    "image": {
+      "content": {
+        "name": "Anzeigeinhalt"
+      }
+    },
+    "sensor": {
+      "battery_voltage": {
+        "name": "Batteriespannung"
+      },
+      "last_seen": {
+        "name": "Zuletzt gesehen"
+      },
+      "rssi": {
+        "name": "Signalstärke (RSSI)"
+      }
+    },
+    "update": {
+      "firmware": {
+        "name": "Firmware"
+      }
+    }
+  },
+  "exceptions": {
+    "authentication_error": {
+      "message": "Authentifizierung fehlgeschlagen. Verschlüsselungsschlüssel aktualisieren."
+    },
+    "device_not_found": {
+      "message": "Bluetooth-Gerät mit Adresse `{address}` konnte nicht gefunden werden."
+    },
+    "device_sleeping": {
+      "message": "Gerät `{device_id}` schläft und ist nicht sofort erreichbar. Aufwecken und erneut versuchen."
+    },
+    "device_sleeping_ota": {
+      "message": "Das Gerät schläft und kann derzeit nicht aktualisiert werden. Aufwecken (Taste drücken oder auf nächsten geplanten Check-in warten) und Update erneut starten."
+    },
+    "invalid_device_id": {
+      "message": "Gerät `{device_id}` ist kein gültiges OpenDisplay-Gerät."
+    },
+    "media_download_error": {
+      "message": "Medien konnten nicht heruntergeladen werden: {error}"
+    },
+    "mime_type_not_applicable": {
+      "message": "Das Feld mime_type gilt nur für MIME-Datensätze. record_type auf mime setzen oder mime_type weglassen."
+    },
+    "multiple_errors": {
+      "message": "Fehler bei einem oder mehreren Geräten:\n{errors}"
+    },
+    "nfc_content_empty": {
+      "message": "NFC-Inhalt darf nicht leer sein."
+    },
+    "nfc_content_too_long": {
+      "message": "NFC-Inhalt ist zu groß ({size} Bytes). Maximal sind {max} Bytes erlaubt."
+    },
+    "nfc_mime_type_invalid": {
+      "message": "MIME-Typ `{mime_type}` ist ungültig. Er muss 1-255 Bytes lang sein, wenn UTF-8-kodiert."
+    },
+    "nfc_not_supported": {
+      "message": "Gerät `{device_id}` hat nicht auf den NFC-Schreibvorgang reagiert. Die Firmware unterstützt möglicherweise kein Schreiben von NFC-Tags; auf die neueste Firmware aktualisieren."
+    },
+    "nfc_write_failed": {
+      "message": "NFC-Tag konnte nicht beschrieben werden: {error}"
+    },
+    "no_buzzers": {
+      "message": "Gerät `{device_id}` hat keinen Summer konfiguriert."
+    },
+    "no_leds": {
+      "message": "Gerät `{device_id}` hat keine LEDs konfiguriert."
+    },
+    "no_nfc": {
+      "message": "Gerät `{device_id}` hat keinen NFC-Chip konfiguriert."
+    },
+    "no_targets_specified": {
+      "message": "Keine Zielgeräte angegeben."
+    },
+    "upload_error": {
+      "message": "Hochladen auf das Display fehlgeschlagen: {error}"
+    },
+    "url_not_allowed": {
+      "message": "URL `{url}` ist nicht erlaubt. In `allowlist_external_urls` in configuration.yaml hinzufügen."
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "data": {
+          "blocks_per_ack": "Blöcke pro Bestätigung gesendet",
+          "max_queue_size": "Maximale Anzahl an Upload-Frames in der Warteschlange",
+          "missed_cycles": "Verpasste Weckzyklen bis zur Markierung als nicht verfügbar",
+          "probe_before_queue": "Vor dem Einreihen Verbindung versuchen",
+          "queue_timeout_hours": "Timeout für wartende Inhalte (Stunden)",
+          "sleep_mode": "Deep-Sleep-Verhalten"
+        },
+        "data_description": {
+          "blocks_per_ack": "Anzahl der Bildframes, die das Gerät empfängt, bevor es während eines schnellen (Sliding-Window) Uploads eine Bestätigung sendet. Höhere Werte reduzieren Rundreisen; der effektive Wert wird vom Gerät und der maximalen Anzahl an Frames in der Übertragung begrenzt.",
+          "max_queue_size": "Maximale Anzahl an Bildframes, die gleichzeitig während eines schnellen (Sliding-Window) Uploads in der Übertragung gehalten werden. Höhere Werte erhöhen den Durchsatz bei langsamen (Proxy-)Verbindungen. Auf 1 setzen, um schnellen Transfer zu deaktivieren und den klassischen Upload mit einem Frame gleichzeitig zu verwenden.",
+          "missed_cycles": "Anzahl erwarteter Weckvorgänge, die das Gerät verpassen darf, bevor seine Entitäten als nicht verfügbar markiert werden.",
+          "probe_before_queue": "Vor dem Einreihen eines Bildes für ein schlafendes Gerät eine schnelle Verbindungsprobe durchführen, falls es tatsächlich wach ist (verpasste Werbungen, immer aktive Radios). Fügt höchstens einige Sekunden hinzu, wenn das Gerät wirklich schläft.",
+          "queue_timeout_hours": "Wie lange wartende Inhalte für ein schlafendes Gerät auf ein Wecken warten, bevor sie verfallen.",
+          "sleep_mode": "Automatisch folgt der eigenen Energieeinstellung des Geräts (Batteriebetrieb mit aktiviertem Deep Sleep). Erzwingen von Ein oder Aus zur Überschreibung."
+        }
+      }
+    }
+  },
+  "selector": {
+    "dither_mode": {
+      "options": {
+        "atkinson": "Atkinson",
+        "burkes": "Burkes",
+        "floyd_steinberg": "Floyd-Steinberg",
+        "jarvis_judice_ninke": "Jarvis, Judice & Ninke",
+        "none": "Keine",
+        "ordered": "Geordnet",
+        "sierra": "Sierra",
+        "sierra_lite": "Sierra Lite",
+        "stucki": "Stucki"
+      }
+    },
+    "fit_mode": {
+      "options": {
+        "contain": "Anpassen",
+        "cover": "Abdecken",
+        "crop": "Zuschneiden",
+        "stretch": "Strecken"
+      }
+    },
+    "nfc_record_type": {
+      "options": {
+        "ha_tag": "Home Assistant-Tag",
+        "mime": "MIME-Daten (z. B. vCard)",
+        "text": "Text",
+        "url": "URL"
+      }
+    },
+    "refresh_mode": {
+      "options": {
+        "fast": "Schnell",
+        "full": "Vollständig",
+        "partial": "Teilweise"
+      }
+    },
+    "sleep_mode": {
+      "options": {
+        "auto": "Automatisch (Gerät folgen)",
+        "off": "Zwangsaus",
+        "on": "Zwangsanz"
+      }
+    }
+  },
+  "services": {
+    "activate_buzzer": {
+      "description": "Löst einen Summer-Ton auf einem OpenDisplay-Gerät aus.",
+      "fields": {
+        "device_id": {
+          "description": "Das OpenDisplay-Gerät.",
+          "name": "Gerät"
+        },
+        "duration_ms": {
+          "description": "Tonlänge in Millisekunden (5-1275).",
+          "name": "Dauer"
+        },
+        "frequency_hz": {
+          "description": "Tonfrequenz in Hz (0 = Stille, 400-12000).",
+          "name": "Frequenz"
+        },
+        "instance": {
+          "description": "Index der Summer-Instanz (0-basiert).",
+          "name": "Summer-Instanz"
+        },
+        "repeats": {
+          "description": "Anzahl der Wiederholungen des Tons (1-255).",
+          "name": "Wiederholungen"
+        }
+      },
+      "name": "Summer aktivieren"
+    },
+    "activate_led": {
+      "description": "Löst ein LED-Blitzmuster auf einem OpenDisplay-Gerät aus.",
+      "fields": {
+        "brightness": {
+          "description": "LED-Helligkeit (1-16).",
+          "name": "Helligkeit"
+        },
+        "color1": {
+          "description": "Farbe des ersten Schritts.",
+          "name": "Farbe 1"
+        },
+        "color2": {
+          "description": "Farbe des zweiten Schritts (weglassen oder Blitzanzahl auf 0 setzen, um zu überspringen).",
+          "name": "Farbe 2"
+        },
+        "color3": {
+          "description": "Farbe des dritten Schritts (weglassen oder Blitzanzahl auf 0 setzen, um zu überspringen).",
+          "name": "Farbe 3"
+        },
+        "device_id": {
+          "description": "Das OpenDisplay-Gerät.",
+          "name": "Gerät"
+        },
+        "flash_count1": {
+          "description": "Anzahl der Blitze im ersten Schritt (0 überspringt diesen Schritt).",
+          "name": "Blitzanzahl 1"
+        },
+        "flash_count2": {
+          "description": "Anzahl der Blitze im zweiten Schritt (0 überspringt diesen Schritt).",
+          "name": "Blitzanzahl 2"
+        },
+        "flash_count3": {
+          "description": "Anzahl der Blitze im dritten Schritt (0 überspringt diesen Schritt).",
+          "name": "Blitzanzahl 3"
+        },
+        "instance": {
+          "description": "Index der LED-Instanz (0-basiert).",
+          "name": "LED-Instanz"
+        },
+        "inter_delay1": {
+          "description": "Verzögerung nach dem ersten Schritt vor dem nächsten.",
+          "name": "Schrittverzögerung 1"
+        },
+        "inter_delay2": {
+          "description": "Verzögerung nach dem zweiten Schritt vor dem nächsten.",
+          "name": "Schrittverzögerung 2"
+        },
+        "inter_delay3": {
+          "description": "Verzögerung nach dem dritten Schritt vor der Wiederholung.",
+          "name": "Schrittverzögerung 3"
+        },
+        "loop_delay1": {
+          "description": "Verzögerung zwischen Blitzen im ersten Schritt.",
+          "name": "Blitzverzögerung 1"
+        },
+        "loop_delay2": {
+          "description": "Verzögerung zwischen Blitzen im zweiten Schritt.",
+          "name": "Blitzverzögerung 2"
+        },
+        "loop_delay3": {
+          "description": "Verzögerung zwischen Blitzen im dritten Schritt.",
+          "name": "Blitzverzögerung 3"
+        },
+        "repeats": {
+          "description": "Anzahl der Wiederholungen des gesamten Musters (0 = unendlich).",
+          "name": "Wiederholungen"
+        }
+      },
+      "name": "LED aktivieren"
+    },
+    "drawcustom": {
+      "description": "Zeichnet ein benutzerdefiniertes Bild auf einem oder mehreren OpenDisplay-Geräten.",
+      "fields": {
+        "background": {
+          "description": "Hintergrundfüllfarbe.",
+          "name": "Hintergrundfarbe"
+        },
+        "dither": {
+          "description": "Dithering-Algorithmus für die Farbpalettenkonvertierung.",
+          "name": "Dithering-Modus"
+        },
+        "dry-run": {
+          "description": "Bild erzeugen, ohne es auf das Gerät hochzuladen.",
+          "name": "Testlauf"
+        },
+        "measured_palette": {
+          "description": "Die gemessene Farbpalette des Panels verwenden, wenn verfügbar. Ausschalten, um gegen das theoretische Farbschema zu dithern. Keine Auswirkung auf Panels ohne Messdaten.",
+          "name": "Gemessene Palette verwenden"
+        },
+        "payload": {
+          "description": "Array von Zeichenelementen.",
+          "name": "Nutzlast"
+        },
+        "refresh_type": {
+          "description": "Display-Aktualisierungsmodus. Teilweise Aktualisierung aktualisiert nur den geänderten Bereich ohne Flackern; fällt automatisch auf eine vollständige Aktualisierung zurück, wenn nicht möglich.",
+          "name": "Aktualisierungstyp"
+        },
+        "rotate": {
+          "description": "Drehung im Uhrzeigersinn in Grad.",
+          "name": "Drehung"
+        }
+      },
+      "name": "Benutzerdefiniertes Bild zeichnen"
+    },
+    "upload_image": {
+      "description": "Lädt ein Bild auf ein OpenDisplay-Gerät hoch.",
+      "fields": {
+        "device_id": {
+          "description": "Das OpenDisplay-Gerät, auf das das Bild hochgeladen wird.",
+          "name": "Gerät"
+        },
+        "dither_mode": {
+          "description": "Der Dithering-Algorithmus für die Umwandlung des Bildes in die Farbpalette des Displays.",
+          "name": "Dithering-Modus"
+        },
+        "fit_mode": {
+          "description": "Wie das Bild an die Display-Abmessungen angepasst wird.",
+          "name": "Anpassungsmodus"
+        },
+        "image": {
+          "description": "Das Bild, das auf das Display hochgeladen wird. Wähle ein Medienobjekt oder gib eine direkte Bild-URL an (die URL muss zu allowlist_external_urls hinzugefügt werden).",
+          "name": "Bild"
+        },
+        "measured_palette": {
+          "description": "Die gemessene Farbpalette des Panels verwenden, wenn verfügbar. Ausschalten, um gegen das theoretische Farbschema zu dithern. Keine Auswirkung auf Panels ohne gemessene Daten.",
+          "name": "Gemessene Palette verwenden"
+        },
+        "refresh_mode": {
+          "description": "Der Anzeigenerneuerungsmodus. Volle Erneuerung beseitigt Nachbilder, ist aber langsamer. Schnelle Erneuerung wird nicht von allen Displays unterstützt. Teilweise Aktualisierung aktualisiert nur den geänderten Bereich ohne Flackern (B/W-Panels mit Teilunterstützung; fällt automatisch auf volle Erneuerung zurück, wenn nicht möglich).",
+          "name": "Erneuerungsmodus"
+        },
+        "rotation": {
+          "description": "Der Rotationswinkel in Grad, im Uhrzeigersinn angewendet.",
+          "name": "Rotation"
+        },
+        "tone_compression": {
+          "description": "Stärke der Dynamikumfangkompression. Leer lassen für automatische Einstellung.",
+          "name": "Tonkompression"
+        }
+      },
+      "name": "Bild hochladen",
+      "sections": {
+        "additional_fields": {
+          "name": "Zusätzliche Optionen"
+        }
+      }
+    },
+    "write_nfc": {
+      "description": "Schreibt einen NDEF-Datensatz (URL, Text oder MIME-Daten wie vCard) auf den NFC-Chip eines OpenDisplay-Geräts.",
+      "fields": {
+        "content": {
+          "description": "Die zu schreibenden Daten. Für einen URL-Datensatz die URL; für einen Text-Datensatz den Text; für einen MIME-Datensatz die Rohdaten; für einen Home Assistant-Tag die Tag-ID. Auf 512 Bytes bei UTF-8-Codierung begrenzt.",
+          "name": "Inhalt"
+        },
+        "device_id": {
+          "description": "Das OpenDisplay-Gerät.",
+          "name": "Gerät"
+        },
+        "mime_type": {
+          "description": "Der MIME-Typ des Inhalts. Gilt nur für MIME-Datensätze; Standard ist text/vcard.",
+          "name": "MIME-Typ"
+        },
+        "record_type": {
+          "description": "Der Typ des zu schreibenden NDEF-Datensatzes. Home Assistant-Tag schreibt eine Home Assistant-Tag-URL; das Scannen mit der Begleit-App löst tag_scanned aus und registriert den Tag beim ersten Scan automatisch.",
+          "name": "Datensatztyp"
+        }
+      },
+      "name": "NFC-Tag beschreiben"
+    }
+  }
+}

--- a/custom_components/opendisplay/translations/en.json
+++ b/custom_components/opendisplay/translations/en.json
@@ -181,7 +181,7 @@
             "message": "Failed to upload to the display: {error}"
         },
         "url_not_allowed": {
-            "message": "URL `{url}` is not allowed. Add it to `allowlist_external_urls` in your configuration.yaml."
+            "message": "URL `{url}` is not allowed. Add it to `allowlist_external_urls` in configuration.yaml."
         }
     },
     "selector": {

--- a/custom_components/opendisplay/translations/es.json
+++ b/custom_components/opendisplay/translations/es.json
@@ -1,0 +1,429 @@
+{
+  "config": {
+    "abort": {
+      "already_configured": "El dispositivo ya está configurado",
+      "already_in_progress": "El flujo de configuración ya está en curso",
+      "cannot_connect": "Error al conectar",
+      "no_devices_found": "No se encontraron dispositivos en la red",
+      "reauth_successful": "La reautenticación fue exitosa",
+      "unknown": "Error inesperado"
+    },
+    "error": {
+      "cannot_connect": "Error al conectar",
+      "invalid_auth": "Autenticación inválida",
+      "invalid_key_format": "La clave de cifrado debe tener exactamente 32 caracteres hexadecimales (0-9, a-f).",
+      "unknown": "Error inesperado"
+    },
+    "flow_title": "{name}",
+    "step": {
+      "bluetooth_confirm": {
+        "description": "Configurar {name}?"
+      },
+      "encryption_key": {
+        "data": {
+          "encryption_key": "Clave de cifrado"
+        },
+        "data_description": {
+          "encryption_key": "Introducir la clave de cifrado AES-128 hexadecimal de 32 caracteres para este dispositivo."
+        },
+        "description": "{name} requiere una clave de cifrado para conectarse.",
+        "title": "Cifrado requerido"
+      },
+      "reauth_confirm": {
+        "data": {
+          "encryption_key": "Clave de cifrado"
+        },
+        "data_description": {
+          "encryption_key": "Introducir la clave de cifrado AES-128 hexadecimal de 32 caracteres para este dispositivo."
+        },
+        "description": "La autenticación falló para {name}. Introducir la clave de cifrado correcta o dejar en blanco si el cifrado está deshabilitado en el dispositivo.",
+        "title": "Reautenticación requerida"
+      },
+      "user": {
+        "data": {
+          "address": "Dispositivo"
+        },
+        "data_description": {
+          "address": "Seleccionar el dispositivo Bluetooth para configurar."
+        },
+        "description": "Elegir un dispositivo para configurar"
+      }
+    }
+  },
+  "entity": {
+    "binary_sensor": {
+      "update_pending": {
+        "name": "Actualización pendiente"
+      }
+    },
+    "event": {
+      "button": {
+        "name": "Botón {number}",
+        "state_attributes": {
+          "event_type": {
+            "state": {
+              "button_down": "Botón presionado",
+              "button_up": "Botón liberado"
+            }
+          }
+        }
+      },
+      "touch": {
+        "name": "Toque {number}",
+        "state_attributes": {
+          "event_type": {
+            "state": {
+              "touch_down": "Toque presionado",
+              "touch_move": "Toque movido",
+              "touch_up": "Toque liberado"
+            }
+          }
+        }
+      }
+    },
+    "image": {
+      "content": {
+        "name": "Contenido de la pantalla"
+      }
+    },
+    "sensor": {
+      "battery_voltage": {
+        "name": "Voltaje de batería"
+      },
+      "last_seen": {
+        "name": "Última vez visto"
+      },
+      "rssi": {
+        "name": "Intensidad de señal (RSSI)"
+      }
+    },
+    "update": {
+      "firmware": {
+        "name": "Firmware"
+      }
+    }
+  },
+  "exceptions": {
+    "authentication_error": {
+      "message": "Autenticación fallida. Actualizar la clave de cifrado."
+    },
+    "device_not_found": {
+      "message": "No se pudo encontrar el dispositivo Bluetooth con la dirección `{address}`."
+    },
+    "device_sleeping": {
+      "message": "El dispositivo `{device_id}` está en reposo y no se puede alcanzar inmediatamente. Despertarlo e intentar de nuevo."
+    },
+    "device_sleeping_ota": {
+      "message": "El dispositivo está en reposo y no puede actualizarse ahora. Despertarlo (presionar su botón o esperar su próxima conexión programada) y comenzar la actualización de nuevo."
+    },
+    "invalid_device_id": {
+      "message": "El dispositivo `{device_id}` no es un dispositivo OpenDisplay válido."
+    },
+    "media_download_error": {
+      "message": "Error al descargar medios: {error}"
+    },
+    "mime_type_not_applicable": {
+      "message": "El campo mime_type solo aplica a registros MIME. Establecer record_type en mime, o omitir mime_type."
+    },
+    "multiple_errors": {
+      "message": "Ocurrieron errores en uno o más dispositivos:\n{errors}"
+    },
+    "nfc_content_empty": {
+      "message": "El contenido NFC no puede estar vacío."
+    },
+    "nfc_content_too_long": {
+      "message": "El contenido NFC es demasiado grande ({size} bytes). El máximo es {max} bytes."
+    },
+    "nfc_mime_type_invalid": {
+      "message": "El tipo MIME `{mime_type}` no es válido. Debe tener entre 1 y 255 bytes codificados en UTF-8."
+    },
+    "nfc_not_supported": {
+      "message": "El dispositivo `{device_id}` no respondió a la escritura NFC. Su firmware puede no soportar la escritura de etiquetas NFC; intentar actualizar al firmware más reciente."
+    },
+    "nfc_write_failed": {
+      "message": "Error al escribir la etiqueta NFC: {error}"
+    },
+    "no_buzzers": {
+      "message": "El dispositivo `{device_id}` no tiene zumbador configurado."
+    },
+    "no_leds": {
+      "message": "El dispositivo `{device_id}` no tiene LEDs configurados."
+    },
+    "no_nfc": {
+      "message": "El dispositivo `{device_id}` no tiene chip NFC configurado."
+    },
+    "no_targets_specified": {
+      "message": "No se especificaron dispositivos objetivo."
+    },
+    "upload_error": {
+      "message": "Error al subir a la pantalla: {error}"
+    },
+    "url_not_allowed": {
+      "message": "La URL `{url}` no está permitida. Agrégala a `allowlist_external_urls` en configuration.yaml."
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "data": {
+          "blocks_per_ack": "Bloques enviados por acuse de recibo",
+          "max_queue_size": "Máximo de cuadros de carga en vuelo",
+          "missed_cycles": "Ciclos de activación perdidos antes de marcar como no disponible",
+          "probe_before_queue": "Intentar conectar antes de encolar",
+          "queue_timeout_hours": "Tiempo de espera de contenido en cola (horas)",
+          "sleep_mode": "Manejo de modo de suspensión profunda"
+        },
+        "data_description": {
+          "blocks_per_ack": "Cantidad de cuadros de imagen que el dispositivo recibe antes de enviar un acuse durante una carga rápida (ventana deslizante). Valores más altos reducen viajes de ida y vuelta; el valor efectivo está limitado por el dispositivo y el máximo de cuadros en vuelo.",
+          "max_queue_size": "Número máximo de cuadros de imagen mantenidos en vuelo a la vez durante una carga rápida (ventana deslizante). Valores más altos aumentan el rendimiento en enlaces lentos (proxy). Establecer en 1 para desactivar la transferencia rápida y usar la carga clásica cuadro por cuadro.",
+          "missed_cycles": "Cantidad de activaciones esperadas que el dispositivo puede perder antes de que sus entidades se marquen como no disponibles.",
+          "probe_before_queue": "Antes de encolar una imagen para un dispositivo en reposo, hacer un intento rápido de conexión por si está despierto (publicidad perdida, radios siempre activas). Añade como máximo unos segundos cuando el dispositivo realmente está dormido.",
+          "queue_timeout_hours": "Tiempo que el contenido en cola para un dispositivo dormido espera una activación antes de expirar.",
+          "sleep_mode": "Automático sigue la configuración de energía del dispositivo (batería con suspensión profunda activada). Forzar activado o desactivado para anular."
+        }
+      }
+    }
+  },
+  "selector": {
+    "dither_mode": {
+      "options": {
+        "atkinson": "Atkinson",
+        "burkes": "Burkes",
+        "floyd_steinberg": "Floyd-Steinberg",
+        "jarvis_judice_ninke": "Jarvis, Judice & Ninke",
+        "none": "Ninguno",
+        "ordered": "Ordenado",
+        "sierra": "Sierra",
+        "sierra_lite": "Sierra Lite",
+        "stucki": "Stucki"
+      }
+    },
+    "fit_mode": {
+      "options": {
+        "contain": "Contener",
+        "cover": "Cubrir",
+        "crop": "Recortar",
+        "stretch": "Estirar"
+      }
+    },
+    "nfc_record_type": {
+      "options": {
+        "ha_tag": "Etiqueta de Home Assistant",
+        "mime": "Datos MIME (p. ej., vCard)",
+        "text": "Texto",
+        "url": "URL"
+      }
+    },
+    "refresh_mode": {
+      "options": {
+        "fast": "Rápido",
+        "full": "Completo",
+        "partial": "Parcial"
+      }
+    },
+    "sleep_mode": {
+      "options": {
+        "auto": "Automático (seguir dispositivo)",
+        "off": "Forzar apagado",
+        "on": "Forzar encendido"
+      }
+    }
+  },
+  "services": {
+    "activate_buzzer": {
+      "description": "Activa un tono de buzzer en un dispositivo OpenDisplay.",
+      "fields": {
+        "device_id": {
+          "description": "El dispositivo OpenDisplay.",
+          "name": "Dispositivo"
+        },
+        "duration_ms": {
+          "description": "Duración del tono en milisegundos (5-1275).",
+          "name": "Duración"
+        },
+        "frequency_hz": {
+          "description": "Frecuencia del tono en Hz (0 = silencio, 400-12000).",
+          "name": "Frecuencia"
+        },
+        "instance": {
+          "description": "Índice de instancia del buzzer (basado en 0).",
+          "name": "Instancia del buzzer"
+        },
+        "repeats": {
+          "description": "Número de repeticiones del tono (1-255).",
+          "name": "Repeticiones"
+        }
+      },
+      "name": "Activar buzzer"
+    },
+    "activate_led": {
+      "description": "Activa un patrón de destellos LED en un dispositivo OpenDisplay.",
+      "fields": {
+        "brightness": {
+          "description": "Brillo del LED (1-16).",
+          "name": "Brillo"
+        },
+        "color1": {
+          "description": "Color del primer paso.",
+          "name": "Color 1"
+        },
+        "color2": {
+          "description": "Color del segundo paso (omitir o poner el conteo de destellos en 0 para saltar).",
+          "name": "Color 2"
+        },
+        "color3": {
+          "description": "Color del tercer paso (omitir o poner el conteo de destellos en 0 para saltar).",
+          "name": "Color 3"
+        },
+        "device_id": {
+          "description": "El dispositivo OpenDisplay.",
+          "name": "Dispositivo"
+        },
+        "flash_count1": {
+          "description": "Número de destellos para el primer paso (0 salta este paso).",
+          "name": "Conteo de destellos 1"
+        },
+        "flash_count2": {
+          "description": "Número de destellos para el segundo paso (0 salta este paso).",
+          "name": "Conteo de destellos 2"
+        },
+        "flash_count3": {
+          "description": "Número de destellos para el tercer paso (0 salta este paso).",
+          "name": "Conteo de destellos 3"
+        },
+        "instance": {
+          "description": "Índice de instancia del LED (basado en 0).",
+          "name": "Instancia del LED"
+        },
+        "inter_delay1": {
+          "description": "Retraso después del primer paso antes de pasar al siguiente.",
+          "name": "Retraso del paso 1"
+        },
+        "inter_delay2": {
+          "description": "Retraso después del segundo paso antes de pasar al siguiente.",
+          "name": "Retraso del paso 2"
+        },
+        "inter_delay3": {
+          "description": "Retraso después del tercer paso antes de repetir.",
+          "name": "Retraso del paso 3"
+        },
+        "loop_delay1": {
+          "description": "Retraso entre destellos en el primer paso.",
+          "name": "Retraso de destello 1"
+        },
+        "loop_delay2": {
+          "description": "Retraso entre destellos en el segundo paso.",
+          "name": "Retraso de destello 2"
+        },
+        "loop_delay3": {
+          "description": "Retraso entre destellos en el tercer paso.",
+          "name": "Retraso de destello 3"
+        },
+        "repeats": {
+          "description": "Número de repeticiones del patrón completo (0 = infinito).",
+          "name": "Repeticiones"
+        }
+      },
+      "name": "Activar LED"
+    },
+    "drawcustom": {
+      "description": "Dibuja una imagen personalizada en uno o más dispositivos OpenDisplay.",
+      "fields": {
+        "background": {
+          "description": "Color de fondo.",
+          "name": "Color de fondo"
+        },
+        "dither": {
+          "description": "Algoritmo de tramado para la conversión de la paleta de colores.",
+          "name": "Modo de tramado"
+        },
+        "dry-run": {
+          "description": "Generar imagen sin subirla al dispositivo.",
+          "name": "Simulación"
+        },
+        "measured_palette": {
+          "description": "Usar la paleta de colores medida del panel cuando esté disponible. Desactivar para tramado contra el esquema teórico. Sin efecto en paneles sin datos medidos.",
+          "name": "Usar paleta medida"
+        },
+        "payload": {
+          "description": "Array de elementos de dibujo.",
+          "name": "Contenido"
+        },
+        "refresh_type": {
+          "description": "Modo de actualización de pantalla. La actualización parcial solo cambia la región modificada sin parpadeo; se usa actualización completa automáticamente cuando no es posible.",
+          "name": "Tipo de actualización"
+        },
+        "rotate": {
+          "description": "Rotación en sentido horario en grados.",
+          "name": "Rotación"
+        }
+      },
+      "name": "Dibujar imagen personalizada"
+    },
+    "upload_image": {
+      "description": "Sube una imagen a un dispositivo OpenDisplay.",
+      "fields": {
+        "device_id": {
+          "description": "El dispositivo OpenDisplay al que subir la imagen.",
+          "name": "Dispositivo"
+        },
+        "dither_mode": {
+          "description": "Algoritmo de tramado para convertir la imagen a la paleta de colores del display.",
+          "name": "Modo de tramado"
+        },
+        "fit_mode": {
+          "description": "Cómo se ajusta la imagen a las dimensiones del display.",
+          "name": "Modo de ajuste"
+        },
+        "image": {
+          "description": "La imagen para subir al display. Seleccionar un elemento multimedia o proporcionar una URL directa de imagen (la URL debe estar en allowlist_external_urls).",
+          "name": "Imagen"
+        },
+        "measured_palette": {
+          "description": "Usar la paleta de colores medida del panel cuando esté disponible. Desactivar para aplicar tramado contra el esquema de color teórico. Sin efecto en paneles sin datos medidos.",
+          "name": "Usar paleta medida"
+        },
+        "refresh_mode": {
+          "description": "El modo de actualización de la pantalla. La actualización completa elimina imágenes fantasma pero es más lenta. La actualización rápida no es compatible con todas las pantallas. La actualización parcial solo actualiza la región cambiada sin parpadeo (paneles B/N con soporte parcial; vuelve automáticamente a actualización completa si no es posible).",
+          "name": "Modo de actualización"
+        },
+        "rotation": {
+          "description": "El ángulo de rotación en grados, aplicado en sentido horario.",
+          "name": "Rotación"
+        },
+        "tone_compression": {
+          "description": "Intensidad de compresión del rango dinámico. Dejar vacío para automático.",
+          "name": "Compresión de tono"
+        }
+      },
+      "name": "Subir imagen",
+      "sections": {
+        "additional_fields": {
+          "name": "Opciones adicionales"
+        }
+      }
+    },
+    "write_nfc": {
+      "description": "Escribe un registro NDEF (URL, texto o datos MIME como una vCard) en el chip NFC de un dispositivo OpenDisplay.",
+      "fields": {
+        "content": {
+          "description": "Los datos a escribir. Para un registro URL, la URL; para un registro de texto, el texto; para un registro MIME, los datos en bruto; para una etiqueta Home Assistant, el id de la etiqueta. Limitado a 512 bytes codificados en UTF-8.",
+          "name": "Contenido"
+        },
+        "device_id": {
+          "description": "El dispositivo OpenDisplay.",
+          "name": "Dispositivo"
+        },
+        "mime_type": {
+          "description": "El tipo MIME del contenido. Solo aplica a registros MIME; por defecto es text/vcard.",
+          "name": "Tipo MIME"
+        },
+        "record_type": {
+          "description": "El tipo de registro NDEF a escribir. La etiqueta Home Assistant escribe una URL de etiqueta Home Assistant; escanearla con la app compañera dispara tag_scanned y registra la etiqueta automáticamente en el primer escaneo.",
+          "name": "Tipo de registro"
+        }
+      },
+      "name": "Escribir etiqueta NFC"
+    }
+  }
+}

--- a/custom_components/opendisplay/translations/fr.json
+++ b/custom_components/opendisplay/translations/fr.json
@@ -1,0 +1,429 @@
+{
+  "config": {
+    "abort": {
+      "already_configured": "L’appareil est déjà configuré",
+      "already_in_progress": "Un flux de configuration est déjà en cours",
+      "cannot_connect": "Échec de la connexion",
+      "no_devices_found": "Aucun appareil trouvé sur le réseau",
+      "reauth_successful": "La ré-authentification a réussi",
+      "unknown": "Erreur inattendue"
+    },
+    "error": {
+      "cannot_connect": "Échec de la connexion",
+      "invalid_auth": "Authentification invalide",
+      "invalid_key_format": "La clé de chiffrement doit comporter exactement 32 caractères hexadécimaux (0-9, a-f).",
+      "unknown": "Erreur inattendue"
+    },
+    "flow_title": "{name}",
+    "step": {
+      "bluetooth_confirm": {
+        "description": "Configurer {name} ?"
+      },
+      "encryption_key": {
+        "data": {
+          "encryption_key": "Clé de chiffrement"
+        },
+        "data_description": {
+          "encryption_key": "Saisir la clé de chiffrement AES-128 hexadécimale de 32 caractères pour cet appareil."
+        },
+        "description": "{name} nécessite une clé de chiffrement pour se connecter.",
+        "title": "Chiffrement requis"
+      },
+      "reauth_confirm": {
+        "data": {
+          "encryption_key": "Clé de chiffrement"
+        },
+        "data_description": {
+          "encryption_key": "Saisir la clé de chiffrement AES-128 hexadécimale de 32 caractères pour cet appareil."
+        },
+        "description": "L’authentification a échoué pour {name}. Saisir la clé de chiffrement correcte ou laisser vide si le chiffrement a été désactivé sur l’appareil.",
+        "title": "Ré-authentification requise"
+      },
+      "user": {
+        "data": {
+          "address": "Appareil"
+        },
+        "data_description": {
+          "address": "Sélectionner l’appareil Bluetooth à configurer."
+        },
+        "description": "Choisir un appareil à configurer"
+      }
+    }
+  },
+  "entity": {
+    "binary_sensor": {
+      "update_pending": {
+        "name": "Mise à jour en attente"
+      }
+    },
+    "event": {
+      "button": {
+        "name": "Bouton {number}",
+        "state_attributes": {
+          "event_type": {
+            "state": {
+              "button_down": "Bouton enfoncé",
+              "button_up": "Bouton relâché"
+            }
+          }
+        }
+      },
+      "touch": {
+        "name": "Toucher {number}",
+        "state_attributes": {
+          "event_type": {
+            "state": {
+              "touch_down": "Toucher enfoncé",
+              "touch_move": "Toucher déplacé",
+              "touch_up": "Toucher relâché"
+            }
+          }
+        }
+      }
+    },
+    "image": {
+      "content": {
+        "name": "Contenu de l’affichage"
+      }
+    },
+    "sensor": {
+      "battery_voltage": {
+        "name": "Tension de la batterie"
+      },
+      "last_seen": {
+        "name": "Dernière détection"
+      },
+      "rssi": {
+        "name": "Puissance du signal (RSSI)"
+      }
+    },
+    "update": {
+      "firmware": {
+        "name": "Firmware"
+      }
+    }
+  },
+  "exceptions": {
+    "authentication_error": {
+      "message": "Échec de l’authentification. Mettre à jour la clé de chiffrement."
+    },
+    "device_not_found": {
+      "message": "Impossible de trouver l’appareil Bluetooth avec l’adresse `{address}`."
+    },
+    "device_sleeping": {
+      "message": "L’appareil `{device_id}` est en veille et ne peut pas être atteint immédiatement. Le réveiller et réessayer."
+    },
+    "device_sleeping_ota": {
+      "message": "L’appareil est en veille et ne peut pas être mis à jour pour le moment. Le réveiller (appuyer sur son bouton ou attendre son prochain check-in programmé) et relancer la mise à jour."
+    },
+    "invalid_device_id": {
+      "message": "L’appareil `{device_id}` n’est pas un appareil OpenDisplay valide."
+    },
+    "media_download_error": {
+      "message": "Échec du téléchargement du média : {error}"
+    },
+    "mime_type_not_applicable": {
+      "message": "Le champ mime_type s’applique uniquement aux enregistrements MIME. Définir record_type sur mime ou omettre mime_type."
+    },
+    "multiple_errors": {
+      "message": "Des erreurs sont survenues pour un ou plusieurs appareils :\n{errors}"
+    },
+    "nfc_content_empty": {
+      "message": "Le contenu NFC ne peut pas être vide."
+    },
+    "nfc_content_too_long": {
+      "message": "Le contenu NFC est trop volumineux ({size} octets). Le maximum est {max} octets."
+    },
+    "nfc_mime_type_invalid": {
+      "message": "Le type MIME `{mime_type}` est invalide. Il doit comporter entre 1 et 255 octets en UTF-8."
+    },
+    "nfc_not_supported": {
+      "message": "L’appareil `{device_id}` n’a pas répondu à l’écriture NFC. Son firmware peut ne pas supporter l’écriture des tags NFC ; essayer de mettre à jour vers le dernier firmware."
+    },
+    "nfc_write_failed": {
+      "message": "Échec de l’écriture du tag NFC : {error}"
+    },
+    "no_buzzers": {
+      "message": "L’appareil `{device_id}` n’a pas de buzzer configuré."
+    },
+    "no_leds": {
+      "message": "L’appareil `{device_id}` n’a pas de LED configurées."
+    },
+    "no_nfc": {
+      "message": "L’appareil `{device_id}` n’a pas de puce NFC configurée."
+    },
+    "no_targets_specified": {
+      "message": "Aucun appareil cible spécifié."
+    },
+    "upload_error": {
+      "message": "Échec du téléversement vers l’affichage : {error}"
+    },
+    "url_not_allowed": {
+      "message": "L’URL `{url}` n’est pas autorisée. L’ajouter à `allowlist_external_urls` dans configuration.yaml."
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "data": {
+          "blocks_per_ack": "Blocs envoyés par accusé de réception",
+          "max_queue_size": "Nombre maximum de trames en cours de téléversement",
+          "missed_cycles": "Cycles de réveil manqués avant indisponibilité",
+          "probe_before_queue": "Essayer de se connecter avant de mettre en file d’attente",
+          "queue_timeout_hours": "Expiration du contenu en file d’attente (heures)",
+          "sleep_mode": "Gestion du mode veille profonde"
+        },
+        "data_description": {
+          "blocks_per_ack": "Nombre de trames d’image reçues par l’appareil avant qu’il n’envoie un accusé de réception lors d’un téléversement rapide (fenêtre glissante). Des valeurs plus élevées réduisent les allers-retours ; la valeur effective est limitée par l’appareil et le nombre maximum de trames en cours.",
+          "max_queue_size": "Nombre maximum de trames d’image maintenues en cours lors d’un téléversement rapide (fenêtre glissante). Des valeurs plus élevées augmentent le débit sur les liaisons lentes (proxy). Mettre à 1 pour désactiver le transfert rapide et utiliser le téléversement classique une trame à la fois.",
+          "missed_cycles": "Nombre de réveils attendus que l’appareil peut manquer avant que ses entités soient marquées comme indisponibles.",
+          "probe_before_queue": "Avant de mettre une image en file d’attente pour un appareil en veille, effectuer une tentative rapide de connexion au cas où il serait en fait réveillé (publicités manquées, radios toujours actives). Ajoute au maximum quelques secondes lorsque l’appareil est vraiment en veille.",
+          "queue_timeout_hours": "Durée pendant laquelle le contenu en file d’attente pour un appareil en veille attend un réveil avant d’expirer.",
+          "sleep_mode": "Automatique suit la configuration d’alimentation propre à l’appareil (alimentation sur batterie avec veille profonde activée). Forcer activé ou désactivé pour outrepasser."
+        }
+      }
+    }
+  },
+  "selector": {
+    "dither_mode": {
+      "options": {
+        "atkinson": "Atkinson",
+        "burkes": "Burkes",
+        "floyd_steinberg": "Floyd-Steinberg",
+        "jarvis_judice_ninke": "Jarvis, Judice & Ninke",
+        "none": "Aucun",
+        "ordered": "Ordonné",
+        "sierra": "Sierra",
+        "sierra_lite": "Sierra Lite",
+        "stucki": "Stucki"
+      }
+    },
+    "fit_mode": {
+      "options": {
+        "contain": "Contenir",
+        "cover": "Couvrir",
+        "crop": "Rogner",
+        "stretch": "Étendre"
+      }
+    },
+    "nfc_record_type": {
+      "options": {
+        "ha_tag": "Étiquette Home Assistant",
+        "mime": "Données MIME (ex. vCard)",
+        "text": "Texte",
+        "url": "URL"
+      }
+    },
+    "refresh_mode": {
+      "options": {
+        "fast": "Rapide",
+        "full": "Complet",
+        "partial": "Partiel"
+      }
+    },
+    "sleep_mode": {
+      "options": {
+        "auto": "Automatique (suivre l'appareil)",
+        "off": "Forcer désactivé",
+        "on": "Forcer activé"
+      }
+    }
+  },
+  "services": {
+    "activate_buzzer": {
+      "description": "Déclenche un son de buzzer sur un appareil OpenDisplay.",
+      "fields": {
+        "device_id": {
+          "description": "L'appareil OpenDisplay.",
+          "name": "Appareil"
+        },
+        "duration_ms": {
+          "description": "Durée du son en millisecondes (5-1275).",
+          "name": "Durée"
+        },
+        "frequency_hz": {
+          "description": "Fréquence du son en Hz (0 = silence, 400-12000).",
+          "name": "Fréquence"
+        },
+        "instance": {
+          "description": "Index de l'instance du buzzer (base 0).",
+          "name": "Instance du buzzer"
+        },
+        "repeats": {
+          "description": "Nombre de répétitions du son (1-255).",
+          "name": "Répétitions"
+        }
+      },
+      "name": "Activer le buzzer"
+    },
+    "activate_led": {
+      "description": "Déclenche un motif de clignotement LED sur un appareil OpenDisplay.",
+      "fields": {
+        "brightness": {
+          "description": "Luminosité de la LED (1-16).",
+          "name": "Luminosité"
+        },
+        "color1": {
+          "description": "Couleur de la première étape.",
+          "name": "Couleur 1"
+        },
+        "color2": {
+          "description": "Couleur de la deuxième étape (omettre ou mettre le nombre de clignotements à 0 pour ignorer).",
+          "name": "Couleur 2"
+        },
+        "color3": {
+          "description": "Couleur de la troisième étape (omettre ou mettre le nombre de clignotements à 0 pour ignorer).",
+          "name": "Couleur 3"
+        },
+        "device_id": {
+          "description": "L'appareil OpenDisplay.",
+          "name": "Appareil"
+        },
+        "flash_count1": {
+          "description": "Nombre de clignotements pour la première étape (0 ignore cette étape).",
+          "name": "Nombre de clignotements 1"
+        },
+        "flash_count2": {
+          "description": "Nombre de clignotements pour la deuxième étape (0 ignore cette étape).",
+          "name": "Nombre de clignotements 2"
+        },
+        "flash_count3": {
+          "description": "Nombre de clignotements pour la troisième étape (0 ignore cette étape).",
+          "name": "Nombre de clignotements 3"
+        },
+        "instance": {
+          "description": "Index de l'instance LED (base 0).",
+          "name": "Instance LED"
+        },
+        "inter_delay1": {
+          "description": "Délai après la première étape avant de passer à la suivante.",
+          "name": "Délai étape 1"
+        },
+        "inter_delay2": {
+          "description": "Délai après la deuxième étape avant de passer à la suivante.",
+          "name": "Délai étape 2"
+        },
+        "inter_delay3": {
+          "description": "Délai après la troisième étape avant de répéter.",
+          "name": "Délai étape 3"
+        },
+        "loop_delay1": {
+          "description": "Délai entre les clignotements dans la première étape.",
+          "name": "Délai clignotement 1"
+        },
+        "loop_delay2": {
+          "description": "Délai entre les clignotements dans la deuxième étape.",
+          "name": "Délai clignotement 2"
+        },
+        "loop_delay3": {
+          "description": "Délai entre les clignotements dans la troisième étape.",
+          "name": "Délai clignotement 3"
+        },
+        "repeats": {
+          "description": "Nombre de répétitions du motif complet (0 = infini).",
+          "name": "Répétitions"
+        }
+      },
+      "name": "Activer la LED"
+    },
+    "drawcustom": {
+      "description": "Dessine une image personnalisée sur un ou plusieurs appareils OpenDisplay.",
+      "fields": {
+        "background": {
+          "description": "Couleur de fond.",
+          "name": "Couleur de fond"
+        },
+        "dither": {
+          "description": "Algorithme de tramage pour la conversion de la palette de couleurs.",
+          "name": "Mode de tramage"
+        },
+        "dry-run": {
+          "description": "Générer l'image sans la télécharger sur l'appareil.",
+          "name": "Exécution test"
+        },
+        "measured_palette": {
+          "description": "Utiliser la palette de couleurs mesurée du panneau si disponible. Désactiver pour tramer selon le schéma théorique. Sans effet sur les panneaux sans données mesurées.",
+          "name": "Utiliser la palette mesurée"
+        },
+        "payload": {
+          "description": "Tableau d'éléments de dessin.",
+          "name": "Charge utile"
+        },
+        "refresh_type": {
+          "description": "Mode de rafraîchissement de l'affichage. Partiel met à jour uniquement la zone modifiée sans clignotement ; bascule automatiquement sur un rafraîchissement complet si nécessaire.",
+          "name": "Type de rafraîchissement"
+        },
+        "rotate": {
+          "description": "Rotation horaire en degrés.",
+          "name": "Rotation"
+        }
+      },
+      "name": "Dessiner une image personnalisée"
+    },
+    "upload_image": {
+      "description": "Télécharge une image sur un appareil OpenDisplay.",
+      "fields": {
+        "device_id": {
+          "description": "L'appareil OpenDisplay sur lequel télécharger l'image.",
+          "name": "Appareil"
+        },
+        "dither_mode": {
+          "description": "Algorithme de tramage utilisé pour convertir l'image à la palette de couleurs de l'affichage.",
+          "name": "Mode de tramage"
+        },
+        "fit_mode": {
+          "description": "Mode d'ajustement de l'image aux dimensions de l'affichage.",
+          "name": "Mode d'ajustement"
+        },
+        "image": {
+          "description": "Image à télécharger sur l'affichage. Choisir un média ou fournir une URL directe d'image (l'URL doit être ajoutée à allowlist_external_urls).",
+          "name": "Image"
+        },
+        "measured_palette": {
+          "description": "Utiliser la palette de couleurs mesurée du panneau si disponible. Désactiver pour appliquer un tramage selon le schéma de couleurs théorique. Sans effet sur les panneaux sans données mesurées.",
+          "name": "Utiliser la palette mesurée"
+        },
+        "refresh_mode": {
+          "description": "Mode de rafraîchissement de l'affichage. Le rafraîchissement complet élimine les images fantômes mais est plus lent. Le rafraîchissement rapide n'est pas supporté par tous les écrans. Le rafraîchissement partiel met à jour uniquement la zone modifiée sans clignotement (panneaux N/B avec support partiel ; bascule automatiquement sur un rafraîchissement complet si impossible).",
+          "name": "Mode de rafraîchissement"
+        },
+        "rotation": {
+          "description": "Angle de rotation en degrés, appliqué dans le sens horaire.",
+          "name": "Rotation"
+        },
+        "tone_compression": {
+          "description": "Force de compression de la plage dynamique. Laisser vide pour automatique.",
+          "name": "Compression de tonalité"
+        }
+      },
+      "name": "Téléverser une image",
+      "sections": {
+        "additional_fields": {
+          "name": "Options supplémentaires"
+        }
+      }
+    },
+    "write_nfc": {
+      "description": "Écrire un enregistrement NDEF (URL, texte ou données MIME comme une vCard) sur la puce NFC d'un appareil OpenDisplay.",
+      "fields": {
+        "content": {
+          "description": "Les données à écrire. Pour un enregistrement URL, l'URL ; pour un enregistrement texte, le texte ; pour un enregistrement MIME, les données brutes ; pour une étiquette Home Assistant, l'identifiant de l'étiquette. Limité à 512 octets en UTF-8.",
+          "name": "Contenu"
+        },
+        "device_id": {
+          "description": "L'appareil OpenDisplay.",
+          "name": "Appareil"
+        },
+        "mime_type": {
+          "description": "Le type MIME du contenu. S'applique uniquement aux enregistrements MIME ; par défaut text/vcard.",
+          "name": "Type MIME"
+        },
+        "record_type": {
+          "description": "Le type d'enregistrement NDEF à écrire. L'étiquette Home Assistant écrit une URL d'étiquette Home Assistant ; la lecture avec l'application compagnon déclenche tag_scanned et enregistre automatiquement l'étiquette lors du premier scan.",
+          "name": "Type d'enregistrement"
+        }
+      },
+      "name": "Écrire une étiquette NFC"
+    }
+  }
+}

--- a/custom_components/opendisplay/translations/it.json
+++ b/custom_components/opendisplay/translations/it.json
@@ -1,0 +1,429 @@
+{
+  "config": {
+    "abort": {
+      "already_configured": "Dispositivo già configurato",
+      "already_in_progress": "Flusso di configurazione già in corso",
+      "cannot_connect": "Connessione fallita",
+      "no_devices_found": "Nessun dispositivo trovato sulla rete",
+      "reauth_successful": "Ri-autenticazione riuscita",
+      "unknown": "Errore imprevisto"
+    },
+    "error": {
+      "cannot_connect": "Connessione fallita",
+      "invalid_auth": "Autenticazione non valida",
+      "invalid_key_format": "La chiave di crittografia deve essere esattamente di 32 caratteri esadecimali (0-9, a-f).",
+      "unknown": "Errore imprevisto"
+    },
+    "flow_title": "{name}",
+    "step": {
+      "bluetooth_confirm": {
+        "description": "Configurare {name}?"
+      },
+      "encryption_key": {
+        "data": {
+          "encryption_key": "Chiave di crittografia"
+        },
+        "data_description": {
+          "encryption_key": "Inserire la chiave di crittografia AES-128 esadecimale di 32 caratteri per questo dispositivo."
+        },
+        "description": "{name} richiede una chiave di crittografia per connettersi.",
+        "title": "Crittografia richiesta"
+      },
+      "reauth_confirm": {
+        "data": {
+          "encryption_key": "Chiave di crittografia"
+        },
+        "data_description": {
+          "encryption_key": "Inserire la chiave di crittografia AES-128 esadecimale di 32 caratteri per questo dispositivo."
+        },
+        "description": "Autenticazione fallita per {name}. Inserire la chiave di crittografia corretta o lasciare vuoto se la crittografia è stata disabilitata sul dispositivo.",
+        "title": "Ri-autenticazione richiesta"
+      },
+      "user": {
+        "data": {
+          "address": "Dispositivo"
+        },
+        "data_description": {
+          "address": "Selezionare il dispositivo Bluetooth da configurare."
+        },
+        "description": "Scegliere un dispositivo da configurare"
+      }
+    }
+  },
+  "entity": {
+    "binary_sensor": {
+      "update_pending": {
+        "name": "Aggiornamento in sospeso"
+      }
+    },
+    "event": {
+      "button": {
+        "name": "Pulsante {number}",
+        "state_attributes": {
+          "event_type": {
+            "state": {
+              "button_down": "Pulsante premuto",
+              "button_up": "Pulsante rilasciato"
+            }
+          }
+        }
+      },
+      "touch": {
+        "name": "Tocco {number}",
+        "state_attributes": {
+          "event_type": {
+            "state": {
+              "touch_down": "Tocco iniziato",
+              "touch_move": "Tocco in movimento",
+              "touch_up": "Tocco terminato"
+            }
+          }
+        }
+      }
+    },
+    "image": {
+      "content": {
+        "name": "Contenuto display"
+      }
+    },
+    "sensor": {
+      "battery_voltage": {
+        "name": "Tensione batteria"
+      },
+      "last_seen": {
+        "name": "Ultimo rilevamento"
+      },
+      "rssi": {
+        "name": "Intensità segnale (RSSI)"
+      }
+    },
+    "update": {
+      "firmware": {
+        "name": "Firmware"
+      }
+    }
+  },
+  "exceptions": {
+    "authentication_error": {
+      "message": "Autenticazione fallita. Aggiornare la chiave di crittografia."
+    },
+    "device_not_found": {
+      "message": "Impossibile trovare il dispositivo Bluetooth con indirizzo `{address}`."
+    },
+    "device_sleeping": {
+      "message": "Il dispositivo `{device_id}` è in stato di sospensione e non può essere raggiunto immediatamente. Riattivarlo e riprovare."
+    },
+    "device_sleeping_ota": {
+      "message": "Il dispositivo è in stato di sospensione e non può essere aggiornato ora. Riattivarlo (premere il pulsante o attendere il prossimo check-in programmato) e avviare nuovamente l'aggiornamento."
+    },
+    "invalid_device_id": {
+      "message": "Il dispositivo `{device_id}` non è un dispositivo OpenDisplay valido."
+    },
+    "media_download_error": {
+      "message": "Download del media fallito: {error}"
+    },
+    "mime_type_not_applicable": {
+      "message": "Il campo mime_type si applica solo ai record MIME. Impostare record_type su mime o omettere mime_type."
+    },
+    "multiple_errors": {
+      "message": "Si sono verificati errori per uno o più dispositivi:\n{errors}"
+    },
+    "nfc_content_empty": {
+      "message": "Il contenuto NFC non può essere vuoto."
+    },
+    "nfc_content_too_long": {
+      "message": "Il contenuto NFC è troppo grande ({size} byte). Il massimo è {max} byte."
+    },
+    "nfc_mime_type_invalid": {
+      "message": "Il tipo MIME `{mime_type}` non è valido. Deve essere da 1 a 255 byte codificati in UTF-8."
+    },
+    "nfc_not_supported": {
+      "message": "Il dispositivo `{device_id}` non ha risposto alla scrittura NFC. Il firmware potrebbe non supportare la scrittura di tag NFC; provare ad aggiornare all'ultimo firmware."
+    },
+    "nfc_write_failed": {
+      "message": "Scrittura del tag NFC fallita: {error}"
+    },
+    "no_buzzers": {
+      "message": "Il dispositivo `{device_id}` non ha un buzzer configurato."
+    },
+    "no_leds": {
+      "message": "Il dispositivo `{device_id}` non ha LED configurati."
+    },
+    "no_nfc": {
+      "message": "Il dispositivo `{device_id}` non ha un chip NFC configurato."
+    },
+    "no_targets_specified": {
+      "message": "Nessun dispositivo target specificato."
+    },
+    "upload_error": {
+      "message": "Caricamento sul display fallito: {error}"
+    },
+    "url_not_allowed": {
+      "message": "L'URL `{url}` non è consentito. Aggiungerlo a `allowlist_external_urls` in configuration.yaml."
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "data": {
+          "blocks_per_ack": "Blocchi inviati per ogni conferma",
+          "max_queue_size": "Numero massimo di frame di upload in volo",
+          "missed_cycles": "Cicli di risveglio mancati prima di considerare non disponibile",
+          "probe_before_queue": "Provare a connettersi prima di mettere in coda",
+          "queue_timeout_hours": "Timeout contenuto in coda (ore)",
+          "sleep_mode": "Gestione deep sleep"
+        },
+        "data_description": {
+          "blocks_per_ack": "Numero di frame immagine che il dispositivo riceve prima di inviare una conferma durante un upload veloce (sliding-window). Valori più alti riducono i round trip; il valore effettivo è limitato dal dispositivo e dal massimo numero di frame in volo.",
+          "max_queue_size": "Numero massimo di frame immagine mantenuti in volo contemporaneamente durante un upload veloce (sliding-window). Valori più alti aumentano la velocità su connessioni lente (proxy). Impostare a 1 per disabilitare il trasferimento veloce e usare il caricamento classico frame per frame.",
+          "missed_cycles": "Numero di risvegli attesi che il dispositivo può mancare prima che le sue entità vengano marcate come non disponibili.",
+          "probe_before_queue": "Prima di mettere in coda un'immagine per un dispositivo in sospensione, effettuare un tentativo rapido di connessione nel caso sia effettivamente sveglio (advertisement mancati, radio sempre attive). Aggiunge al massimo pochi secondi se il dispositivo è davvero in sospensione.",
+          "queue_timeout_hours": "Durata massima in ore per cui il contenuto in coda per un dispositivo in sospensione attende un risveglio prima di scadere.",
+          "sleep_mode": "Automatico segue la configurazione energetica del dispositivo (alimentazione a batteria con deep sleep abilitato). Forzare acceso o spento per sovrascrivere."
+        }
+      }
+    }
+  },
+  "selector": {
+    "dither_mode": {
+      "options": {
+        "atkinson": "Atkinson",
+        "burkes": "Burkes",
+        "floyd_steinberg": "Floyd-Steinberg",
+        "jarvis_judice_ninke": "Jarvis, Judice & Ninke",
+        "none": "Nessuno",
+        "ordered": "Ordinato",
+        "sierra": "Sierra",
+        "sierra_lite": "Sierra Lite",
+        "stucki": "Stucki"
+      }
+    },
+    "fit_mode": {
+      "options": {
+        "contain": "Contenere",
+        "cover": "Copertura",
+        "crop": "Ritaglia",
+        "stretch": "Allunga"
+      }
+    },
+    "nfc_record_type": {
+      "options": {
+        "ha_tag": "Tag Home Assistant",
+        "mime": "Dati MIME (es. vCard)",
+        "text": "Testo",
+        "url": "URL"
+      }
+    },
+    "refresh_mode": {
+      "options": {
+        "fast": "Veloce",
+        "full": "Completo",
+        "partial": "Parziale"
+      }
+    },
+    "sleep_mode": {
+      "options": {
+        "auto": "Automatico (segui dispositivo)",
+        "off": "Forza disattivazione",
+        "on": "Forza attivazione"
+      }
+    }
+  },
+  "services": {
+    "activate_buzzer": {
+      "description": "Attiva un tono buzzer su un dispositivo OpenDisplay.",
+      "fields": {
+        "device_id": {
+          "description": "Il dispositivo OpenDisplay.",
+          "name": "Dispositivo"
+        },
+        "duration_ms": {
+          "description": "Durata del tono in millisecondi (5-1275).",
+          "name": "Durata"
+        },
+        "frequency_hz": {
+          "description": "Frequenza del tono in Hz (0 = silenzio, 400-12000).",
+          "name": "Frequenza"
+        },
+        "instance": {
+          "description": "Indice dell'istanza buzzer (base zero).",
+          "name": "Istanza buzzer"
+        },
+        "repeats": {
+          "description": "Numero di ripetizioni del tono (1-255).",
+          "name": "Ripetizioni"
+        }
+      },
+      "name": "Attiva buzzer"
+    },
+    "activate_led": {
+      "description": "Attiva un pattern di lampeggio LED su un dispositivo OpenDisplay.",
+      "fields": {
+        "brightness": {
+          "description": "Luminosità LED (1-16).",
+          "name": "Luminosità"
+        },
+        "color1": {
+          "description": "Colore del primo step.",
+          "name": "Colore 1"
+        },
+        "color2": {
+          "description": "Colore del secondo step (omettere o impostare conteggio lampeggi a 0 per saltare).",
+          "name": "Colore 2"
+        },
+        "color3": {
+          "description": "Colore del terzo step (omettere o impostare conteggio lampeggi a 0 per saltare).",
+          "name": "Colore 3"
+        },
+        "device_id": {
+          "description": "Il dispositivo OpenDisplay.",
+          "name": "Dispositivo"
+        },
+        "flash_count1": {
+          "description": "Numero di lampeggi per il primo step (0 per saltare).",
+          "name": "Conteggio lampeggi 1"
+        },
+        "flash_count2": {
+          "description": "Numero di lampeggi per il secondo step (0 per saltare).",
+          "name": "Conteggio lampeggi 2"
+        },
+        "flash_count3": {
+          "description": "Numero di lampeggi per il terzo step (0 per saltare).",
+          "name": "Conteggio lampeggi 3"
+        },
+        "instance": {
+          "description": "Indice dell'istanza LED (base zero).",
+          "name": "Istanza LED"
+        },
+        "inter_delay1": {
+          "description": "Ritardo dopo il primo step prima del successivo.",
+          "name": "Ritardo step 1"
+        },
+        "inter_delay2": {
+          "description": "Ritardo dopo il secondo step prima del successivo.",
+          "name": "Ritardo step 2"
+        },
+        "inter_delay3": {
+          "description": "Ritardo dopo il terzo step prima della ripetizione.",
+          "name": "Ritardo step 3"
+        },
+        "loop_delay1": {
+          "description": "Ritardo tra lampeggi nel primo step.",
+          "name": "Ritardo lampeggio 1"
+        },
+        "loop_delay2": {
+          "description": "Ritardo tra lampeggi nel secondo step.",
+          "name": "Ritardo lampeggio 2"
+        },
+        "loop_delay3": {
+          "description": "Ritardo tra lampeggi nel terzo step.",
+          "name": "Ritardo lampeggio 3"
+        },
+        "repeats": {
+          "description": "Numero di ripetizioni del pattern completo (0 = infinito).",
+          "name": "Ripetizioni"
+        }
+      },
+      "name": "Attiva LED"
+    },
+    "drawcustom": {
+      "description": "Disegna un'immagine personalizzata su uno o più dispositivi OpenDisplay.",
+      "fields": {
+        "background": {
+          "description": "Colore di sfondo.",
+          "name": "Colore sfondo"
+        },
+        "dither": {
+          "description": "Algoritmo di dithering per la conversione della tavolozza colori.",
+          "name": "Modalità dithering"
+        },
+        "dry-run": {
+          "description": "Genera l'immagine senza caricarla sul dispositivo.",
+          "name": "Simulazione"
+        },
+        "measured_palette": {
+          "description": "Usa la tavolozza colori misurata del pannello se disponibile. Disattivare per ditherizzare contro lo schema teorico. Nessun effetto su pannelli senza dati misurati.",
+          "name": "Usa tavolozza misurata"
+        },
+        "payload": {
+          "description": "Array di elementi da disegnare.",
+          "name": "Payload"
+        },
+        "refresh_type": {
+          "description": "Modalità di aggiornamento del display. L'aggiornamento parziale modifica solo la regione cambiata senza lampeggi; si ricorre automaticamente a un aggiornamento completo se non possibile.",
+          "name": "Tipo di aggiornamento"
+        },
+        "rotate": {
+          "description": "Rotazione in senso orario in gradi.",
+          "name": "Rotazione"
+        }
+      },
+      "name": "Disegna immagine personalizzata"
+    },
+    "upload_image": {
+      "description": "Carica un'immagine su un dispositivo OpenDisplay.",
+      "fields": {
+        "device_id": {
+          "description": "Il dispositivo OpenDisplay su cui caricare l'immagine.",
+          "name": "Dispositivo"
+        },
+        "dither_mode": {
+          "description": "Algoritmo di dithering da usare per convertire l'immagine nella tavolozza colori del display.",
+          "name": "Modalità dithering"
+        },
+        "fit_mode": {
+          "description": "Come adattare l'immagine alle dimensioni del display.",
+          "name": "Modalità adattamento"
+        },
+        "image": {
+          "description": "L'immagine da caricare sul display. Selezionare un elemento multimediale o fornire un URL diretto dell'immagine (l'URL deve essere aggiunto a allowlist_external_urls).",
+          "name": "Immagine"
+        },
+        "measured_palette": {
+          "description": "Usare la tavolozza colori misurata del pannello quando disponibile. Disattivare per applicare dithering sullo schema colori teorico. Nessun effetto sui pannelli senza dati misurati.",
+          "name": "Usa tavolozza misurata"
+        },
+        "refresh_mode": {
+          "description": "Modalità di aggiornamento del display. L'aggiornamento completo elimina il ghosting ma è più lento. L'aggiornamento rapido non è supportato da tutti i display. L'aggiornamento parziale modifica solo la regione cambiata senza lampeggiamenti (pannelli B/N con supporto parziale; torna automaticamente all'aggiornamento completo se non possibile).",
+          "name": "Modalità aggiornamento"
+        },
+        "rotation": {
+          "description": "Angolo di rotazione in gradi, applicato in senso orario.",
+          "name": "Rotazione"
+        },
+        "tone_compression": {
+          "description": "Intensità della compressione della gamma dinamica. Lasciare vuoto per automatico.",
+          "name": "Compressione tono"
+        }
+      },
+      "name": "Carica immagine",
+      "sections": {
+        "additional_fields": {
+          "name": "Opzioni aggiuntive"
+        }
+      }
+    },
+    "write_nfc": {
+      "description": "Scrive un record NDEF (URL, testo o dati MIME come una vCard) nel chip NFC di un dispositivo OpenDisplay.",
+      "fields": {
+        "content": {
+          "description": "I dati da scrivere. Per un record URL, l'URL; per un record testo, il testo; per un record MIME, i dati grezzi; per un tag Home Assistant, l'id del tag. Limitato a 512 byte in codifica UTF-8.",
+          "name": "Contenuto"
+        },
+        "device_id": {
+          "description": "Il dispositivo OpenDisplay.",
+          "name": "Dispositivo"
+        },
+        "mime_type": {
+          "description": "Il tipo MIME del contenuto. Si applica solo ai record MIME; predefinito text/vcard.",
+          "name": "Tipo MIME"
+        },
+        "record_type": {
+          "description": "Il tipo di record NDEF da scrivere. Il tag Home Assistant scrive un URL tag Home Assistant; la scansione con l'app companion attiva tag_scanned e registra automaticamente il tag alla prima scansione.",
+          "name": "Tipo record"
+        }
+      },
+      "name": "Scrivi tag NFC"
+    }
+  }
+}

--- a/custom_components/opendisplay/translations/nl.json
+++ b/custom_components/opendisplay/translations/nl.json
@@ -1,0 +1,429 @@
+{
+  "config": {
+    "abort": {
+      "already_configured": "Apparaat is al geconfigureerd",
+      "already_in_progress": "Configuratiestroom is al bezig",
+      "cannot_connect": "Verbinding mislukt",
+      "no_devices_found": "Geen apparaten gevonden op het netwerk",
+      "reauth_successful": "Her-authenticatie was succesvol",
+      "unknown": "Onverwachte fout"
+    },
+    "error": {
+      "cannot_connect": "Verbinding mislukt",
+      "invalid_auth": "Ongeldige authenticatie",
+      "invalid_key_format": "De encryptiesleutel moet precies 32 hexadecimale tekens bevatten (0-9, a-f).",
+      "unknown": "Onverwachte fout"
+    },
+    "flow_title": "{name}",
+    "step": {
+      "bluetooth_confirm": {
+        "description": "OpenDisplay {name} instellen?"
+      },
+      "encryption_key": {
+        "data": {
+          "encryption_key": "Encryptiesleutel"
+        },
+        "data_description": {
+          "encryption_key": "Voer de 32-teken hexadecimale AES-128 encryptiesleutel in voor dit apparaat."
+        },
+        "description": "{name} vereist een encryptiesleutel om verbinding te maken.",
+        "title": "Encryptie vereist"
+      },
+      "reauth_confirm": {
+        "data": {
+          "encryption_key": "Encryptiesleutel"
+        },
+        "data_description": {
+          "encryption_key": "Voer de 32-teken hexadecimale AES-128 encryptiesleutel in voor dit apparaat."
+        },
+        "description": "Authenticatie mislukt voor {name}. Voer de juiste encryptiesleutel in, of laat leeg als encryptie op het apparaat is uitgeschakeld.",
+        "title": "Her-authenticatie vereist"
+      },
+      "user": {
+        "data": {
+          "address": "Apparaat"
+        },
+        "data_description": {
+          "address": "Selecteer het Bluetooth-apparaat om in te stellen."
+        },
+        "description": "Kies een apparaat om in te stellen"
+      }
+    }
+  },
+  "entity": {
+    "binary_sensor": {
+      "update_pending": {
+        "name": "Update in afwachting"
+      }
+    },
+    "event": {
+      "button": {
+        "name": "Knop {number}",
+        "state_attributes": {
+          "event_type": {
+            "state": {
+              "button_down": "Knop ingedrukt",
+              "button_up": "Knop losgelaten"
+            }
+          }
+        }
+      },
+      "touch": {
+        "name": "Aanraking {number}",
+        "state_attributes": {
+          "event_type": {
+            "state": {
+              "touch_down": "Aanraking gestart",
+              "touch_move": "Aanraking verplaatst",
+              "touch_up": "Aanraking beëindigd"
+            }
+          }
+        }
+      }
+    },
+    "image": {
+      "content": {
+        "name": "Display-inhoud"
+      }
+    },
+    "sensor": {
+      "battery_voltage": {
+        "name": "Batterijspanning"
+      },
+      "last_seen": {
+        "name": "Laatst gezien"
+      },
+      "rssi": {
+        "name": "Signaalsterkte (RSSI)"
+      }
+    },
+    "update": {
+      "firmware": {
+        "name": "Firmware"
+      }
+    }
+  },
+  "exceptions": {
+    "authentication_error": {
+      "message": "Authenticatie mislukt. Update de encryptiesleutel."
+    },
+    "device_not_found": {
+      "message": "Bluetooth-apparaat met adres `{address}` niet gevonden."
+    },
+    "device_sleeping": {
+      "message": "Apparaat `{device_id}` slaapt en is niet direct bereikbaar. Wek het en probeer opnieuw."
+    },
+    "device_sleeping_ota": {
+      "message": "Het apparaat slaapt en kan nu niet worden bijgewerkt. Wek het (druk op de knop of wacht op de volgende geplande check-in) en start de update opnieuw."
+    },
+    "invalid_device_id": {
+      "message": "Apparaat `{device_id}` is geen geldig OpenDisplay-apparaat."
+    },
+    "media_download_error": {
+      "message": "Media downloaden mislukt: {error}"
+    },
+    "mime_type_not_applicable": {
+      "message": "Het veld mime_type is alleen van toepassing op MIME-records. Stel record_type in op mime, of laat mime_type weg."
+    },
+    "multiple_errors": {
+      "message": "Fouten opgetreden voor een of meer apparaten:\n{errors}"
+    },
+    "nfc_content_empty": {
+      "message": "NFC-inhoud mag niet leeg zijn."
+    },
+    "nfc_content_too_long": {
+      "message": "NFC-inhoud is te groot ({size} bytes). Maximaal is {max} bytes."
+    },
+    "nfc_mime_type_invalid": {
+      "message": "MIME-type `{mime_type}` is ongeldig. Het moet 1-255 bytes zijn bij UTF-8 codering."
+    },
+    "nfc_not_supported": {
+      "message": "Apparaat `{device_id}` reageerde niet op het schrijven van NFC. De firmware ondersteunt mogelijk geen NFC-tags schrijven; probeer te updaten naar de nieuwste firmware."
+    },
+    "nfc_write_failed": {
+      "message": "Schrijven van de NFC-tag mislukt: {error}"
+    },
+    "no_buzzers": {
+      "message": "Apparaat `{device_id}` heeft geen buzzer geconfigureerd."
+    },
+    "no_leds": {
+      "message": "Apparaat `{device_id}` heeft geen LEDs geconfigureerd."
+    },
+    "no_nfc": {
+      "message": "Apparaat `{device_id}` heeft geen NFC-chip geconfigureerd."
+    },
+    "no_targets_specified": {
+      "message": "Geen doelapparaten opgegeven."
+    },
+    "upload_error": {
+      "message": "Uploaden naar het display mislukt: {error}"
+    },
+    "url_not_allowed": {
+      "message": "URL `{url}` is niet toegestaan. Voeg deze toe aan `allowlist_external_urls` in configuration.yaml."
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "data": {
+          "blocks_per_ack": "Blokken verzonden per bevestiging",
+          "max_queue_size": "Maximaal aantal uploadframes in behandeling",
+          "missed_cycles": "Gemiste wake-cycli voordat onbeschikbaar",
+          "probe_before_queue": "Proberen te verbinden vóór in de wachtrij plaatsen",
+          "queue_timeout_hours": "Timeout voor wachtrij-inhoud (uren)",
+          "sleep_mode": "Diepe slaap afhandeling"
+        },
+        "data_description": {
+          "blocks_per_ack": "Aantal beeldframes dat het apparaat ontvangt voordat het één bevestiging stuurt tijdens een snelle (sliding-window) upload. Hogere waarden verminderen rondreizen; de effectieve waarde wordt begrensd door het apparaat en het maximum aantal frames in behandeling.",
+          "max_queue_size": "Maximaal aantal beeldframes dat tegelijk in behandeling wordt gehouden tijdens een snelle (sliding-window) upload. Hogere waarden verhogen de doorvoer op trage (proxy) verbindingen. Instellen op 1 schakelt snelle overdracht uit en gebruikt de klassieke upload één frame per keer.",
+          "missed_cycles": "Hoeveel verwachte wake-ups het apparaat mag missen voordat zijn entiteiten als onbeschikbaar worden gemarkeerd.",
+          "probe_before_queue": "Voor het in de wachtrij plaatsen van een afbeelding voor een slapend apparaat, één snelle verbindingspoging doen voor het geval het toch wakker is (gemiste advertenties, altijd-aan radio's). Voegt maximaal enkele seconden toe als het apparaat echt slaapt.",
+          "queue_timeout_hours": "Hoe lang inhoud in de wachtrij voor een slapend apparaat wacht op een wake voordat het verloopt.",
+          "sleep_mode": "Automatisch volgt de eigen stroomconfiguratie van het apparaat (batterijvoeding met diepe slaap ingeschakeld). Forceren aan of uit om te overschrijven."
+        }
+      }
+    }
+  },
+  "selector": {
+    "dither_mode": {
+      "options": {
+        "atkinson": "Atkinson",
+        "burkes": "Burkes",
+        "floyd_steinberg": "Floyd-Steinberg",
+        "jarvis_judice_ninke": "Jarvis, Judice & Ninke",
+        "none": "Geen",
+        "ordered": "Geordend",
+        "sierra": "Sierra",
+        "sierra_lite": "Sierra Lite",
+        "stucki": "Stucki"
+      }
+    },
+    "fit_mode": {
+      "options": {
+        "contain": "Bevatten",
+        "cover": "Bedekken",
+        "crop": "Bijsnijden",
+        "stretch": "Rekken"
+      }
+    },
+    "nfc_record_type": {
+      "options": {
+        "ha_tag": "Home Assistant-tag",
+        "mime": "MIME-gegevens (bijv. vCard)",
+        "text": "Tekst",
+        "url": "URL"
+      }
+    },
+    "refresh_mode": {
+      "options": {
+        "fast": "Snel",
+        "full": "Volledig",
+        "partial": "Gedeeltelijk"
+      }
+    },
+    "sleep_mode": {
+      "options": {
+        "auto": "Automatisch (volg apparaat)",
+        "off": "Forceer uit",
+        "on": "Forceer aan"
+      }
+    }
+  },
+  "services": {
+    "activate_buzzer": {
+      "description": "Activeert een zoemer op een OpenDisplay-apparaat.",
+      "fields": {
+        "device_id": {
+          "description": "Het OpenDisplay-apparaat.",
+          "name": "Apparaat"
+        },
+        "duration_ms": {
+          "description": "Duur van de toon in milliseconden (5-1275).",
+          "name": "Duur"
+        },
+        "frequency_hz": {
+          "description": "Toonfrequentie in Hz (0 = stilte, 400-12000).",
+          "name": "Frequentie"
+        },
+        "instance": {
+          "description": "Index van de zoemerinstantie (0-gebaseerd).",
+          "name": "Zoemerinstantie"
+        },
+        "repeats": {
+          "description": "Aantal keren om de toon te herhalen (1-255).",
+          "name": "Herhalingen"
+        }
+      },
+      "name": "Zoemer activeren"
+    },
+    "activate_led": {
+      "description": "Activeert een LED-flits patroon op een OpenDisplay-apparaat.",
+      "fields": {
+        "brightness": {
+          "description": "LED-helderheid (1-16).",
+          "name": "Helderheid"
+        },
+        "color1": {
+          "description": "Kleur van de eerste stap.",
+          "name": "Kleur 1"
+        },
+        "color2": {
+          "description": "Kleur van de tweede stap (weglaten of flitsaantal op 0 zetten om over te slaan).",
+          "name": "Kleur 2"
+        },
+        "color3": {
+          "description": "Kleur van de derde stap (weglaten of flitsaantal op 0 zetten om over te slaan).",
+          "name": "Kleur 3"
+        },
+        "device_id": {
+          "description": "Het OpenDisplay-apparaat.",
+          "name": "Apparaat"
+        },
+        "flash_count1": {
+          "description": "Aantal flitsen voor de eerste stap (0 slaat deze stap over).",
+          "name": "Aantal flitsen 1"
+        },
+        "flash_count2": {
+          "description": "Aantal flitsen voor de tweede stap (0 slaat deze stap over).",
+          "name": "Aantal flitsen 2"
+        },
+        "flash_count3": {
+          "description": "Aantal flitsen voor de derde stap (0 slaat deze stap over).",
+          "name": "Aantal flitsen 3"
+        },
+        "instance": {
+          "description": "Index van de LED-instantie (0-gebaseerd).",
+          "name": "LED-instantie"
+        },
+        "inter_delay1": {
+          "description": "Vertraging na de eerste stap voordat de volgende begint.",
+          "name": "Stapvertraging 1"
+        },
+        "inter_delay2": {
+          "description": "Vertraging na de tweede stap voordat de volgende begint.",
+          "name": "Stapvertraging 2"
+        },
+        "inter_delay3": {
+          "description": "Vertraging na de derde stap voordat het patroon herhaalt.",
+          "name": "Stapvertraging 3"
+        },
+        "loop_delay1": {
+          "description": "Vertraging tussen flitsen in de eerste stap.",
+          "name": "Flitsvertraging 1"
+        },
+        "loop_delay2": {
+          "description": "Vertraging tussen flitsen in de tweede stap.",
+          "name": "Flitsvertraging 2"
+        },
+        "loop_delay3": {
+          "description": "Vertraging tussen flitsen in de derde stap.",
+          "name": "Flitsvertraging 3"
+        },
+        "repeats": {
+          "description": "Aantal keren om het volledige patroon te herhalen (0 = oneindig).",
+          "name": "Herhalingen"
+        }
+      },
+      "name": "LED activeren"
+    },
+    "drawcustom": {
+      "description": "Tekent een aangepaste afbeelding op een of meer OpenDisplay-apparaten.",
+      "fields": {
+        "background": {
+          "description": "Achtergrondkleur.",
+          "name": "Achtergrondkleur"
+        },
+        "dither": {
+          "description": "Dithering-algoritme voor kleurpaletconversie.",
+          "name": "Dither-modus"
+        },
+        "dry-run": {
+          "description": "Afbeelding genereren zonder upload naar het apparaat.",
+          "name": "Droge run"
+        },
+        "measured_palette": {
+          "description": "Gebruik het gemeten kleurenpalet van het paneel indien beschikbaar. Uitschakelen om te dither tegen het theoretische kleurenschema. Geen effect op panelen zonder gemeten data.",
+          "name": "Gemeten palet gebruiken"
+        },
+        "payload": {
+          "description": "Array van tekeningelementen.",
+          "name": "Payload"
+        },
+        "refresh_type": {
+          "description": "Weergave vernieuwingsmodus. Gedeeltelijke updates vernieuwen alleen het gewijzigde gebied zonder te flitsen; valt automatisch terug op volledige verversing indien niet mogelijk.",
+          "name": "Vernieuwingsmodus"
+        },
+        "rotate": {
+          "description": "Draaiing met de klok mee in graden.",
+          "name": "Rotatie"
+        }
+      },
+      "name": "Aangepaste afbeelding tekenen"
+    },
+    "upload_image": {
+      "description": "Uploadt een afbeelding naar een OpenDisplay-apparaat.",
+      "fields": {
+        "device_id": {
+          "description": "Het OpenDisplay-apparaat waarnaar de afbeelding wordt geüpload.",
+          "name": "Apparaat"
+        },
+        "dither_mode": {
+          "description": "Het dithering-algoritme voor het converteren van de afbeelding naar het kleurenpalet van het display.",
+          "name": "Dither-modus"
+        },
+        "fit_mode": {
+          "description": "Hoe de afbeelding wordt aangepast aan de afmetingen van het display.",
+          "name": "Aanpassingsmodus"
+        },
+        "image": {
+          "description": "De afbeelding om naar het display te uploaden. Kies een media-item of geef een directe afbeeldings-URL op (de URL moet worden toegevoegd aan allowlist_external_urls).",
+          "name": "Afbeelding"
+        },
+        "measured_palette": {
+          "description": "Gebruik het gemeten kleurenpalet van het paneel indien beschikbaar. Uitschakelen om te dither tegen het theoretische kleurenpalet. Geen effect op panelen zonder gemeten data.",
+          "name": "Gemeten palet gebruiken"
+        },
+        "refresh_mode": {
+          "description": "De verversingsmodus van het display. Volledige verversing verwijdert ghosting maar is trager. Snelle verversing wordt niet door alle displays ondersteund. Gedeeltelijke verversing werkt alleen het veranderde gebied bij zonder te flikkeren (Z/W panelen met gedeeltelijke ondersteuning; valt automatisch terug op volledige verversing als het niet mogelijk is).",
+          "name": "Verversingsmodus"
+        },
+        "rotation": {
+          "description": "De rotatiehoek in graden, met de klok mee toegepast.",
+          "name": "Rotatie"
+        },
+        "tone_compression": {
+          "description": "Sterkte van dynamische bereikcompressie. Leeg laten voor automatisch.",
+          "name": "Tooncompressie"
+        }
+      },
+      "name": "Afbeelding uploaden",
+      "sections": {
+        "additional_fields": {
+          "name": "Aanvullende opties"
+        }
+      }
+    },
+    "write_nfc": {
+      "description": "Schrijft een NDEF-record (URL, tekst of MIME-data zoals een vCard) naar de NFC-chip van een OpenDisplay-apparaat.",
+      "fields": {
+        "content": {
+          "description": "De te schrijven data. Voor een URL-record de URL; voor een tekstrecord de tekst; voor een MIME-record de ruwe data; voor een Home Assistant-tag de tag-id. Beperkt tot 512 bytes bij UTF-8 codering.",
+          "name": "Inhoud"
+        },
+        "device_id": {
+          "description": "Het OpenDisplay-apparaat.",
+          "name": "Apparaat"
+        },
+        "mime_type": {
+          "description": "Het MIME-type van de inhoud. Geldt alleen voor MIME-records; standaard text/vcard.",
+          "name": "MIME-type"
+        },
+        "record_type": {
+          "description": "Het type NDEF-record om te schrijven. Home Assistant-tag schrijft een Home Assistant-tag URL; scannen met de companion app activeert tag_scanned en registreert de tag automatisch bij de eerste scan.",
+          "name": "Recordtype"
+        }
+      },
+      "name": "NFC-tag schrijven"
+    }
+  }
+}

--- a/custom_components/opendisplay/translations/pl.json
+++ b/custom_components/opendisplay/translations/pl.json
@@ -1,0 +1,429 @@
+{
+  "config": {
+    "abort": {
+      "already_configured": "Urządzenie jest już skonfigurowane",
+      "already_in_progress": "Proces konfiguracji jest już w toku",
+      "cannot_connect": "Nie udało się połączyć",
+      "no_devices_found": "Nie znaleziono urządzeń w sieci",
+      "reauth_successful": "Ponowna autoryzacja zakończona sukcesem",
+      "unknown": "Nieoczekiwany błąd"
+    },
+    "error": {
+      "cannot_connect": "Nie udało się połączyć",
+      "invalid_auth": "Nieprawidłowa autoryzacja",
+      "invalid_key_format": "Klucz szyfrowania musi mieć dokładnie 32 znaki szesnastkowe (0-9, a-f).",
+      "unknown": "Nieoczekiwany błąd"
+    },
+    "flow_title": "{name}",
+    "step": {
+      "bluetooth_confirm": {
+        "description": "Skonfigurować {name}?"
+      },
+      "encryption_key": {
+        "data": {
+          "encryption_key": "Klucz szyfrowania"
+        },
+        "data_description": {
+          "encryption_key": "Wprowadź 32-znakowy szesnastkowy klucz szyfrowania AES-128 dla tego urządzenia."
+        },
+        "description": "{name} wymaga klucza szyfrowania do połączenia.",
+        "title": "Wymagane szyfrowanie"
+      },
+      "reauth_confirm": {
+        "data": {
+          "encryption_key": "Klucz szyfrowania"
+        },
+        "data_description": {
+          "encryption_key": "Wprowadź 32-znakowy szesnastkowy klucz szyfrowania AES-128 dla tego urządzenia."
+        },
+        "description": "Autoryzacja nie powiodła się dla {name}. Wprowadź poprawny klucz szyfrowania lub pozostaw puste, jeśli szyfrowanie zostało wyłączone na urządzeniu.",
+        "title": "Wymagana ponowna autoryzacja"
+      },
+      "user": {
+        "data": {
+          "address": "Urządzenie"
+        },
+        "data_description": {
+          "address": "Wybierz urządzenie Bluetooth do konfiguracji."
+        },
+        "description": "Wybierz urządzenie do konfiguracji"
+      }
+    }
+  },
+  "entity": {
+    "binary_sensor": {
+      "update_pending": {
+        "name": "Aktualizacja oczekuje"
+      }
+    },
+    "event": {
+      "button": {
+        "name": "Przycisk {number}",
+        "state_attributes": {
+          "event_type": {
+            "state": {
+              "button_down": "Przycisk wciśnięty",
+              "button_up": "Przycisk zwolniony"
+            }
+          }
+        }
+      },
+      "touch": {
+        "name": "Dotyk {number}",
+        "state_attributes": {
+          "event_type": {
+            "state": {
+              "touch_down": "Dotyk rozpoczęty",
+              "touch_move": "Dotyk przesunięty",
+              "touch_up": "Dotyk zakończony"
+            }
+          }
+        }
+      }
+    },
+    "image": {
+      "content": {
+        "name": "Zawartość wyświetlacza"
+      }
+    },
+    "sensor": {
+      "battery_voltage": {
+        "name": "Napięcie baterii"
+      },
+      "last_seen": {
+        "name": "Ostatnio widziany"
+      },
+      "rssi": {
+        "name": "Siła sygnału (RSSI)"
+      }
+    },
+    "update": {
+      "firmware": {
+        "name": "Oprogramowanie układowe"
+      }
+    }
+  },
+  "exceptions": {
+    "authentication_error": {
+      "message": "Autoryzacja nie powiodła się. Zaktualizuj klucz szyfrowania."
+    },
+    "device_not_found": {
+      "message": "Nie znaleziono urządzenia Bluetooth o adresie `{address}`."
+    },
+    "device_sleeping": {
+      "message": "Urządzenie `{device_id}` jest uśpione i nie można się z nim od razu połączyć. Obudź je i spróbuj ponownie."
+    },
+    "device_sleeping_ota": {
+      "message": "Urządzenie jest uśpione i nie można go teraz zaktualizować. Obudź je (naciśnij przycisk lub poczekaj na kolejne zaplanowane sprawdzenie) i rozpocznij aktualizację ponownie."
+    },
+    "invalid_device_id": {
+      "message": "Urządzenie `{device_id}` nie jest prawidłowym urządzeniem OpenDisplay."
+    },
+    "media_download_error": {
+      "message": "Nie udało się pobrać mediów: {error}"
+    },
+    "mime_type_not_applicable": {
+      "message": "Pole mime_type dotyczy tylko rekordów MIME. Ustaw record_type na mime lub pomiń mime_type."
+    },
+    "multiple_errors": {
+      "message": "Wystąpiły błędy dla jednego lub więcej urządzeń:\n{errors}"
+    },
+    "nfc_content_empty": {
+      "message": "Zawartość NFC nie może być pusta."
+    },
+    "nfc_content_too_long": {
+      "message": "Zawartość NFC jest zbyt duża ({size} bajtów). Maksymalna wielkość to {max} bajtów."
+    },
+    "nfc_mime_type_invalid": {
+      "message": "Typ MIME `{mime_type}` jest nieprawidłowy. Musi mieć 1-255 bajtów po zakodowaniu w UTF-8."
+    },
+    "nfc_not_supported": {
+      "message": "Urządzenie `{device_id}` nie odpowiedziało na zapis NFC. Jego oprogramowanie może nie obsługiwać zapisu tagów NFC; spróbuj zaktualizować do najnowszej wersji."
+    },
+    "nfc_write_failed": {
+      "message": "Nie udało się zapisać tagu NFC: {error}"
+    },
+    "no_buzzers": {
+      "message": "Urządzenie `{device_id}` nie ma skonfigurowanego buzzera."
+    },
+    "no_leds": {
+      "message": "Urządzenie `{device_id}` nie ma skonfigurowanych diod LED."
+    },
+    "no_nfc": {
+      "message": "Urządzenie `{device_id}` nie ma skonfigurowanego układu NFC."
+    },
+    "no_targets_specified": {
+      "message": "Nie określono docelowych urządzeń."
+    },
+    "upload_error": {
+      "message": "Nie udało się przesłać na wyświetlacz: {error}"
+    },
+    "url_not_allowed": {
+      "message": "URL `{url}` nie jest dozwolony. Dodaj go do `allowlist_external_urls` w configuration.yaml."
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "data": {
+          "blocks_per_ack": "Bloki wysyłane na jedno potwierdzenie",
+          "max_queue_size": "Maksymalna liczba ramek przesyłanych jednocześnie",
+          "missed_cycles": "Przegapione cykle wybudzania przed oznaczeniem jako niedostępne",
+          "probe_before_queue": "Spróbuj połączyć się przed dodaniem do kolejki",
+          "queue_timeout_hours": "Limit czasu oczekiwania zawartości w kolejce (godziny)",
+          "sleep_mode": "Obsługa głębokiego uśpienia"
+        },
+        "data_description": {
+          "blocks_per_ack": "Ile ramek obrazu urządzenie otrzymuje przed wysłaniem jednego potwierdzenia podczas szybkiego przesyłania (sliding-window). Wyższe wartości zmniejszają liczbę rund; wartość efektywna jest ograniczona przez urządzenie i maksymalną liczbę ramek w locie.",
+          "max_queue_size": "Maksymalna liczba ramek obrazu utrzymywanych jednocześnie podczas szybkiego przesyłania (sliding-window). Wyższe wartości zwiększają przepustowość na wolnych (proxy) łączach. Ustaw na 1, aby wyłączyć szybki transfer i użyć klasycznego przesyłania po jednej ramce.",
+          "missed_cycles": "Ile oczekiwanych wybudzeń urządzenie może przegapić, zanim jego encje zostaną oznaczone jako niedostępne.",
+          "probe_before_queue": "Przed dodaniem obrazu do kolejki dla uśpionego urządzenia wykonaj jedną szybką próbę połączenia, na wypadek gdyby było faktycznie aktywne (przegapione reklamy, zawsze włączone radio). Dodaje maksymalnie kilka sekund, gdy urządzenie jest naprawdę uśpione.",
+          "queue_timeout_hours": "Jak długo zawartość oczekująca w kolejce dla uśpionego urządzenia czeka na wybudzenie, zanim wygaśnie.",
+          "sleep_mode": "Automatyczne podąża za własną konfiguracją zasilania urządzenia (zasilanie bateryjne z włączonym głębokim uśpieniem). Wymuś włączone lub wyłączone, aby nadpisać."
+        }
+      }
+    }
+  },
+  "selector": {
+    "dither_mode": {
+      "options": {
+        "atkinson": "Atkinson",
+        "burkes": "Burkes",
+        "floyd_steinberg": "Floyd-Steinberg",
+        "jarvis_judice_ninke": "Jarvis, Judice & Ninke",
+        "none": "Brak",
+        "ordered": "Uporządkowany",
+        "sierra": "Sierra",
+        "sierra_lite": "Sierra Lite",
+        "stucki": "Stucki"
+      }
+    },
+    "fit_mode": {
+      "options": {
+        "contain": "Dopasuj",
+        "cover": "Zakryj",
+        "crop": "Przytnij",
+        "stretch": "Rozciągnij"
+      }
+    },
+    "nfc_record_type": {
+      "options": {
+        "ha_tag": "Tag Home Assistant",
+        "mime": "Dane MIME (np. vCard)",
+        "text": "Tekst",
+        "url": "URL"
+      }
+    },
+    "refresh_mode": {
+      "options": {
+        "fast": "Szybki",
+        "full": "Pełny",
+        "partial": "Częściowy"
+      }
+    },
+    "sleep_mode": {
+      "options": {
+        "auto": "Automatyczny (zgodny z urządzeniem)",
+        "off": "Wymuś wyłączenie",
+        "on": "Wymuś włączenie"
+      }
+    }
+  },
+  "services": {
+    "activate_buzzer": {
+      "description": "Wywołuje dźwięk buzzera na urządzeniu OpenDisplay.",
+      "fields": {
+        "device_id": {
+          "description": "Urządzenie OpenDisplay.",
+          "name": "Urządzenie"
+        },
+        "duration_ms": {
+          "description": "Czas trwania tonu w milisekundach (5-1275).",
+          "name": "Czas trwania"
+        },
+        "frequency_hz": {
+          "description": "Częstotliwość tonu w Hz (0 = cisza, 400-12000).",
+          "name": "Częstotliwość"
+        },
+        "instance": {
+          "description": "Indeks instancji buzzera (liczony od 0).",
+          "name": "Instancja buzzera"
+        },
+        "repeats": {
+          "description": "Liczba powtórzeń tonu (1-255).",
+          "name": "Powtórzenia"
+        }
+      },
+      "name": "Aktywuj buzzer"
+    },
+    "activate_led": {
+      "description": "Wywołuje wzór migania LED na urządzeniu OpenDisplay.",
+      "fields": {
+        "brightness": {
+          "description": "Jasność LED (1-16).",
+          "name": "Jasność"
+        },
+        "color1": {
+          "description": "Kolor pierwszego kroku.",
+          "name": "Kolor 1"
+        },
+        "color2": {
+          "description": "Kolor drugiego kroku (pomiń lub ustaw liczbę błysków na 0, aby pominąć).",
+          "name": "Kolor 2"
+        },
+        "color3": {
+          "description": "Kolor trzeciego kroku (pomiń lub ustaw liczbę błysków na 0, aby pominąć).",
+          "name": "Kolor 3"
+        },
+        "device_id": {
+          "description": "Urządzenie OpenDisplay.",
+          "name": "Urządzenie"
+        },
+        "flash_count1": {
+          "description": "Liczba błysków w pierwszym kroku (0 pomija ten krok).",
+          "name": "Liczba błysków 1"
+        },
+        "flash_count2": {
+          "description": "Liczba błysków w drugim kroku (0 pomija ten krok).",
+          "name": "Liczba błysków 2"
+        },
+        "flash_count3": {
+          "description": "Liczba błysków w trzecim kroku (0 pomija ten krok).",
+          "name": "Liczba błysków 3"
+        },
+        "instance": {
+          "description": "Indeks instancji LED (liczony od 0).",
+          "name": "Instancja LED"
+        },
+        "inter_delay1": {
+          "description": "Opóźnienie po pierwszym kroku przed przejściem do następnego.",
+          "name": "Opóźnienie kroku 1"
+        },
+        "inter_delay2": {
+          "description": "Opóźnienie po drugim kroku przed przejściem do następnego.",
+          "name": "Opóźnienie kroku 2"
+        },
+        "inter_delay3": {
+          "description": "Opóźnienie po trzecim kroku przed powtórzeniem.",
+          "name": "Opóźnienie kroku 3"
+        },
+        "loop_delay1": {
+          "description": "Opóźnienie między błyskami w pierwszym kroku.",
+          "name": "Opóźnienie błysku 1"
+        },
+        "loop_delay2": {
+          "description": "Opóźnienie między błyskami w drugim kroku.",
+          "name": "Opóźnienie błysku 2"
+        },
+        "loop_delay3": {
+          "description": "Opóźnienie między błyskami w trzecim kroku.",
+          "name": "Opóźnienie błysku 3"
+        },
+        "repeats": {
+          "description": "Liczba powtórzeń całego wzoru (0 = nieskończoność).",
+          "name": "Powtórzenia"
+        }
+      },
+      "name": "Aktywuj LED"
+    },
+    "drawcustom": {
+      "description": "Rysuje niestandardowy obraz na jednym lub więcej urządzeniach OpenDisplay.",
+      "fields": {
+        "background": {
+          "description": "Kolor tła.",
+          "name": "Kolor tła"
+        },
+        "dither": {
+          "description": "Algorytm ditheringu do konwersji palety kolorów.",
+          "name": "Tryb ditheringu"
+        },
+        "dry-run": {
+          "description": "Generuj obraz bez przesyłania do urządzenia.",
+          "name": "Symulacja"
+        },
+        "measured_palette": {
+          "description": "Użyj zmierzonej palety kolorów panelu, jeśli dostępna. Wyłącz, aby ditherować względem teoretycznej palety. Brak efektu na panelach bez danych pomiarowych.",
+          "name": "Użyj zmierzonej palety"
+        },
+        "payload": {
+          "description": "Tablica elementów rysunku.",
+          "name": "Dane"
+        },
+        "refresh_type": {
+          "description": "Tryb odświeżania wyświetlacza. Częściowe aktualizacje zmieniają tylko obszar, bez migotania; automatycznie przełącza na pełne odświeżanie, gdy to niemożliwe.",
+          "name": "Typ odświeżania"
+        },
+        "rotate": {
+          "description": "Obrót zgodnie z ruchem wskazówek zegara w stopniach.",
+          "name": "Obrót"
+        }
+      },
+      "name": "Narysuj niestandardowy obraz"
+    },
+    "upload_image": {
+      "description": "Przesyła obraz do urządzenia OpenDisplay.",
+      "fields": {
+        "device_id": {
+          "description": "Urządzenie OpenDisplay, do którego przesłać obraz.",
+          "name": "Urządzenie"
+        },
+        "dither_mode": {
+          "description": "Algorytm ditheringu do konwersji obrazu na paletę kolorów wyświetlacza.",
+          "name": "Tryb ditheringu"
+        },
+        "fit_mode": {
+          "description": "Sposób dopasowania obrazu do wymiarów wyświetlacza.",
+          "name": "Tryb dopasowania"
+        },
+        "image": {
+          "description": "Obraz do przesłania na wyświetlacz. Wybierz element multimedialny lub podaj bezpośredni URL obrazu (URL musi być dodany do allowlist_external_urls).",
+          "name": "Obraz"
+        },
+        "measured_palette": {
+          "description": "Użyć zmierzonej palety kolorów panelu, jeśli dostępna. Wyłącz, aby stosować dithering względem teoretycznej palety kolorów. Brak efektu na panelach bez danych pomiarowych.",
+          "name": "Użyj zmierzonej palety"
+        },
+        "refresh_mode": {
+          "description": "Tryb odświeżania wyświetlacza. Pełne odświeżanie usuwa efekt duchów, ale jest wolniejsze. Szybkie odświeżanie nie jest obsługiwane na wszystkich wyświetlaczach. Częściowe aktualizuje tylko zmieniony obszar bez migotania (panele B/W z częściowym wsparciem; automatycznie przełącza na pełne odświeżanie, gdy nie jest możliwe).",
+          "name": "Tryb odświeżania"
+        },
+        "rotation": {
+          "description": "Kąt obrotu w stopniach, stosowany zgodnie z ruchem wskazówek zegara.",
+          "name": "Obrót"
+        },
+        "tone_compression": {
+          "description": "Siła kompresji zakresu dynamicznego. Pozostawić puste dla automatycznej wartości.",
+          "name": "Kompresja tonów"
+        }
+      },
+      "name": "Prześlij obraz",
+      "sections": {
+        "additional_fields": {
+          "name": "Dodatkowe opcje"
+        }
+      }
+    },
+    "write_nfc": {
+      "description": "Zapisuje rekord NDEF (URL, tekst lub dane MIME, np. vCard) do chipu NFC urządzenia OpenDisplay.",
+      "fields": {
+        "content": {
+          "description": "Dane do zapisania. Dla rekordu URL - adres URL; dla rekordu tekstowego - tekst; dla rekordu MIME - surowe dane; dla tagu Home Assistant - identyfikator tagu. Ograniczone do 512 bajtów po kodowaniu UTF-8.",
+          "name": "Zawartość"
+        },
+        "device_id": {
+          "description": "Urządzenie OpenDisplay.",
+          "name": "Urządzenie"
+        },
+        "mime_type": {
+          "description": "Typ MIME zawartości. Dotyczy tylko rekordów MIME; domyślnie text/vcard.",
+          "name": "Typ MIME"
+        },
+        "record_type": {
+          "description": "Typ rekordu NDEF do zapisu. Tag Home Assistant zapisuje URL tagu Home Assistant; zeskanowanie go w aplikacji towarzyszącej wywołuje tag_scanned i automatycznie rejestruje tag przy pierwszym skanie.",
+          "name": "Typ rekordu"
+        }
+      },
+      "name": "Zapisz tag NFC"
+    }
+  }
+}

--- a/custom_components/opendisplay/translations/pt-BR.json
+++ b/custom_components/opendisplay/translations/pt-BR.json
@@ -1,0 +1,429 @@
+{
+  "config": {
+    "abort": {
+      "already_configured": "Dispositivo já configurado",
+      "already_in_progress": "Fluxo de configuração já em andamento",
+      "cannot_connect": "Falha ao conectar",
+      "no_devices_found": "Nenhum dispositivo encontrado na rede",
+      "reauth_successful": "Reautenticação bem-sucedida",
+      "unknown": "Erro inesperado"
+    },
+    "error": {
+      "cannot_connect": "Falha ao conectar",
+      "invalid_auth": "Autenticação inválida",
+      "invalid_key_format": "A chave de criptografia deve ter exatamente 32 caracteres hexadecimais (0-9, a-f).",
+      "unknown": "Erro inesperado"
+    },
+    "flow_title": "{name}",
+    "step": {
+      "bluetooth_confirm": {
+        "description": "Configurar {name}?"
+      },
+      "encryption_key": {
+        "data": {
+          "encryption_key": "Chave de criptografia"
+        },
+        "data_description": {
+          "encryption_key": "Digite a chave de criptografia AES-128 hexadecimal de 32 caracteres para este dispositivo."
+        },
+        "description": "{name} requer uma chave de criptografia para conectar.",
+        "title": "Criptografia necessária"
+      },
+      "reauth_confirm": {
+        "data": {
+          "encryption_key": "Chave de criptografia"
+        },
+        "data_description": {
+          "encryption_key": "Digite a chave de criptografia AES-128 hexadecimal de 32 caracteres para este dispositivo."
+        },
+        "description": "Falha na autenticação para {name}. Digite a chave de criptografia correta ou deixe em branco se a criptografia foi desativada no dispositivo.",
+        "title": "Reautenticação necessária"
+      },
+      "user": {
+        "data": {
+          "address": "Dispositivo"
+        },
+        "data_description": {
+          "address": "Selecione o dispositivo Bluetooth para configurar."
+        },
+        "description": "Escolher um dispositivo para configurar"
+      }
+    }
+  },
+  "entity": {
+    "binary_sensor": {
+      "update_pending": {
+        "name": "Atualização pendente"
+      }
+    },
+    "event": {
+      "button": {
+        "name": "Botão {number}",
+        "state_attributes": {
+          "event_type": {
+            "state": {
+              "button_down": "Botão pressionado",
+              "button_up": "Botão solto"
+            }
+          }
+        }
+      },
+      "touch": {
+        "name": "Toque {number}",
+        "state_attributes": {
+          "event_type": {
+            "state": {
+              "touch_down": "Toque iniciado",
+              "touch_move": "Toque movendo",
+              "touch_up": "Toque finalizado"
+            }
+          }
+        }
+      }
+    },
+    "image": {
+      "content": {
+        "name": "Conteúdo do display"
+      }
+    },
+    "sensor": {
+      "battery_voltage": {
+        "name": "Voltagem da bateria"
+      },
+      "last_seen": {
+        "name": "Última vez visto"
+      },
+      "rssi": {
+        "name": "Intensidade do sinal (RSSI)"
+      }
+    },
+    "update": {
+      "firmware": {
+        "name": "Firmware"
+      }
+    }
+  },
+  "exceptions": {
+    "authentication_error": {
+      "message": "Falha na autenticação. Atualize a chave de criptografia."
+    },
+    "device_not_found": {
+      "message": "Não foi possível encontrar o dispositivo Bluetooth com o endereço `{address}`."
+    },
+    "device_sleeping": {
+      "message": "O dispositivo `{device_id}` está em modo de espera e não pode ser acessado imediatamente. Desperte-o e tente novamente."
+    },
+    "device_sleeping_ota": {
+      "message": "O dispositivo está em modo de espera e não pode ser atualizado agora. Desperte-o (pressione seu botão ou aguarde a próxima verificação agendada) e inicie a atualização novamente."
+    },
+    "invalid_device_id": {
+      "message": "O dispositivo `{device_id}` não é um dispositivo OpenDisplay válido."
+    },
+    "media_download_error": {
+      "message": "Falha ao baixar mídia: {error}"
+    },
+    "mime_type_not_applicable": {
+      "message": "O campo mime_type aplica-se apenas a registros MIME. Defina record_type como mime ou omita mime_type."
+    },
+    "multiple_errors": {
+      "message": "Ocorreram erros para um ou mais dispositivos:\n{errors}"
+    },
+    "nfc_content_empty": {
+      "message": "O conteúdo NFC não pode estar vazio."
+    },
+    "nfc_content_too_long": {
+      "message": "O conteúdo NFC é muito grande ({size} bytes). O máximo é {max} bytes."
+    },
+    "nfc_mime_type_invalid": {
+      "message": "O tipo MIME `{mime_type}` é inválido. Deve ter entre 1 e 255 bytes quando codificado em UTF-8."
+    },
+    "nfc_not_supported": {
+      "message": "O dispositivo `{device_id}` não respondeu à gravação NFC. O firmware pode não suportar gravação de tags NFC; tente atualizar para o firmware mais recente."
+    },
+    "nfc_write_failed": {
+      "message": "Falha ao gravar a tag NFC: {error}"
+    },
+    "no_buzzers": {
+      "message": "O dispositivo `{device_id}` não tem buzzer configurado."
+    },
+    "no_leds": {
+      "message": "O dispositivo `{device_id}` não tem LEDs configurados."
+    },
+    "no_nfc": {
+      "message": "O dispositivo `{device_id}` não tem chip NFC configurado."
+    },
+    "no_targets_specified": {
+      "message": "Nenhum dispositivo alvo especificado."
+    },
+    "upload_error": {
+      "message": "Falha ao enviar para o display: {error}"
+    },
+    "url_not_allowed": {
+      "message": "URL `{url}` não é permitida. Adicione-a a `allowlist_external_urls` no configuration.yaml."
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "data": {
+          "blocks_per_ack": "Blocos enviados por reconhecimento",
+          "max_queue_size": "Máximo de quadros de upload em voo",
+          "missed_cycles": "Ciclos de ativação perdidos antes de indisponível",
+          "probe_before_queue": "Tentar conectar antes de enfileirar",
+          "queue_timeout_hours": "Tempo limite de conteúdo enfileirado (horas)",
+          "sleep_mode": "Gerenciamento de modo de sono profundo"
+        },
+        "data_description": {
+          "blocks_per_ack": "Quantos quadros de imagem o dispositivo recebe antes de enviar um reconhecimento durante um upload rápido (janela deslizante). Valores maiores reduzem viagens de ida e volta; o valor efetivo é limitado pelo dispositivo e pelo máximo de quadros em voo.",
+          "max_queue_size": "Número máximo de quadros de imagem mantidos em voo simultaneamente durante um upload rápido (janela deslizante). Valores maiores aumentam a taxa em conexões lentas (proxy). Defina como 1 para desativar a transferência rápida e usar o upload clássico quadro a quadro.",
+          "missed_cycles": "Quantas ativações esperadas o dispositivo pode perder antes que suas entidades sejam marcadas como indisponíveis.",
+          "probe_before_queue": "Antes de enfileirar uma imagem para um dispositivo em sono, faça uma tentativa rápida de conexão caso ele esteja acordado (anúncios perdidos, rádios sempre ligados). Adiciona no máximo alguns segundos quando o dispositivo realmente está dormindo.",
+          "queue_timeout_hours": "Quanto tempo o conteúdo enfileirado para um dispositivo em sono espera por uma ativação antes de expirar.",
+          "sleep_mode": "Automático segue a configuração de energia do dispositivo (bateria com sono profundo ativado). Forçar ligado ou desligado para substituir."
+        }
+      }
+    }
+  },
+  "selector": {
+    "dither_mode": {
+      "options": {
+        "atkinson": "Atkinson",
+        "burkes": "Burkes",
+        "floyd_steinberg": "Floyd-Steinberg",
+        "jarvis_judice_ninke": "Jarvis, Judice & Ninke",
+        "none": "Nenhum",
+        "ordered": "Ordenado",
+        "sierra": "Sierra",
+        "sierra_lite": "Sierra Lite",
+        "stucki": "Stucki"
+      }
+    },
+    "fit_mode": {
+      "options": {
+        "contain": "Conter",
+        "cover": "Cobrir",
+        "crop": "Cortar",
+        "stretch": "Esticar"
+      }
+    },
+    "nfc_record_type": {
+      "options": {
+        "ha_tag": "Etiqueta Home Assistant",
+        "mime": "Dados MIME (ex: vCard)",
+        "text": "Texto",
+        "url": "URL"
+      }
+    },
+    "refresh_mode": {
+      "options": {
+        "fast": "Rápido",
+        "full": "Completo",
+        "partial": "Parcial"
+      }
+    },
+    "sleep_mode": {
+      "options": {
+        "auto": "Automático (seguir dispositivo)",
+        "off": "Forçar desligado",
+        "on": "Forçar ligado"
+      }
+    }
+  },
+  "services": {
+    "activate_buzzer": {
+      "description": "Ativa um tom de buzina em um dispositivo OpenDisplay.",
+      "fields": {
+        "device_id": {
+          "description": "O dispositivo OpenDisplay.",
+          "name": "Dispositivo"
+        },
+        "duration_ms": {
+          "description": "Duração do tom em milissegundos (5-1275).",
+          "name": "Duração"
+        },
+        "frequency_hz": {
+          "description": "Frequência do tom em Hz (0 = silêncio, 400-12000).",
+          "name": "Frequência"
+        },
+        "instance": {
+          "description": "Índice da instância da buzina (base 0).",
+          "name": "Instância da buzina"
+        },
+        "repeats": {
+          "description": "Número de repetições do tom (1-255).",
+          "name": "Repetições"
+        }
+      },
+      "name": "Ativar buzina"
+    },
+    "activate_led": {
+      "description": "Ativa um padrão de flash de LED em um dispositivo OpenDisplay.",
+      "fields": {
+        "brightness": {
+          "description": "Brilho do LED (1-16).",
+          "name": "Brilho"
+        },
+        "color1": {
+          "description": "Cor do primeiro passo.",
+          "name": "Cor 1"
+        },
+        "color2": {
+          "description": "Cor do segundo passo (omitir ou definir contagem de flashes para 0 para pular).",
+          "name": "Cor 2"
+        },
+        "color3": {
+          "description": "Cor do terceiro passo (omitir ou definir contagem de flashes para 0 para pular).",
+          "name": "Cor 3"
+        },
+        "device_id": {
+          "description": "O dispositivo OpenDisplay.",
+          "name": "Dispositivo"
+        },
+        "flash_count1": {
+          "description": "Número de flashes para o primeiro passo (0 pula este passo).",
+          "name": "Contagem de flashes 1"
+        },
+        "flash_count2": {
+          "description": "Número de flashes para o segundo passo (0 pula este passo).",
+          "name": "Contagem de flashes 2"
+        },
+        "flash_count3": {
+          "description": "Número de flashes para o terceiro passo (0 pula este passo).",
+          "name": "Contagem de flashes 3"
+        },
+        "instance": {
+          "description": "Índice da instância do LED (base 0).",
+          "name": "Instância do LED"
+        },
+        "inter_delay1": {
+          "description": "Atraso após o primeiro passo antes de passar para o próximo.",
+          "name": "Atraso do passo 1"
+        },
+        "inter_delay2": {
+          "description": "Atraso após o segundo passo antes de passar para o próximo.",
+          "name": "Atraso do passo 2"
+        },
+        "inter_delay3": {
+          "description": "Atraso após o terceiro passo antes de repetir.",
+          "name": "Atraso do passo 3"
+        },
+        "loop_delay1": {
+          "description": "Atraso entre flashes no primeiro passo.",
+          "name": "Atraso do flash 1"
+        },
+        "loop_delay2": {
+          "description": "Atraso entre flashes no segundo passo.",
+          "name": "Atraso do flash 2"
+        },
+        "loop_delay3": {
+          "description": "Atraso entre flashes no terceiro passo.",
+          "name": "Atraso do flash 3"
+        },
+        "repeats": {
+          "description": "Número de vezes para repetir o padrão completo (0 = infinito).",
+          "name": "Repetições"
+        }
+      },
+      "name": "Ativar LED"
+    },
+    "drawcustom": {
+      "description": "Desenha uma imagem personalizada em um ou mais dispositivos OpenDisplay.",
+      "fields": {
+        "background": {
+          "description": "Cor de preenchimento do fundo.",
+          "name": "Cor de fundo"
+        },
+        "dither": {
+          "description": "Algoritmo de dithering para conversão da paleta de cores.",
+          "name": "Modo de dithering"
+        },
+        "dry-run": {
+          "description": "Gerar imagem sem enviar para o dispositivo.",
+          "name": "Execução simulada"
+        },
+        "measured_palette": {
+          "description": "Usar a paleta de cores medida do painel quando disponível. Desligar para dither contra o esquema teórico de cores. Sem efeito em painéis sem dados medidos.",
+          "name": "Usar paleta medida"
+        },
+        "payload": {
+          "description": "Array de elementos de desenho.",
+          "name": "Conteúdo"
+        },
+        "refresh_type": {
+          "description": "Modo de atualização do display. Atualizações parciais alteram apenas a região modificada sem piscar; recai automaticamente para atualização completa quando não possível.",
+          "name": "Tipo de atualização"
+        },
+        "rotate": {
+          "description": "Rotação no sentido horário em graus.",
+          "name": "Rotação"
+        }
+      },
+      "name": "Desenhar imagem personalizada"
+    },
+    "upload_image": {
+      "description": "Envia uma imagem para um dispositivo OpenDisplay.",
+      "fields": {
+        "device_id": {
+          "description": "O dispositivo OpenDisplay para enviar a imagem.",
+          "name": "Dispositivo"
+        },
+        "dither_mode": {
+          "description": "Algoritmo de dithering para converter a imagem para a paleta de cores do display.",
+          "name": "Modo de dithering"
+        },
+        "fit_mode": {
+          "description": "Como a imagem é ajustada às dimensões do display.",
+          "name": "Modo de ajuste"
+        },
+        "image": {
+          "description": "A imagem para enviar ao display. Escolher um item de mídia ou fornecer uma URL direta da imagem (a URL deve estar adicionada em allowlist_external_urls).",
+          "name": "Imagem"
+        },
+        "measured_palette": {
+          "description": "Usar a paleta de cores medida do painel quando disponível. Desative para aplicar dithering contra o esquema de cores teórico. Sem efeito em painéis sem dados medidos.",
+          "name": "Usar paleta medida"
+        },
+        "refresh_mode": {
+          "description": "Modo de atualização do display. Atualização completa elimina ghosting, mas é mais lenta. Atualização rápida não é suportada em todos os displays. Atualização parcial atualiza apenas a região alterada sem piscar (painéis P/B com suporte parcial; reverte para atualização completa automaticamente quando não possível).",
+          "name": "Modo de atualização"
+        },
+        "rotation": {
+          "description": "Ângulo de rotação em graus, aplicado no sentido horário.",
+          "name": "Rotação"
+        },
+        "tone_compression": {
+          "description": "Força da compressão da faixa dinâmica. Deixe vazio para automático.",
+          "name": "Compressão de tom"
+        }
+      },
+      "name": "Enviar imagem",
+      "sections": {
+        "additional_fields": {
+          "name": "Opções adicionais"
+        }
+      }
+    },
+    "write_nfc": {
+      "description": "Grava um registro NDEF (URL, texto ou dados MIME como um vCard) no chip NFC de um dispositivo OpenDisplay.",
+      "fields": {
+        "content": {
+          "description": "Os dados a gravar. Para um registro URL, a URL; para texto, o texto; para MIME, os dados brutos; para uma tag Home Assistant, o ID da tag. Limitado a 512 bytes codificados em UTF-8.",
+          "name": "Conteúdo"
+        },
+        "device_id": {
+          "description": "O dispositivo OpenDisplay.",
+          "name": "Dispositivo"
+        },
+        "mime_type": {
+          "description": "O tipo MIME do conteúdo. Aplica-se apenas a registros MIME; padrão é text/vcard.",
+          "name": "Tipo MIME"
+        },
+        "record_type": {
+          "description": "O tipo de registro NDEF a gravar. Tag Home Assistant grava uma URL de tag Home Assistant; escaneá-la com o app companion dispara tag_scanned e registra a tag automaticamente na primeira leitura.",
+          "name": "Tipo de registro"
+        }
+      },
+      "name": "Gravar tag NFC"
+    }
+  }
+}

--- a/custom_components/opendisplay/translations/pt.json
+++ b/custom_components/opendisplay/translations/pt.json
@@ -1,0 +1,429 @@
+{
+  "config": {
+    "abort": {
+      "already_configured": "Dispositivo já configurado",
+      "already_in_progress": "Fluxo de configuração já em progresso",
+      "cannot_connect": "Falha na ligação",
+      "no_devices_found": "Nenhum dispositivo encontrado na rede",
+      "reauth_successful": "Reautenticação bem-sucedida",
+      "unknown": "Erro inesperado"
+    },
+    "error": {
+      "cannot_connect": "Falha na ligação",
+      "invalid_auth": "Autenticação inválida",
+      "invalid_key_format": "A chave de encriptação deve ter exatamente 32 caracteres hexadecimais (0-9, a-f).",
+      "unknown": "Erro inesperado"
+    },
+    "flow_title": "{name}",
+    "step": {
+      "bluetooth_confirm": {
+        "description": "Configurar {name}?"
+      },
+      "encryption_key": {
+        "data": {
+          "encryption_key": "Chave de encriptação"
+        },
+        "data_description": {
+          "encryption_key": "Introduzir a chave de encriptação AES-128 hexadecimal de 32 caracteres para este dispositivo."
+        },
+        "description": "{name} requer uma chave de encriptação para ligar.",
+        "title": "Encriptação necessária"
+      },
+      "reauth_confirm": {
+        "data": {
+          "encryption_key": "Chave de encriptação"
+        },
+        "data_description": {
+          "encryption_key": "Introduzir a chave de encriptação AES-128 hexadecimal de 32 caracteres para este dispositivo."
+        },
+        "description": "Falha na autenticação para {name}. Introduzir a chave de encriptação correta ou deixar em branco se a encriptação foi desativada no dispositivo.",
+        "title": "Reautenticação necessária"
+      },
+      "user": {
+        "data": {
+          "address": "Dispositivo"
+        },
+        "data_description": {
+          "address": "Selecionar o dispositivo Bluetooth para configurar."
+        },
+        "description": "Escolher um dispositivo para configurar"
+      }
+    }
+  },
+  "entity": {
+    "binary_sensor": {
+      "update_pending": {
+        "name": "Atualização pendente"
+      }
+    },
+    "event": {
+      "button": {
+        "name": "Botão {number}",
+        "state_attributes": {
+          "event_type": {
+            "state": {
+              "button_down": "Botão pressionado",
+              "button_up": "Botão libertado"
+            }
+          }
+        }
+      },
+      "touch": {
+        "name": "Toque {number}",
+        "state_attributes": {
+          "event_type": {
+            "state": {
+              "touch_down": "Toque pressionado",
+              "touch_move": "Toque em movimento",
+              "touch_up": "Toque libertado"
+            }
+          }
+        }
+      }
+    },
+    "image": {
+      "content": {
+        "name": "Conteúdo do ecrã"
+      }
+    },
+    "sensor": {
+      "battery_voltage": {
+        "name": "Voltagem da bateria"
+      },
+      "last_seen": {
+        "name": "Última vez visto"
+      },
+      "rssi": {
+        "name": "Intensidade do sinal (RSSI)"
+      }
+    },
+    "update": {
+      "firmware": {
+        "name": "Firmware"
+      }
+    }
+  },
+  "exceptions": {
+    "authentication_error": {
+      "message": "Falha na autenticação. Atualizar a chave de encriptação."
+    },
+    "device_not_found": {
+      "message": "Não foi possível encontrar o dispositivo Bluetooth com o endereço `{address}`."
+    },
+    "device_sleeping": {
+      "message": "O dispositivo `{device_id}` está em modo de repouso e não pode ser alcançado imediatamente. Acordar e tentar novamente."
+    },
+    "device_sleeping_ota": {
+      "message": "O dispositivo está em modo de repouso e não pode ser atualizado agora. Acordar (pressionar o botão ou aguardar a próxima verificação agendada) e iniciar a atualização novamente."
+    },
+    "invalid_device_id": {
+      "message": "O dispositivo `{device_id}` não é um dispositivo OpenDisplay válido."
+    },
+    "media_download_error": {
+      "message": "Falha ao transferir mídia: {error}"
+    },
+    "mime_type_not_applicable": {
+      "message": "O campo mime_type aplica-se apenas a registos MIME. Definir record_type para mime ou omitir mime_type."
+    },
+    "multiple_errors": {
+      "message": "Ocorreram erros em um ou mais dispositivos:\n{errors}"
+    },
+    "nfc_content_empty": {
+      "message": "O conteúdo NFC não pode estar vazio."
+    },
+    "nfc_content_too_long": {
+      "message": "O conteúdo NFC é demasiado grande ({size} bytes). O máximo é {max} bytes."
+    },
+    "nfc_mime_type_invalid": {
+      "message": "O tipo MIME `{mime_type}` é inválido. Deve ter entre 1 e 255 bytes quando codificado em UTF-8."
+    },
+    "nfc_not_supported": {
+      "message": "O dispositivo `{device_id}` não respondeu à escrita NFC. O firmware pode não suportar escrita de etiquetas NFC; tentar atualizar para o firmware mais recente."
+    },
+    "nfc_write_failed": {
+      "message": "Falha ao escrever a etiqueta NFC: {error}"
+    },
+    "no_buzzers": {
+      "message": "O dispositivo `{device_id}` não tem buzzer configurado."
+    },
+    "no_leds": {
+      "message": "O dispositivo `{device_id}` não tem LEDs configurados."
+    },
+    "no_nfc": {
+      "message": "O dispositivo `{device_id}` não tem chip NFC configurado."
+    },
+    "no_targets_specified": {
+      "message": "Nenhum dispositivo alvo especificado."
+    },
+    "upload_error": {
+      "message": "Falha ao carregar para o ecrã: {error}"
+    },
+    "url_not_allowed": {
+      "message": "URL `{url}` não é permitida. Adicionar a `allowlist_external_urls` no configuration.yaml."
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "data": {
+          "blocks_per_ack": "Blocos enviados por confirmação",
+          "max_queue_size": "Máximo de frames de upload em voo",
+          "missed_cycles": "Ciclos de ativação perdidos antes de indisponível",
+          "probe_before_queue": "Tentar ligar antes de enfileirar",
+          "queue_timeout_hours": "Tempo limite de conteúdo enfileirado (horas)",
+          "sleep_mode": "Gestão de sono profundo"
+        },
+        "data_description": {
+          "blocks_per_ack": "Número de frames de imagem que o dispositivo recebe antes de enviar uma confirmação durante um upload rápido (janela deslizante). Valores mais altos reduzem viagens de ida e volta; o valor efetivo é limitado pelo dispositivo e pelo máximo de frames em voo.",
+          "max_queue_size": "Número máximo de frames de imagem mantidos em voo simultaneamente durante um upload rápido (janela deslizante). Valores mais altos aumentam a taxa em ligações lentas (proxy). Definir para 1 para desativar a transferência rápida e usar o upload clássico de um frame de cada vez.",
+          "missed_cycles": "Número de ativações esperadas que o dispositivo pode perder antes de as suas entidades serem marcadas como indisponíveis.",
+          "probe_before_queue": "Antes de enfileirar uma imagem para um dispositivo em repouso, fazer uma tentativa rápida de ligação caso esteja acordado (anúncios perdidos, rádios sempre ligados). Acrescenta no máximo alguns segundos quando o dispositivo está realmente em repouso.",
+          "queue_timeout_hours": "Tempo que o conteúdo enfileirado para um dispositivo em repouso espera por uma ativação antes de expirar.",
+          "sleep_mode": "Automático segue a configuração de energia do dispositivo (bateria com sono profundo ativado). Forçar ligado ou desligado para substituir."
+        }
+      }
+    }
+  },
+  "selector": {
+    "dither_mode": {
+      "options": {
+        "atkinson": "Atkinson",
+        "burkes": "Burkes",
+        "floyd_steinberg": "Floyd-Steinberg",
+        "jarvis_judice_ninke": "Jarvis, Judice & Ninke",
+        "none": "Nenhum",
+        "ordered": "Ordenado",
+        "sierra": "Sierra",
+        "sierra_lite": "Sierra Lite",
+        "stucki": "Stucki"
+      }
+    },
+    "fit_mode": {
+      "options": {
+        "contain": "Conter",
+        "cover": "Cobrir",
+        "crop": "Cortar",
+        "stretch": "Esticar"
+      }
+    },
+    "nfc_record_type": {
+      "options": {
+        "ha_tag": "Etiqueta Home Assistant",
+        "mime": "Dados MIME (ex. vCard)",
+        "text": "Texto",
+        "url": "URL"
+      }
+    },
+    "refresh_mode": {
+      "options": {
+        "fast": "Rápido",
+        "full": "Completo",
+        "partial": "Parcial"
+      }
+    },
+    "sleep_mode": {
+      "options": {
+        "auto": "Automático (seguir dispositivo)",
+        "off": "Forçar desligar",
+        "on": "Forçar ligar"
+      }
+    }
+  },
+  "services": {
+    "activate_buzzer": {
+      "description": "Ativa um tom de buzina num dispositivo OpenDisplay.",
+      "fields": {
+        "device_id": {
+          "description": "O dispositivo OpenDisplay.",
+          "name": "Dispositivo"
+        },
+        "duration_ms": {
+          "description": "Duração do tom em milissegundos (5-1275).",
+          "name": "Duração"
+        },
+        "frequency_hz": {
+          "description": "Frequência do tom em Hz (0 = silêncio, 400-12000).",
+          "name": "Frequência"
+        },
+        "instance": {
+          "description": "Índice da instância da buzina (base 0).",
+          "name": "Instância da buzina"
+        },
+        "repeats": {
+          "description": "Número de repetições do tom (1-255).",
+          "name": "Repetições"
+        }
+      },
+      "name": "Ativar buzina"
+    },
+    "activate_led": {
+      "description": "Ativa um padrão de flash LED num dispositivo OpenDisplay.",
+      "fields": {
+        "brightness": {
+          "description": "Brilho do LED (1-16).",
+          "name": "Brilho"
+        },
+        "color1": {
+          "description": "Cor do primeiro passo.",
+          "name": "Cor 1"
+        },
+        "color2": {
+          "description": "Cor do segundo passo (omitir ou definir contagem de flashes para 0 para ignorar).",
+          "name": "Cor 2"
+        },
+        "color3": {
+          "description": "Cor do terceiro passo (omitir ou definir contagem de flashes para 0 para ignorar).",
+          "name": "Cor 3"
+        },
+        "device_id": {
+          "description": "O dispositivo OpenDisplay.",
+          "name": "Dispositivo"
+        },
+        "flash_count1": {
+          "description": "Número de flashes para o primeiro passo (0 ignora este passo).",
+          "name": "Contagem de flashes 1"
+        },
+        "flash_count2": {
+          "description": "Número de flashes para o segundo passo (0 ignora este passo).",
+          "name": "Contagem de flashes 2"
+        },
+        "flash_count3": {
+          "description": "Número de flashes para o terceiro passo (0 ignora este passo).",
+          "name": "Contagem de flashes 3"
+        },
+        "instance": {
+          "description": "Índice da instância do LED (base 0).",
+          "name": "Instância do LED"
+        },
+        "inter_delay1": {
+          "description": "Atraso após o primeiro passo antes de passar ao seguinte.",
+          "name": "Atraso do passo 1"
+        },
+        "inter_delay2": {
+          "description": "Atraso após o segundo passo antes de passar ao seguinte.",
+          "name": "Atraso do passo 2"
+        },
+        "inter_delay3": {
+          "description": "Atraso após o terceiro passo antes de repetir.",
+          "name": "Atraso do passo 3"
+        },
+        "loop_delay1": {
+          "description": "Atraso entre flashes no primeiro passo.",
+          "name": "Atraso do flash 1"
+        },
+        "loop_delay2": {
+          "description": "Atraso entre flashes no segundo passo.",
+          "name": "Atraso do flash 2"
+        },
+        "loop_delay3": {
+          "description": "Atraso entre flashes no terceiro passo.",
+          "name": "Atraso do flash 3"
+        },
+        "repeats": {
+          "description": "Número de repetições do padrão completo (0 = infinito).",
+          "name": "Repetições"
+        }
+      },
+      "name": "Ativar LED"
+    },
+    "drawcustom": {
+      "description": "Desenha uma imagem personalizada num ou mais dispositivos OpenDisplay.",
+      "fields": {
+        "background": {
+          "description": "Cor de preenchimento do fundo.",
+          "name": "Cor de fundo"
+        },
+        "dither": {
+          "description": "Algoritmo de dithering para conversão da paleta de cores.",
+          "name": "Modo de dithering"
+        },
+        "dry-run": {
+          "description": "Gerar imagem sem carregar para o dispositivo.",
+          "name": "Execução simulada"
+        },
+        "measured_palette": {
+          "description": "Usar a paleta de cores medida do painel quando disponível. Desligar para ditherizar contra o esquema teórico de cores. Sem efeito em painéis sem dados medidos.",
+          "name": "Usar paleta medida"
+        },
+        "payload": {
+          "description": "Array de elementos de desenho.",
+          "name": "Carga útil"
+        },
+        "refresh_type": {
+          "description": "Modo de atualização do ecrã. Atualizações parciais apenas da região alterada sem piscar; recorre automaticamente a atualização completa quando não possível.",
+          "name": "Tipo de atualização"
+        },
+        "rotate": {
+          "description": "Rotação no sentido dos ponteiros do relógio em graus.",
+          "name": "Rotação"
+        }
+      },
+      "name": "Desenhar imagem personalizada"
+    },
+    "upload_image": {
+      "description": "Carrega uma imagem para um dispositivo OpenDisplay.",
+      "fields": {
+        "device_id": {
+          "description": "O dispositivo OpenDisplay para carregar a imagem.",
+          "name": "Dispositivo"
+        },
+        "dither_mode": {
+          "description": "O algoritmo de dithering a usar para converter a imagem para a paleta de cores do ecrã.",
+          "name": "Modo de dithering"
+        },
+        "fit_mode": {
+          "description": "Como a imagem é ajustada às dimensões do ecrã.",
+          "name": "Modo de ajuste"
+        },
+        "image": {
+          "description": "A imagem a carregar para o ecrã. Escolher um item de media, ou fornecer uma URL direta da imagem (a URL deve estar adicionada a allowlist_external_urls).",
+          "name": "Imagem"
+        },
+        "measured_palette": {
+          "description": "Usar a paleta de cores medida do painel quando disponível. Desligar para aplicar dithering contra o esquema de cores teórico. Sem efeito em painéis sem dados medidos.",
+          "name": "Usar paleta medida"
+        },
+        "refresh_mode": {
+          "description": "O modo de atualização do ecrã. Atualização completa elimina ghosting mas é mais lenta. Atualização rápida não é suportada em todos os ecrãs. Atualização parcial atualiza apenas a região alterada sem piscar (painéis P/B com suporte parcial; recorre automaticamente a atualização completa quando não possível).",
+          "name": "Modo de atualização"
+        },
+        "rotation": {
+          "description": "O ângulo de rotação em graus, aplicado no sentido horário.",
+          "name": "Rotação"
+        },
+        "tone_compression": {
+          "description": "Força da compressão da gama dinâmica. Deixar vazio para automático.",
+          "name": "Compressão de tons"
+        }
+      },
+      "name": "Carregar imagem",
+      "sections": {
+        "additional_fields": {
+          "name": "Opções adicionais"
+        }
+      }
+    },
+    "write_nfc": {
+      "description": "Grava um registo NDEF (URL, texto ou dados MIME como um vCard) no chip NFC de um dispositivo OpenDisplay.",
+      "fields": {
+        "content": {
+          "description": "Os dados a gravar. Para um registo URL, a URL; para um registo de texto, o texto; para um registo MIME, os dados brutos; para uma etiqueta Home Assistant, o id da etiqueta. Limitado a 512 bytes quando codificado em UTF-8.",
+          "name": "Conteúdo"
+        },
+        "device_id": {
+          "description": "O dispositivo OpenDisplay.",
+          "name": "Dispositivo"
+        },
+        "mime_type": {
+          "description": "O tipo MIME do conteúdo. Aplica-se apenas a registos MIME; padrão é text/vcard.",
+          "name": "Tipo MIME"
+        },
+        "record_type": {
+          "description": "O tipo de registo NDEF a gravar. Etiqueta Home Assistant grava uma URL de etiqueta Home Assistant; ao ser digitalizada com a app companion dispara tag_scanned e regista a etiqueta automaticamente na primeira digitalização.",
+          "name": "Tipo de registo"
+        }
+      },
+      "name": "Gravar etiqueta NFC"
+    }
+  }
+}

--- a/scripts/translate.py
+++ b/scripts/translate.py
@@ -149,17 +149,21 @@ English source. Preserve trailing punctuation as-is.
 """
 
 
+# Path separator for flattened keys. NOT a dot: Home Assistant select entities
+# use their option values as translation keys, and those legitimately contain
+# dots, e.g. entity.select.subghzchannel.state."100 - 864.000 Mhz (Europe, etc)".
+# A dot separator silently mis-nests those. NUL cannot appear in a JSON key that
+# came from a real translation file, so it round-trips safely.
+SEP = "\x00"
+
+
 def flatten(obj: dict, prefix: str = "") -> dict[str, str]:
-    """Flatten nested translation data into dotted paths."""
+    """Flatten nested translation data into separator-joined paths."""
     flat: dict[str, str] = {}
     for key, value in obj.items():
-        if "." in key:
-            raise ValueError(
-                f"Key {key!r} at {prefix or '<root>'} contains a dot, which "
-                "would corrupt dotted-path flattening. Change the flattening "
-                "separator before adding keys like this."
-            )
-        path = f"{prefix}.{key}" if prefix else key
+        if SEP in key:
+            raise ValueError(f"Key {key!r} at {prefix or '<root>'} contains NUL")
+        path = f"{prefix}{SEP}{key}" if prefix else key
         if isinstance(value, dict):
             flat.update(flatten(value, path))
         else:
@@ -168,15 +172,20 @@ def flatten(obj: dict, prefix: str = "") -> dict[str, str]:
 
 
 def unflatten(flat: dict[str, str]) -> dict:
-    """Rebuild nested translation data from dotted paths."""
+    """Rebuild nested translation data from flattened paths."""
     nested: dict = {}
     for path, value in sorted(flat.items()):
-        parts = path.split(".")
+        parts = path.split(SEP)
         cursor = nested
         for part in parts[:-1]:
             cursor = cursor.setdefault(part, {})
         cursor[parts[-1]] = value
     return nested
+
+
+def show(path: str) -> str:
+    """Human-readable form of a flattened path, for logs and PR summaries."""
+    return path.replace(SEP, ".")
 
 
 def fingerprint(text: str) -> str:
@@ -337,6 +346,10 @@ def translate_language(
 
     for index, chunk in enumerate(chunks, start=1):
         batch = {key: todo[key] for key in chunk}
+        # The model never sees the real paths: they carry a NUL separator and
+        # would waste output tokens round-tripping. Send 1..n and map back.
+        numbered = {str(n): todo[key] for n, key in enumerate(chunk)}
+        by_number = {str(n): key for n, key in enumerate(chunk)}
         print(f"  [{code}] chunk {index}/{len(chunks)} ({len(batch)} strings)")
 
         elapsed = time.monotonic() - throttle[0]
@@ -345,7 +358,7 @@ def translate_language(
         throttle[0] = time.monotonic()
 
         try:
-            response = call_model(token, language, batch)
+            response = call_model(token, language, numbered)
         except urllib.error.HTTPError as err:
             if err.code == 429:
                 # Daily or per-minute budget exhausted. Keep what we have: a
@@ -356,20 +369,26 @@ def translate_language(
                 return accepted, rejected
             raise
 
-        good, bad = validate(batch, response)
+        translated = {
+            by_number[n]: value
+            for n, value in response.items()
+            if n in by_number and isinstance(value, str)
+        }
+        good, bad = validate(batch, translated)
         accepted.update(good)
 
         # One retry, isolated, in case a neighbouring string derailed the batch.
         for key, reason in bad.items():
-            print(f"  [{code}] retrying {key} ({reason})")
+            print(f"  [{code}] retrying {show(key)} ({reason})")
             time.sleep(MIN_SECONDS_BETWEEN_REQUESTS)
             throttle[0] = time.monotonic()
             try:
-                retry = call_model(token, language, {key: todo[key]})
+                retry = call_model(token, language, {"0": todo[key]})
             except urllib.error.HTTPError:
                 rejected[key] = reason
                 continue
-            good_retry, bad_retry = validate({key: todo[key]}, retry)
+            retried = {key: retry["0"]} if isinstance(retry.get("0"), str) else {}
+            good_retry, bad_retry = validate({key: todo[key]}, retried)
             accepted.update(good_retry)
             rejected.update(bad_retry)
 
@@ -458,7 +477,7 @@ def main() -> int:
 
         for key in needs_review:
             review.append(
-                f"- **{code}** `{key}`: English source changed, but the "
+                f"- **{code}** `{show(key)}`: English source changed, but the "
                 f"translation was edited by hand and was left as-is."
             )
 
@@ -507,7 +526,7 @@ def main() -> int:
             line += f", {len(rejected)} skipped"
         summary.append(line)
         for key, reason in sorted(rejected.items()):
-            summary.append(f"  - skipped `{key}`: {reason}")
+            summary.append(f"  - skipped `{show(key)}`: {reason}")
 
     if args.dry_run:
         if review:

--- a/scripts/translate.py
+++ b/scripts/translate.py
@@ -1,0 +1,538 @@
+#!/usr/bin/env python3
+"""Fill in missing Home Assistant translations using GitHub Models.
+
+Source of truth is ``translations/en.json`` -- the fully resolved English file.
+``strings.json`` is NOT usable here: it contains ``[%key:...%]`` references that
+only Home Assistant's build tooling (script/hassfest) resolves. The runtime
+translation loader does no such resolution, so shipped translation files must be
+fully resolved.
+
+A key is sent to the model only when it is missing, or when its English source
+was reworded since it was last translated. Everything else is left alone, so a
+run after adding three new strings costs three strings' worth of tokens rather
+than the whole file.
+
+Manual corrections are protected. ``.translation-state.json`` records, per key,
+a fingerprint of the English source *and* of the translation this script wrote.
+If the translation on disk no longer matches the recorded fingerprint, a human
+edited it: the script will never overwrite that key, and instead reports it for
+review if the English behind it changed. See ``classify`` for the full policy.
+
+Runs on the stdlib only -- no new entries in requirements.txt.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import ssl
+import sys
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+
+def _ssl_context() -> ssl.SSLContext:
+    """TLS context that also works on python.org macOS builds.
+
+    Those ship without a CA bundle wired into OpenSSL, so urllib fails with
+    CERTIFICATE_VERIFY_FAILED even though curl succeeds. CI runners are fine;
+    this keeps local runs working without an extra setup step.
+    """
+    try:
+        import certifi
+
+        return ssl.create_default_context(cafile=certifi.where())
+    except ImportError:
+        return ssl.create_default_context()
+
+
+SSL_CONTEXT = _ssl_context()
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+TRANSLATIONS_DIR = REPO_ROOT / "custom_components" / "opendisplay" / "translations"
+SOURCE_FILE = TRANSLATIONS_DIR / "en.json"
+
+# Deliberately outside custom_components/: this is CI bookkeeping, not data that
+# should ship to every HACS user alongside the integration.
+STATE_FILE = REPO_ROOT / ".github" / "translation-state.json"
+
+# When the English source is reworded but the existing translation was edited by
+# a human, prefer the human's wording and surface it for review. Flip this to
+# True to let fresh machine output win instead.
+OVERWRITE_MANUAL_EDITS = False
+
+API_URL = "https://models.github.ai/inference/chat/completions"
+
+# Low rate-limit tier: 150 requests/day vs 50 for high tier. Tagged multilingual.
+# Verify against https://models.github.ai/catalog/models before changing.
+MODEL = "openai/gpt-4.1-mini"
+
+# GitHub Models caps output at 4000 tokens per request on the Copilot Free/Pro
+# tier, well below the model's own 32k ceiling. That cap -- not the model -- is
+# why we chunk. ~80 strings lands around 1800 output tokens, leaving margin for
+# languages that render longer than English.
+CHUNK_SIZE = 80
+
+# 15 requests/minute on the low tier.
+MIN_SECONDS_BETWEEN_REQUESTS = 4.5
+
+LANGUAGES = {
+    "de": "German",
+    "fr": "French",
+    "nl": "Dutch",
+    "es": "Spanish",
+    "it": "Italian",
+    "pl": "Polish",
+    "pt-BR": "Brazilian Portuguese",
+    "cs": "Czech",
+}
+
+PLACEHOLDER_RE = re.compile(r"\{[^{}]*\}")
+
+# Every target language distinguishes a familiar from a polite second person.
+# Rule 6 of the prompt asks the model to sidestep the choice with impersonal
+# phrasing; this is only the tie-breaker for sentences where that is impossible.
+FALLBACK_REGISTER = "informal"
+
+# Terms that must survive translation untouched. Product and protocol names read
+# as noise when localised, and HA's own translations leave them in English.
+DO_NOT_TRANSLATE = [
+    "OpenDisplay",
+    "Home Assistant",
+    "BLE",
+    "Bluetooth",
+    "NFC",
+    "AP",
+    "MAC",
+    "OTA",
+    "RSSI",
+    "LED",
+]
+
+SYSTEM_PROMPT = """\
+You translate user-interface strings for a Home Assistant integration from \
+English into {language}.
+
+You will receive a JSON object mapping opaque dotted keys to English strings. \
+Return a JSON object with the EXACT same keys, where each value is the \
+{language} translation of the corresponding English string.
+
+Rules:
+1. Return only the JSON object. No prose, no markdown fences, no explanation.
+2. Keys are identifiers, not content. Copy them verbatim; never translate a key.
+3. Placeholders wrapped in curly braces, such as {{name}} or {{number}}, are \
+substituted at runtime. Reproduce every placeholder exactly, character for \
+character, including its braces. Never translate, rename, reorder into a \
+different placeholder, add, or drop one. You may move a placeholder within the \
+sentence when the target language's grammar requires it.
+4. Leave these terms in English: {do_not_translate}.
+5. Use the terminology and phrasing Home Assistant itself uses in {language} \
+for common concepts (device, entity, sensor, configuration, service, area).
+6. Stay neutral about formality. {language} distinguishes levels of politeness \
+when addressing someone directly, and this interface should commit to neither. \
+Rephrase so the question does not arise: use the infinitive or a bare noun \
+phrase for instructions and labels, and an impersonal or passive construction \
+for statements. For example, prefer the {language} equivalent of "Enter \
+encryption key" over "Please enter your encryption key", and of "Set up \
+{{name}}?" over "Do you want to set up {{name}}?". This is normal, idiomatic \
+phrasing for software interfaces, not a stilted workaround.
+7. Only if a sentence genuinely cannot be expressed without addressing the \
+reader, use the {fallback_register} form, and keep it consistent.
+8. These are short UI labels, field descriptions, and error messages. Keep them \
+concise and idiomatic. Do not add politeness or filler that is absent from the \
+English source. Preserve trailing punctuation as-is.
+"""
+
+
+def flatten(obj: dict, prefix: str = "") -> dict[str, str]:
+    """Flatten nested translation data into dotted paths."""
+    flat: dict[str, str] = {}
+    for key, value in obj.items():
+        if "." in key:
+            raise ValueError(
+                f"Key {key!r} at {prefix or '<root>'} contains a dot, which "
+                "would corrupt dotted-path flattening. Change the flattening "
+                "separator before adding keys like this."
+            )
+        path = f"{prefix}.{key}" if prefix else key
+        if isinstance(value, dict):
+            flat.update(flatten(value, path))
+        else:
+            flat[path] = value
+    return flat
+
+
+def unflatten(flat: dict[str, str]) -> dict:
+    """Rebuild nested translation data from dotted paths."""
+    nested: dict = {}
+    for path, value in sorted(flat.items()):
+        parts = path.split(".")
+        cursor = nested
+        for part in parts[:-1]:
+            cursor = cursor.setdefault(part, {})
+        cursor[parts[-1]] = value
+    return nested
+
+
+def fingerprint(text: str) -> str:
+    """Short, stable content hash. Only ever compared, never reversed."""
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()[:12]
+
+
+def classify(
+    source: dict[str, str],
+    existing: dict[str, str],
+    state: dict[str, dict[str, str]],
+    force: bool,
+) -> tuple[dict[str, str], list[str], list[str]]:
+    """Decide what to do with every key of one language.
+
+    Returns (to_translate, needs_review, obsolete).
+
+    The state entry for a key records two fingerprints: ``src`` (the English at
+    the time we translated) and ``out`` (what we wrote). Comparing ``out``
+    against the file on disk is what distinguishes a translation this script
+    owns from one a human has since corrected.
+    """
+    to_translate: dict[str, str] = {}
+    needs_review: list[str] = []
+
+    for key, english in source.items():
+        if key not in existing:
+            to_translate[key] = english
+            continue
+
+        if force:
+            to_translate[key] = english
+            continue
+
+        entry = state.get(key)
+        if entry is None:
+            # No provenance: hand-authored, or predates the state file. Not ours
+            # to touch.
+            continue
+
+        human_edited = entry.get("out") != fingerprint(existing[key])
+        source_changed = entry.get("src") != fingerprint(english)
+
+        if not source_changed:
+            continue
+
+        if human_edited and not OVERWRITE_MANUAL_EDITS:
+            needs_review.append(key)
+            continue
+
+        to_translate[key] = english
+
+    obsolete = [key for key in existing if key not in source]
+    return to_translate, needs_review, obsolete
+
+
+def write_translation_file(path: Path, flat: dict[str, str]) -> None:
+    """Write a translation file matching en.json's formatting."""
+    path.write_text(
+        json.dumps(unflatten(flat), indent=2, ensure_ascii=False, sort_keys=True)
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+def call_model(token: str, language: str, batch: dict[str, str]) -> dict[str, str]:
+    """Translate one batch of strings. Raises on transport or parse failure."""
+    body = json.dumps(
+        {
+            "model": MODEL,
+            "temperature": 0,
+            "response_format": {"type": "json_object"},
+            "messages": [
+                {
+                    "role": "system",
+                    "content": SYSTEM_PROMPT.format(
+                        language=language,
+                        do_not_translate=", ".join(DO_NOT_TRANSLATE),
+                        fallback_register=FALLBACK_REGISTER,
+                    ),
+                },
+                {
+                    "role": "user",
+                    "content": json.dumps(batch, indent=2, ensure_ascii=False),
+                },
+            ],
+        }
+    ).encode("utf-8")
+
+    request = urllib.request.Request(
+        API_URL,
+        data=body,
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+        },
+    )
+
+    with urllib.request.urlopen(request, timeout=180, context=SSL_CONTEXT) as response:
+        payload = json.load(response)
+
+    content = payload["choices"][0]["message"]["content"].strip()
+
+    # response_format should make fences impossible, but a stray ```json wrapper
+    # would otherwise fail the whole run. Cheap to tolerate.
+    if content.startswith("```"):
+        content = content.split("\n", 1)[1].rsplit("```", 1)[0]
+
+    return json.loads(content)
+
+
+def validate(
+    source: dict[str, str], translated: dict[str, str]
+) -> tuple[dict[str, str], dict[str, str]]:
+    """Split a model response into (accepted, rejected-with-reason).
+
+    A translation that loses or mangles a placeholder renders broken in Home
+    Assistant, so placeholder equality is enforced rather than trusted.
+    """
+    accepted: dict[str, str] = {}
+    rejected: dict[str, str] = {}
+
+    for key, english in source.items():
+        if key not in translated:
+            rejected[key] = "missing from model response"
+            continue
+
+        value = translated[key]
+        if not isinstance(value, str) or not value.strip():
+            rejected[key] = "empty or non-string translation"
+            continue
+
+        expected = sorted(PLACEHOLDER_RE.findall(english))
+        actual = sorted(PLACEHOLDER_RE.findall(value))
+        if expected != actual:
+            rejected[key] = f"placeholder mismatch: expected {expected}, got {actual}"
+            continue
+
+        accepted[key] = value
+
+    return accepted, rejected
+
+
+def translate_language(
+    token: str,
+    code: str,
+    language: str,
+    todo: dict[str, str],
+    throttle: list[float],
+) -> tuple[dict[str, str], dict[str, str]]:
+    """Translate every missing string for one language, chunk by chunk."""
+    keys = sorted(todo)
+    accepted: dict[str, str] = {}
+    rejected: dict[str, str] = {}
+
+    chunks = [keys[i : i + CHUNK_SIZE] for i in range(0, len(keys), CHUNK_SIZE)]
+
+    for index, chunk in enumerate(chunks, start=1):
+        batch = {key: todo[key] for key in chunk}
+        print(f"  [{code}] chunk {index}/{len(chunks)} ({len(batch)} strings)")
+
+        elapsed = time.monotonic() - throttle[0]
+        if elapsed < MIN_SECONDS_BETWEEN_REQUESTS:
+            time.sleep(MIN_SECONDS_BETWEEN_REQUESTS - elapsed)
+        throttle[0] = time.monotonic()
+
+        try:
+            response = call_model(token, language, batch)
+        except urllib.error.HTTPError as err:
+            if err.code == 429:
+                # Daily or per-minute budget exhausted. Keep what we have: a
+                # partial-but-valid PR beats a failed run.
+                print(f"  [{code}] rate limited, stopping early", file=sys.stderr)
+                for key in chunk:
+                    rejected[key] = "rate limited"
+                return accepted, rejected
+            raise
+
+        good, bad = validate(batch, response)
+        accepted.update(good)
+
+        # One retry, isolated, in case a neighbouring string derailed the batch.
+        for key, reason in bad.items():
+            print(f"  [{code}] retrying {key} ({reason})")
+            time.sleep(MIN_SECONDS_BETWEEN_REQUESTS)
+            throttle[0] = time.monotonic()
+            try:
+                retry = call_model(token, language, {key: todo[key]})
+            except urllib.error.HTTPError:
+                rejected[key] = reason
+                continue
+            good_retry, bad_retry = validate({key: todo[key]}, retry)
+            accepted.update(good_retry)
+            rejected.update(bad_retry)
+
+    return accepted, rejected
+
+
+def emit_output(name: str, value: str) -> None:
+    """Write a step output for the workflow to consume."""
+    output = os.environ.get("GITHUB_OUTPUT")
+    if not output:
+        return
+    with open(output, "a", encoding="utf-8") as handle:
+        if "\n" in value:
+            handle.write(f"{name}<<__EOF__\n{value}\n__EOF__\n")
+        else:
+            handle.write(f"{name}={value}\n")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--languages",
+        help=f"Comma-separated subset of: {', '.join(LANGUAGES)}",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Report what would be translated. Makes no API calls.",
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Re-translate every key, including ones a human edited.",
+    )
+    args = parser.parse_args()
+
+    if args.force:
+        print(
+            "--force will overwrite manual corrections in the selected "
+            "languages.",
+            file=sys.stderr,
+        )
+
+    source = flatten(json.loads(SOURCE_FILE.read_text(encoding="utf-8")))
+    print(f"{SOURCE_FILE.name}: {len(source)} strings")
+
+    if args.languages:
+        codes = [code.strip() for code in args.languages.split(",") if code.strip()]
+        unknown = [code for code in codes if code not in LANGUAGES]
+        if unknown:
+            parser.error(f"unknown language(s): {', '.join(unknown)}")
+    else:
+        codes = list(LANGUAGES)
+
+    token = os.environ.get("GITHUB_TOKEN", "")
+    if not token and not args.dry_run:
+        print(
+            "GITHUB_TOKEN is not set. In Actions, add 'models: read' to the "
+            "workflow permissions block. Locally, export a PAT with the "
+            "models:read scope.",
+            file=sys.stderr,
+        )
+        return 1
+
+    state: dict[str, dict[str, dict[str, str]]] = {}
+    if STATE_FILE.exists():
+        state = json.loads(STATE_FILE.read_text(encoding="utf-8"))
+
+    throttle = [0.0]
+    changed = False
+    summary: list[str] = []
+    review: list[str] = []
+
+    for code in codes:
+        language = LANGUAGES[code]
+        target = TRANSLATIONS_DIR / f"{code}.json"
+
+        existing: dict[str, str] = {}
+        if target.exists():
+            existing = flatten(json.loads(target.read_text(encoding="utf-8")))
+
+        lang_state = state.setdefault(code, {})
+        todo, needs_review, obsolete = classify(
+            source, existing, lang_state, args.force
+        )
+
+        for key in needs_review:
+            review.append(
+                f"- **{code}** `{key}`: English source changed, but the "
+                f"translation was edited by hand and was left as-is."
+            )
+
+        if not todo and not obsolete:
+            print(f"{code} ({language}): up to date")
+            continue
+
+        if args.dry_run:
+            print(
+                f"{code} ({language}): would translate {len(todo)}, "
+                f"flag {len(needs_review)} for review, "
+                f"drop {len(obsolete)} obsolete"
+            )
+            continue
+
+        print(f"{code} ({language}): translating {len(todo)} strings")
+        accepted, rejected = (
+            translate_language(token, code, language, todo, throttle)
+            if todo
+            else ({}, {})
+        )
+
+        merged = {key: value for key, value in existing.items() if key in source}
+        merged.update(accepted)
+
+        if not merged:
+            continue
+
+        write_translation_file(target, merged)
+        changed = True
+
+        # Record provenance only for what we just wrote. Untouched keys keep
+        # their existing entry; obsolete keys lose theirs.
+        for key, value in accepted.items():
+            lang_state[key] = {
+                "src": fingerprint(source[key]),
+                "out": fingerprint(value),
+            }
+        for key in obsolete:
+            lang_state.pop(key, None)
+
+        line = f"- **{code}** ({language}): {len(accepted)} translated"
+        if obsolete:
+            line += f", {len(obsolete)} obsolete removed"
+        if rejected:
+            line += f", {len(rejected)} skipped"
+        summary.append(line)
+        for key, reason in sorted(rejected.items()):
+            summary.append(f"  - skipped `{key}`: {reason}")
+
+    if args.dry_run:
+        if review:
+            print("\nNeeds review:\n" + "\n".join(review))
+        return 0
+
+    if changed:
+        STATE_FILE.write_text(
+            json.dumps(state, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+        )
+
+    if review:
+        summary.append("")
+        summary.append("**Needs review** (manual translations left untouched):")
+        summary.extend(review)
+
+    emit_output("changed", "true" if changed else "false")
+    emit_output(
+        "summary",
+        "\n".join(summary) if summary else "No translation changes.",
+    )
+
+    print("\n" + ("\n".join(summary) if summary else "No changes."))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/translate.py
+++ b/scripts/translate.py
@@ -88,6 +88,9 @@ LANGUAGES = {
     "es": "Spanish",
     "it": "Italian",
     "pl": "Polish",
+    # Home Assistant treats these as separate locales, and they diverge in
+    # everyday UI vocabulary (ecra/tela, utilizador/usuario).
+    "pt": "European Portuguese",
     "pt-BR": "Brazilian Portuguese",
     "cs": "Czech",
 }
@@ -482,7 +485,10 @@ def main() -> int:
             )
 
         if not todo and not obsolete:
-            print(f"{code} ({language}): up to date")
+            flagged = (
+                f", {len(needs_review)} flagged for review" if needs_review else ""
+            )
+            print(f"{code} ({language}): up to date{flagged}")
             continue
 
         if args.dry_run:

--- a/scripts/verify_translations.py
+++ b/scripts/verify_translations.py
@@ -23,7 +23,7 @@ SOURCE_FILE = TRANSLATIONS_DIR / "en.json"
 # Reuse the flattening and placeholder rules rather than reimplementing them,
 # so the two scripts can never disagree about what "valid" means.
 sys.path.insert(0, str(Path(__file__).resolve().parent))
-from translate import PLACEHOLDER_RE, flatten  # noqa: E402
+from translate import PLACEHOLDER_RE, flatten, show  # noqa: E402
 
 # Second-person pronouns that indicate the model addressed the user directly
 # instead of using the impersonal phrasing rule 6 asks for. These are warnings,
@@ -64,7 +64,7 @@ def main() -> int:
             continue
 
         for key in sorted(set(data) - set(source)):
-            errors.append(f"{path.name}: key '{key}' does not exist in en.json")
+            errors.append(f"{path.name}: key '{show(key)}' does not exist in en.json")
 
         for key, translation in sorted(data.items()):
             english = source.get(key)
@@ -72,14 +72,14 @@ def main() -> int:
                 continue
 
             if not translation.strip():
-                errors.append(f"{path.name}: '{key}' is empty")
+                errors.append(f"{path.name}: '{show(key)}' is empty")
                 continue
 
             expected = sorted(PLACEHOLDER_RE.findall(english))
             actual = sorted(PLACEHOLDER_RE.findall(translation))
             if expected != actual:
                 errors.append(
-                    f"{path.name}: '{key}' placeholder mismatch: "
+                    f"{path.name}: '{show(key)}' placeholder mismatch: "
                     f"expected {expected}, got {actual}"
                 )
 
@@ -88,7 +88,7 @@ def main() -> int:
                 match = re.search(pattern[0], translation, pattern[1])
                 if match:
                     warnings.append(
-                        f"{path.name}: '{key}' may address the user directly "
+                        f"{path.name}: '{show(key)}' may address the user directly "
                         f"({match.group(0)!r}): {translation}"
                     )
 

--- a/scripts/verify_translations.py
+++ b/scripts/verify_translations.py
@@ -40,6 +40,7 @@ DIRECT_ADDRESS = {
     "es": (r"\btú\b|\btu\b|\busted\b|\bsus?\b|\bvuestro\b", re.IGNORECASE),
     "it": (r"\btu\b|\btuo\b|\blei\b|\bsuo\b|\bvostro\b", re.IGNORECASE),
     "pl": (r"\bty\b|\btwój\b|\btwoje\w*\b|\bpan\b|\bpani\b", re.IGNORECASE),
+    "pt": (r"\bvocê\b|\btu\b|\bteu\b|\btua\b|\bseu\b|\bsua\b|\bvosso\b", re.IGNORECASE),
     "pt-BR": (r"\bvocê\b|\bteu\b|\btua\b|\bseu\b|\bsua\b", re.IGNORECASE),
     "cs": (r"\bty\b|\btvůj\b|\btvoje\w*\b|\bvy\b|\bváš\b|\bvaše\w*\b", re.IGNORECASE),
 }

--- a/scripts/verify_translations.py
+++ b/scripts/verify_translations.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""Check generated translation files before they reach a pull request.
+
+translate.py validates each string as it comes back from the model. This script
+re-checks the files as they now sit on disk, so a bug in the writing/merging
+path, a bad hand-edit, or a truncated response is caught by CI rather than by a
+user seeing a broken config flow.
+
+Exits non-zero on any problem. Safe to run locally at any time.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+TRANSLATIONS_DIR = REPO_ROOT / "custom_components" / "opendisplay" / "translations"
+SOURCE_FILE = TRANSLATIONS_DIR / "en.json"
+
+# Reuse the flattening and placeholder rules rather than reimplementing them,
+# so the two scripts can never disagree about what "valid" means.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from translate import PLACEHOLDER_RE, flatten  # noqa: E402
+
+# Second-person pronouns that indicate the model addressed the user directly
+# instead of using the impersonal phrasing rule 6 asks for. These are warnings,
+# not failures: a false alarm should never block a release.
+#
+# German is matched case-sensitively on purpose. It capitalises the polite
+# pronouns (Sie/Ihr/Ihnen) and lowercases the identical-looking third person
+# ("sie" = they, "ihre" = their), so folding case turns every "before they
+# expire" into a false formality warning. Other languages are case-insensitive.
+DIRECT_ADDRESS = {
+    "de": (r"\bSie\b|\bIhre?[nmrs]?\b|\bIhnen\b|\bdu\b|\bdir\b|\bdich\b|\bdein\w*\b", 0),
+    "nl": (r"\bje\b|\bjouw\b|\bjij\b|\buw\b|\bu\b", re.IGNORECASE),
+    "fr": (r"\btu\b|\bton\b|\bta\b|\btes\b|\bvous\b|\bvotre\b|\bvos\b", re.IGNORECASE),
+    "es": (r"\btú\b|\btu\b|\busted\b|\bsus?\b|\bvuestro\b", re.IGNORECASE),
+    "it": (r"\btu\b|\btuo\b|\blei\b|\bsuo\b|\bvostro\b", re.IGNORECASE),
+    "pl": (r"\bty\b|\btwój\b|\btwoje\w*\b|\bpan\b|\bpani\b", re.IGNORECASE),
+    "pt-BR": (r"\bvocê\b|\bteu\b|\btua\b|\bseu\b|\bsua\b", re.IGNORECASE),
+    "cs": (r"\bty\b|\btvůj\b|\btvoje\w*\b|\bvy\b|\bváš\b|\bvaše\w*\b", re.IGNORECASE),
+}
+
+
+def main() -> int:
+    source = flatten(json.loads(SOURCE_FILE.read_text(encoding="utf-8")))
+    errors: list[str] = []
+    warnings: list[str] = []
+    checked = 0
+
+    for path in sorted(TRANSLATIONS_DIR.glob("*.json")):
+        code = path.stem
+        if code == "en":
+            continue
+        checked += 1
+
+        try:
+            data = flatten(json.loads(path.read_text(encoding="utf-8")))
+        except (json.JSONDecodeError, ValueError) as err:
+            errors.append(f"{path.name}: not valid translation JSON: {err}")
+            continue
+
+        for key in sorted(set(data) - set(source)):
+            errors.append(f"{path.name}: key '{key}' does not exist in en.json")
+
+        for key, translation in sorted(data.items()):
+            english = source.get(key)
+            if english is None:
+                continue
+
+            if not translation.strip():
+                errors.append(f"{path.name}: '{key}' is empty")
+                continue
+
+            expected = sorted(PLACEHOLDER_RE.findall(english))
+            actual = sorted(PLACEHOLDER_RE.findall(translation))
+            if expected != actual:
+                errors.append(
+                    f"{path.name}: '{key}' placeholder mismatch: "
+                    f"expected {expected}, got {actual}"
+                )
+
+            pattern = DIRECT_ADDRESS.get(code)
+            if pattern:
+                match = re.search(pattern[0], translation, pattern[1])
+                if match:
+                    warnings.append(
+                        f"{path.name}: '{key}' may address the user directly "
+                        f"({match.group(0)!r}): {translation}"
+                    )
+
+        missing = len(set(source) - set(data))
+        extra = len(set(data) - set(source))
+        notes = []
+        if missing:
+            notes.append(f"{missing} missing")
+        if extra:
+            notes.append(f"{extra} unknown")
+        status = ", ".join(notes) if notes else "complete"
+        print(f"{path.name}: {len(data & source.keys())}/{len(source)} ({status})")
+
+    if not checked:
+        print("No translation files to verify yet.")
+        return 0
+
+    if warnings:
+        print(f"\n{len(warnings)} formality warning(s):")
+        for warning in warnings:
+            print(f"  - {warning}")
+
+    if errors:
+        print(f"\n{len(errors)} error(s):", file=sys.stderr)
+        for error in errors:
+            print(f"  - {error}", file=sys.stderr)
+        return 1
+
+    print("\nAll translation files valid.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Adds Czech, Dutch, French, German, Italian, Polish, Portuguese (European and Brazilian), and Spanish translations, plus the workflow that keeps them current.

**Cost: nothing.** Uses GitHub Models via the built-in `GITHUB_TOKEN` with `models: read`. No API key, no secret, no billing. Runs on the Python standard library, so `requirements.txt` is unchanged.

### How it avoids waste

A key is sent to a model only when it is **missing**, or when its **English source was reworded**. Everything else is left alone. A full backfill of 9 languages is 27 requests against a 150/day budget; a run after adding three strings is 9 tiny ones. Verified: re-running immediately after a full run makes **zero** API calls.

### Manual corrections are permanent

`.github/translation-state.json` fingerprints both the English source *and* the translation the workflow wrote, so it can tell its own output from a human edit.

| Situation | Behaviour |
|---|---|
| Key missing | Translated |
| Bot-written, English reworded | Re-translated |
| **Hand-corrected** | **Never overwritten** |
| Hand-corrected *and* English reworded | Flagged under "Needs review", your wording kept |

Verified end to end on the real files, not just unit-tested.

### Validation

`scripts/verify_translations.py` runs as a workflow step and fails the build on placeholder mismatches, empty values, or unknown keys. It runs *inside* the translate workflow because PRs opened by `GITHUB_TOKEN` do not trigger other workflows, so hassfest will not run on the automated PR.

Placeholders like `{name}` are enforced exactly: a translation that drops or renames one is rejected and retried rather than committed. Moving a placeholder is allowed, since German word order requires it (`Taste {number}`).

### Register

Translations avoid the familiar/polite distinction (German du/Sie, French tu/vous) using impersonal phrasing: `{name} einrichten?`, not `Möchten Sie {name} einrichten?`. A heuristic warns on slips.

This surfaced one issue in the **English** source, which said "in **your** configuration.yaml" and propagated a second-person possessive into every language. Reworded here.

### Notes for review

- `pt` and `pt-BR` are both included: 73 of 181 strings differ (`ligação`/`conectar`, `encriptação`/`criptografia`).
- The flattening path separator is NUL, not a dot. Home Assistant `select` entities use their option values as translation keys, and the existing `de.json` on `main` has `"100 - 864.000 Mhz (Europe, etc)"`, which a dot separator mis-nests.
- ⚠️ **Merging `feat/clean-port` into `main` will need manual resolution.** The merge base contains no `translations/` directory, so `en.json`, `de.json`, and `pl.json` are add/add conflicts. The `de`/`pl`/`pt` files on `main` translate the superseded string set (177-226 keys that no longer exist) and should be deleted during that merge, or `verify_translations.py` will fail on unknown keys.
