### PR TITLE
fix: report the firmware patch version everywhere HA shows it

### DIFF
--- a/custom_components/opendisplay/__init__.py
+++ b/custom_components/opendisplay/__init__.py
@@ -274,6 +274,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: OpenDisplayConfigEntry) 
             landing_url = cached.landing_url
             from_cache = True
 
+    # Imported here rather than at module scope because update.py imports from
+    # this module — a top-level import would be circular. Sharing the formatter
+    # keeps the device registry and the update entity from disagreeing about the
+    # version, which is what makes an update appear permanently pending.
+    from .update import _format_firmware_version
+
     profile = SleepProfile.from_entry(entry, device_config)
     coordinator = OpenDisplayCoordinator(hass, address)
 
@@ -295,7 +301,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: OpenDisplayConfigEntry) 
         connections={(CONNECTION_BLUETOOTH, address)},
         manufacturer=manufacturer.manufacturer_name,
         model=f"{size} {color_scheme}",
-        sw_version=f"{fw['major']}.{fw['minor']}",
+        sw_version=_format_firmware_version(fw["major"], fw["minor"], fw.get("patch")),
         hw_version=f"{manufacturer.board_type_name or manufacturer.board_type}"
         if is_flex
         else None,

--- a/custom_components/opendisplay/diagnostics.py
+++ b/custom_components/opendisplay/diagnostics.py
@@ -56,6 +56,7 @@ async def async_get_config_entry_diagnostics(
         "firmware": {
             "major": fw["major"],
             "minor": fw["minor"],
+            "patch": fw.get("patch"),
             "sha": fw["sha"],
         },
         "is_flex": runtime.is_flex,

--- a/custom_components/opendisplay/manifest.json
+++ b/custom_components/opendisplay/manifest.json
@@ -15,6 +15,6 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/OpenDisplay/Home_Assistant_Integration/issues",
   "loggers": ["opendisplay"],
-  "requirements": ["py-opendisplay[silabs-ota]==7.14.0", "odl-renderer==0.5.12"],
+  "requirements": ["py-opendisplay[silabs-ota]==7.14.1", "odl-renderer==0.5.12"],
   "version": "3.0.0-beta.8"
 }

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -9,6 +9,7 @@ so the minor byte always equals the literal tag digits (2.20 -> 20, 1.71 -> 71,
 """
 
 import pytest
+from awesomeversion import AwesomeVersion
 
 from custom_components.opendisplay.update import _format_firmware_version
 
@@ -35,10 +36,41 @@ def test_format_firmware_version(major, minor, expected):
         # three-part form so a device on 2.25.1 matches its release tag.
         (2, 25, 1, "2.25.1"),
         (2, 25, 0, "2.25.0"),
-        # patch unavailable (older py-opendisplay or cached firmware dict):
-        # keep the two-part form; AwesomeVersion treats 2.25 == 2.25.0.
+        # patch unavailable (cached firmware dict written before the patch byte
+        # was parsed): fall back to the two-part form. This is transient — it
+        # still compares older than a patch release, so the device shows a
+        # pending update until it is next interrogated. `.0` would not help
+        # either, since 2.25.0 < 2.25.1 too.
         (2, 25, None, "2.25"),
     ],
 )
 def test_format_firmware_version_with_patch(major, minor, patch, expected):
     assert _format_firmware_version(major, minor, patch) == expected
+
+
+@pytest.mark.parametrize(
+    ("installed", "latest_tag", "expect_update"),
+    [
+        # The regression this exists for (issue #62): newest firmware against
+        # the newest release must report no update.
+        ((2, 25, 1), "2.25.1", False),
+        ((3, 0, 0), "3.0.0", False),
+        # A genuinely newer release is still offered.
+        ((2, 25, 0), "2.25.1", True),
+        ((2, 23, 0), "2.25.1", True),
+        # Legacy two-part release tags: firmware reporting patch 0 formats as
+        # x.y.0, which AwesomeVersion ranks equal to the bare "x.y" tag, so
+        # devices on pre-SemVer releases do not gain a phantom update.
+        ((2, 23, 0), "2.23", False),
+        ((1, 71, 0), "1.71", False),
+    ],
+)
+def test_update_offered_only_when_genuinely_newer(installed, latest_tag, expect_update):
+    """installed_version and latest_version must be comparable like-for-like.
+
+    ``latest_version`` is the GitHub tag verbatim, so a two-part installed
+    string ranks below a patch release of the same minor — which is what made
+    an update look permanently pending.
+    """
+    formatted = _format_firmware_version(*installed)
+    assert (AwesomeVersion(latest_tag) > AwesomeVersion(formatted)) is expect_update


### PR DESCRIPTION
Completes the firmware-version fix. Closes #62.

**The pin is what switches this on.** `manifest.json` pinned `py-opendisplay==7.14.0`, which has no `patch` key, so `fw.get("patch")` returned `None` on every path and the formatter always took its two-part branch:

```
device on 2.25.1, GitHub latest tag 2.25.1
  pin 7.14.0    installed=2.25     update offered: True
  pin 7.14.1    installed=2.25.1   update offered: False
```

**Two places still showed two components:** the device registry (`sw_version`, so the device page read `2.25`) and diagnostics (no `patch` field at all). The device registry now shares `update.py`'s formatter rather than building its own string — two call sites deriving the same version separately is what let them drift. The import is function-local because `update.py` imports from `__init__`; verified it resolves at runtime.

**Regression test** compares installed against latest the way the entity does: `2.25.1` vs tag `2.25.1` → no update; genuinely newer releases still offered; legacy two-part tags (`2.23.0` vs `2.23`) rank equal, so pre-SemVer devices gain no phantom update.

Also reworded the comment on the `patch=None` case — the two-part fallback is right for a stale cached dict, but it is not equivalent: such a device does show a pending update until re-interrogated.

`uv run pytest` — 94 passed. `ruff check` on changed files shows only two pre-existing E501s, identical before and after.