### PR TITLE
feat: expose dizzy dithering in the service selectors

### DIFF
--- a/custom_components/opendisplay/services.yaml
+++ b/custom_components/opendisplay/services.yaml
@@ -39,6 +39,7 @@ upload_image:
                 - "sierra"
                 - "sierra_lite"
                 - "jarvis_judice_ninke"
+                - "dizzy"
         refresh_mode:
           required: false
           default: "full"
@@ -390,6 +391,7 @@ drawcustom:
             - "sierra"
             - "sierra_lite"
             - "jarvis_judice_ninke"
+            - "dizzy"
     refresh_type:
       name: Refresh type
       description: E-paper refresh mode

--- a/custom_components/opendisplay/strings.json
+++ b/custom_components/opendisplay/strings.json
@@ -195,6 +195,7 @@
       "options": {
         "atkinson": "Atkinson",
         "burkes": "Burkes",
+        "dizzy": "Dizzy",
         "floyd_steinberg": "Floyd-Steinberg",
         "jarvis_judice_ninke": "Jarvis, Judice & Ninke",
         "none": "None",

--- a/docs/drawcustom/supported_types.md
+++ b/docs/drawcustom/supported_types.md
@@ -50,7 +50,7 @@ The service targets one or more OpenDisplay devices via the standard Home Assist
 | `payload`          | List of drawing elements (required)      | —         | See [Element types](#element-types)                                                                       |
 | `background`       | Background color                         | `white`   | `white`, `black`, `accent`, `red`, `yellow`                                                               |
 | `rotate`           | Rotation of the whole image, in degrees  | `0`       | `0`, `90`, `180`, `270`                                                                                   |
-| `dither`           | Dithering algorithm                      | `ordered` | `none`, `burkes`, `ordered`, `floyd_steinberg`, `atkinson`, `stucki`, `sierra`, `sierra_lite`, `jarvis_judice_ninke` |
+| `dither`           | Dithering algorithm                      | `ordered` | `none`, `burkes`, `ordered`, `floyd_steinberg`, `atkinson`, `stucki`, `sierra`, `sierra_lite`, `jarvis_judice_ninke`, `dizzy` |
 | `refresh_type`     | E-paper refresh mode                     | `full`    | `full`, `fast`                                                                                            |
 | `tone_compression` | Tone compression strength (%)            | automatic | `0`–`100`; omit for automatic tone mapping                                                                |
 | `dry-run`          | Generate the image without sending it    | `false`   | `true`, `false`                                                                                           |


### PR DESCRIPTION
Exposes `DitherMode.DIZZY` (epaper-dithering 6.0.0) in the HA UI.

py-opendisplay already passes it through: it re-exports `DitherMode` from `epaper_dithering`, and `_str_to_int_enum` builds the service validators from the enum, so `"dizzy"` was already accepted. It was just missing from the hand-maintained UI metadata, making it invisible in the service picker.

- `services.yaml`: added to the `upload_image` and `drawcustom` option lists
- `strings.json`: added the selector label
- `docs/drawcustom/supported_types.md`: documented the value

Both selectors now match `DitherMode` element for element. Suite passes. Translations regenerate from `strings.json` via the translate workflow.