### PR TITLE
feat: enumerate ADC resistor-ladder buttons as event entities

### DIFF
--- a/custom_components/opendisplay/event.py
+++ b/custom_components/opendisplay/event.py
@@ -2,7 +2,9 @@
 
 from dataclasses import dataclass
 
-from opendisplay.models.advertisement import TouchTracker
+from opendisplay.models import BinaryInputs
+from opendisplay.models.advertisement import ButtonChangeEvent, TouchTracker
+from opendisplay.models.enums import BinaryInputType
 
 from homeassistant.components.event import (
     EventDeviceClass,
@@ -34,6 +36,26 @@ class OpenDisplayTouchEntityDescription(EventEntityDescription):
     instance: int
 
 
+def _button_ids(bi: BinaryInputs) -> list[int]:
+    """Return the button ids reported by one binary_inputs block.
+
+    Digital blocks: one button per set ``input_flags`` bit. Ladder blocks
+    share one ADC pin and report ids id_base..id_base+count-1, with count
+    and id_base at the start of the reserved tail.
+    """
+    if bi.input_type == BinaryInputType.ADC_LADDER:
+        if len(bi.reserved) < 2:
+            return []
+        count = bi.reserved[0]
+        id_base = bi.reserved[1]
+        if not 1 <= count <= BinaryInputs.MAX_LADDER_BUTTONS:
+            return []
+        if id_base + count > BinaryInputs.MAX_BUTTON_ID + 1:
+            return []
+        return list(range(id_base, id_base + count))
+    return [i for i in range(8) if bi.input_flags & (1 << i)]
+
+
 async def async_setup_entry(
     hass: HomeAssistant,
     entry: OpenDisplayConfigEntry,
@@ -57,21 +79,25 @@ async def async_setup_entry(
     # --- Button entities ---
     button_descriptions: list[OpenDisplayEventEntityDescription] = []
     button_number = 0
+
+    def _add_button(bi, button_id: int) -> None:
+        nonlocal button_number
+        button_number += 1
+        button_descriptions.append(
+            OpenDisplayEventEntityDescription(
+                key=f"button_{bi.instance_number}_{button_id}",
+                translation_key="button",
+                translation_placeholders={"number": str(button_number)},
+                device_class=EventDeviceClass.BUTTON,
+                event_types=["button_down", "button_up"],
+                byte_index=bi.button_data_byte_index,
+                button_id=button_id,
+            )
+        )
+
     for bi in entry.runtime_data.device_config.binary_inputs:
-        for button_id in range(8):  # input_flags is a bitmask over 8 pin slots
-            if bi.input_flags & (1 << button_id):
-                button_number += 1
-                button_descriptions.append(
-                    OpenDisplayEventEntityDescription(
-                        key=f"button_{bi.instance_number}_{button_id}",
-                        translation_key="button",
-                        translation_placeholders={"number": str(button_number)},
-                        device_class=EventDeviceClass.BUTTON,
-                        event_types=["button_down", "button_up"],
-                        byte_index=bi.button_data_byte_index,
-                        button_id=button_id,
-                    )
-                )
+        for button_id in _button_ids(bi):
+            _add_button(bi, button_id)
 
     _remove_stale(
         f"{coordinator.address}-button_",
@@ -111,6 +137,43 @@ async def async_setup_entry(
     )
 
 
+def _events_for_button(event: ButtonChangeEvent, button_id: int) -> list[str]:
+    """Translate one tracker transition into down/up events for one button.
+
+    Ladder buttons share a report byte: pressing a different button arrives
+    as ``button_slot_changed``, and a press whose frames were dropped by BLE
+    sampling arrives only as ``press_count_changed``.
+    """
+    if event.event_type in ("button_down", "button_up"):
+        return [event.event_type] if event.button_id == button_id else []
+
+    if event.event_type == "button_slot_changed":
+        fired: list[str] = []
+        previous_id = event.previous_raw & 0x07
+        previous_pressed = bool(event.previous_raw & 0x80)
+        if previous_id == button_id and previous_pressed:
+            fired.append("button_up")  # release frame of the old button was lost
+        if event.button_id == button_id:
+            fired.append("button_down")
+            if not event.pressed:
+                fired.append("button_up")  # press and release both in one hop
+        return fired
+
+    if event.event_type == "press_count_changed":
+        # A normal press emits this alongside button_down; only an unchanged
+        # pressed state means presses were dropped between advertisements.
+        if event.button_id != button_id:
+            return []
+        previous_pressed = bool(event.previous_raw & 0x80)
+        if previous_pressed != event.pressed:
+            return []  # the down/up transition was already reported
+        if event.pressed:
+            return ["button_up", "button_down"]  # missed release + re-press
+        return ["button_down", "button_up"]  # missed a full press
+
+    return []
+
+
 class OpenDisplayEventEntity(
     OpenDisplayEntity[OpenDisplayEventEntityDescription], EventEntity
 ):
@@ -124,12 +187,12 @@ class OpenDisplayEventEntity(
         data = self.coordinator.data
         if data is not None and data is not self._last_processed_data:
             for event in data.button_events:
-                if (
-                    event.byte_index == self.entity_description.byte_index
-                    and event.button_id == self.entity_description.button_id
-                    and event.event_type in self.event_types
+                if event.byte_index != self.entity_description.byte_index:
+                    continue
+                for event_type in _events_for_button(
+                    event, self.entity_description.button_id
                 ):
-                    self._trigger_event(event.event_type)
+                    self._trigger_event(event_type)
             self._last_processed_data = data
             self.async_write_ha_state()
 

--- a/tests/test_event_buttons.py
+++ b/tests/test_event_buttons.py
@@ -1,0 +1,162 @@
+"""Unit tests for button event enumeration and tracker-event translation.
+
+Translation scenarios are taken from live XTEINK X4 captures (two ADC
+ladders plus a digital power button).
+"""
+
+from opendisplay.models import BinaryInputs
+from opendisplay.models.advertisement import ButtonChangeEvent
+from opendisplay.models.enums import BinaryInputType
+
+from custom_components.opendisplay.event import _button_ids, _events_for_button
+
+# --- helpers ---------------------------------------------------------------
+
+
+def _digital(input_flags: int, instance: int = 0) -> BinaryInputs:
+    return BinaryInputs(
+        instance_number=instance,
+        input_type=BinaryInputType.DIGITAL,
+        display_as=1,
+        reserved_pins=bytes([3]) + bytes(7),
+        input_flags=input_flags,
+        invert=input_flags,
+        pullups=input_flags,
+        pulldowns=0,
+        button_data_byte_index=7,
+        reserved=bytes(12),
+    )
+
+
+def _ladder(count: int, id_base: int) -> BinaryInputs:
+    # thresholds are irrelevant for enumeration; any strictly-descending set works
+    thresholds = list(range((count + 1) * 100, 0, -100))[: count + 1]
+    thresholds[-1] = 0
+    return BinaryInputs.adc_ladder(
+        instance_number=0,
+        adc_pin=1,
+        id_base=id_base,
+        button_data_byte_index=5,
+        thresholds=thresholds,
+    )
+
+
+def _forged_ladder(reserved: bytes) -> BinaryInputs:
+    return BinaryInputs(
+        instance_number=0,
+        input_type=BinaryInputType.ADC_LADDER,
+        display_as=0,
+        reserved_pins=bytes([1]) + bytes(7),
+        input_flags=0,
+        invert=0,
+        pullups=0,
+        pulldowns=0,
+        button_data_byte_index=5,
+        reserved=reserved,
+    )
+
+
+def _raw(button_id: int, count: int, pressed: bool) -> int:
+    return (button_id & 0x07) | ((count & 0x0F) << 3) | (0x80 if pressed else 0)
+
+
+def _event(
+    event_type: str,
+    button_id: int,
+    pressed: bool,
+    count: int,
+    previous_raw: int,
+    byte_index: int = 5,
+) -> ButtonChangeEvent:
+    return ButtonChangeEvent(
+        address="AA:BB:CC:DD:EE:FF",
+        byte_index=byte_index,
+        event_type=event_type,
+        button_id=button_id,
+        pressed=pressed,
+        press_count=count,
+        previous_press_count=(previous_raw >> 3) & 0x0F,
+        raw=_raw(button_id, count, pressed),
+        previous_raw=previous_raw,
+        timestamp=0.0,
+    )
+
+
+# --- _button_ids: enumeration ------------------------------------------------
+
+
+def test_digital_block_enumerates_set_bits():
+    assert _button_ids(_digital(0b0000_0001)) == [0]
+    assert _button_ids(_digital(0b1010_0010)) == [1, 5, 7]
+    assert _button_ids(_digital(0)) == []
+
+
+def test_ladder_block_enumerates_id_range():
+    # X4 ladder 1: 4 buttons, ids 0-3
+    assert _button_ids(_ladder(4, 0)) == [0, 1, 2, 3]
+    # X4 ladder 2: 2 buttons, ids 4-5
+    assert _button_ids(_ladder(2, 4)) == [4, 5]
+
+
+def test_ladder_block_ignores_input_flags_bitmask():
+    ladder = _ladder(2, 4)
+    assert ladder.input_flags == 0  # the bitmask is unused for ladders
+    assert _button_ids(ladder) == [4, 5]
+
+
+def test_ladder_rejects_bad_shapes():
+    for count, id_base in [(0, 0), (5, 0), (4, 5), (2, 7)]:
+        forged = _forged_ladder(bytes([count, id_base]) + bytes(10))
+        assert _button_ids(forged) == []
+
+
+def test_ladder_rejects_short_reserved():
+    assert _button_ids(_forged_ladder(b"\x02")) == []
+
+
+# --- _events_for_button: tracker-event translation ---------------------------
+
+
+def test_down_up_pass_through_for_matching_id():
+    down = _event("button_down", 2, True, 3, previous_raw=_raw(2, 2, False))
+    up = _event("button_up", 2, False, 3, previous_raw=_raw(2, 3, True))
+    assert _events_for_button(down, 2) == ["button_down"]
+    assert _events_for_button(up, 2) == ["button_up"]
+    assert _events_for_button(down, 1) == []
+    assert _events_for_button(up, 3) == []
+
+
+def test_slot_changed_fires_down_on_new_button():
+    # Live capture: Back released (id 0), then Left pressed (id 2).
+    ev = _event("button_slot_changed", 2, True, 3, previous_raw=_raw(0, 2, False))
+    assert _events_for_button(ev, 2) == ["button_down"]
+    assert _events_for_button(ev, 0) == []  # old button was already released
+
+
+def test_slot_changed_releases_old_button_when_release_frame_lost():
+    ev = _event("button_slot_changed", 5, True, 1, previous_raw=_raw(4, 1, True))
+    assert _events_for_button(ev, 4) == ["button_up"]
+    assert _events_for_button(ev, 5) == ["button_down"]
+
+
+def test_slot_changed_with_release_only_frame_fires_full_press():
+    # Live capture (VolUp): only the new button's release frame was seen.
+    ev = _event("button_slot_changed", 4, False, 2, previous_raw=_raw(5, 1, False))
+    assert _events_for_button(ev, 4) == ["button_down", "button_up"]
+
+
+def test_press_count_changed_ignored_when_state_transition_reported():
+    # button_down already fired for this frame pair; must not double-fire.
+    ev = _event("press_count_changed", 2, True, 3, previous_raw=_raw(2, 2, False))
+    assert _events_for_button(ev, 2) == []
+
+
+def test_press_count_changed_recovers_missed_press():
+    ev = _event("press_count_changed", 2, False, 4, previous_raw=_raw(2, 3, False))
+    assert _events_for_button(ev, 2) == ["button_down", "button_up"]
+    assert _events_for_button(ev, 1) == []
+
+
+def test_press_count_changed_recovers_missed_release_and_repress():
+    ev = _event("press_count_changed", 2, True, 4, previous_raw=_raw(2, 3, True))
+    assert _events_for_button(ev, 2) == ["button_up", "button_down"]


### PR DESCRIPTION
With the release of py-opendisplay 7.14.1, analog buttons now work end-to-end. Tested on my local HA server with an XTEINK X4 using the buttons to page through "panels" of a dashboard. I'm not gonna say it's the fastest thing in the world but it works. 😅

Ladder blocks (input_type=3) share one ADC pin, so the input_flags pin bitmask is empty and the button count/id base live in the reserved tail. Enumerate them alongside digital buttons, and translate the tracker's button_slot_changed / press_count_changed transitions into down/up events so ladder buttons sharing a report byte fire reliably even when BLE advertisement frames are lost.