### PR TITLE
fix(delivery): stop the auth retry loop on a pending config resync

### DIFF
--- a/custom_components/opendisplay/binary_sensor.py
+++ b/custom_components/opendisplay/binary_sensor.py
@@ -80,6 +80,7 @@ class OpenDisplayUpdatePendingSensor(BinarySensorEntity):
         self._expires_at = snapshot.expires_at
         self._attempts = snapshot.attempts
         self._last_error = snapshot.last_error
+        self._auth_paused = snapshot.auth_paused
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
@@ -89,6 +90,9 @@ class OpenDisplayUpdatePendingSensor(BinarySensorEntity):
             "expires_at": _to_iso(self._expires_at),
             "attempts": self._attempts,
             "last_error": self._last_error,
+            # Authoritative: an expiring slot can overwrite last_error with
+            # "expired" while delivery is still blocked on authentication.
+            "auth_paused": self._auth_paused,
         }
 
     async def async_added_to_hass(self) -> None:

--- a/custom_components/opendisplay/delivery.py
+++ b/custom_components/opendisplay/delivery.py
@@ -95,9 +95,6 @@ class PendingUpload:
     queued_at: float
     expires_at: float
     attempts: int = 0
-    # Set when a delivery hit an auth failure; suppresses further doomed
-    # attempts until the entry reloads after reauth.
-    paused: bool = False
     cancel_deadline: CALLBACK_TYPE | None = None
 
 
@@ -118,6 +115,10 @@ class DeliverySnapshot:
     expires_at: float | None
     attempts: int
     last_error: str | None
+    # Authoritative "delivery is blocked on authentication" signal. ``last_error``
+    # is only best-effort for this: a paused slot's expiry timer still fires and
+    # overwrites it with "expired".
+    auth_paused: bool = False
 
 
 class DeliveryManager:
@@ -135,6 +136,12 @@ class DeliveryManager:
         self._pending_upload: PendingUpload | None = None
         self._pending_config_resync: bool = False
         self._last_error: str | None = None
+        # Terminal state for authentication failures. The device rejects every
+        # further attempt identically, and delivery is advertisement-driven with
+        # no throttle, so without this a pending config resync would reconnect
+        # once per advertisement forever (issue #91). Covers *both* work types
+        # and is cleared only by an entry reload, which rebuilds this manager.
+        self._auth_paused: bool = False
 
         self._delivering: bool = False
         self._delivery_task: asyncio.Task[None] | None = None
@@ -180,6 +187,7 @@ class DeliveryManager:
             expires_at=upload.expires_at if upload else None,
             attempts=upload.attempts if upload else 0,
             last_error=self._last_error,
+            auth_paused=self._auth_paused,
         )
 
     # -- submission ---------------------------------------------------------
@@ -213,7 +221,12 @@ class DeliveryManager:
         )
         self._schedule_expiry(slot)
         self._pending_upload = slot
-        self._last_error = None
+        if not self._auth_paused:
+            # Queuing new content must not make a paused manager look healthy.
+            # It also must not resume connection attempts: the pause is
+            # automation-proof by design (a frame-changing automation would
+            # otherwise re-arm the storm before every advertisement).
+            self._last_error = None
         # Show the intended frame immediately (the image entity now reflects
         # what will be delivered, not what is on the panel).
         async_dispatcher_send(
@@ -224,7 +237,12 @@ class DeliveryManager:
 
     @callback
     def request_config_resync(self) -> None:
-        """Request a firmware/config re-read at the next wake."""
+        """Request a firmware/config re-read at the next wake.
+
+        Deliberately does *not* clear ``_auth_paused``: this is called
+        automatically on every advertised reboot edge for sleepy devices, so
+        clearing here would reopen the per-advertisement loop of issue #91.
+        """
         self._pending_config_resync = True
         self._entry.runtime_data.config_resync_pending = True
 
@@ -248,8 +266,9 @@ class DeliveryManager:
 
     def _has_pending_work(self) -> bool:
         """Return True if there is deliverable work queued."""
-        upload_ready = self._pending_upload is not None and not self._pending_upload.paused
-        return upload_ready or self._pending_config_resync
+        if self._auth_paused:
+            return False
+        return self._pending_upload is not None or self._pending_config_resync
 
     # -- delivery drain -----------------------------------------------------
 
@@ -286,13 +305,12 @@ class DeliveryManager:
             # work queued and try again on the next wake.
             self._register_attempt_failure(str(err))
         except (AuthenticationFailedError, AuthenticationRequiredError):
-            # Bad/rotated key: pause the upload and prompt the user to reauth.
+            # Bad/rotated/absent key. Pausing only the upload would leave a
+            # pending config resync deliverable, and the next advertisement would
+            # start another identical, doomed session (issue #91), so the pause is
+            # manager-wide.
             _LOGGER.warning("%s: delivery auth failed; starting reauth", self._address)
-            if self._pending_upload is not None:
-                self._pending_upload.paused = True
-            self._last_error = "auth"
-            self._entry.async_start_reauth(self._hass)
-            self._notify_state()
+            self._pause_for_auth(start_reauth=True)
         except OpenDisplayError as err:
             _LOGGER.warning("%s: delivery failed: %s", self._address, err)
             self._register_attempt_failure(str(err))
@@ -304,7 +322,11 @@ class DeliveryManager:
         """The connection + drain body (see `_deliver` for error handling)."""
         key = self._resolve_key()
         if key is _KEY_INVALID:
-            # Malformed stored key; reauth was already started.
+            # Malformed stored key; ``_resolve_key`` already started reauth. This
+            # returns normally rather than raising, so without pausing here the
+            # work stays deliverable and every advertisement retries it — the
+            # same loop as the auth handler above, by a second route.
+            self._pause_for_auth(start_reauth=False)
             return
 
         runtime = self._entry.runtime_data
@@ -327,7 +349,7 @@ class DeliveryManager:
             # then failed on resync, the BLE fallback re-runs this and must not
             # re-upload an already-delivered frame (``_drain_upload`` clears it).
             pending = self._pending_upload
-            if pending is not None and not pending.paused:
+            if pending is not None:
                 await self._drain_upload(device, pending)
             if self._pending_config_resync:
                 await self._drain_resync(device)
@@ -443,6 +465,21 @@ class DeliveryManager:
         self._notify_state()
 
     # -- helpers ------------------------------------------------------------
+
+    @callback
+    def _pause_for_auth(self, *, start_reauth: bool) -> None:
+        """Enter the manager-wide terminal state for an authentication failure.
+
+        Both entry points (the ``_deliver`` handler and the malformed-key path in
+        ``_drain_once``) must set the flag, record the error and notify entities,
+        so they share this helper rather than repeating it. ``start_reauth`` is
+        False where the caller has already started the flow.
+        """
+        self._auth_paused = True
+        self._last_error = "auth"
+        if start_reauth:
+            self._entry.async_start_reauth(self._hass)
+        self._notify_state()
 
     def _register_attempt_failure(self, reason: str) -> None:
         """Record a failed wake attempt and keep the work queued.

--- a/custom_components/opendisplay/delivery.py
+++ b/custom_components/opendisplay/delivery.py
@@ -221,12 +221,14 @@ class DeliveryManager:
         )
         self._schedule_expiry(slot)
         self._pending_upload = slot
-        if not self._auth_paused:
-            # Queuing new content must not make a paused manager look healthy.
-            # It also must not resume connection attempts: the pause is
-            # automation-proof by design (a frame-changing automation would
-            # otherwise re-arm the storm before every advertisement).
-            self._last_error = None
+        # Queuing new content must not make a paused manager look healthy, and
+        # must not resume connection attempts: the pause is automation-proof by
+        # design (a frame-changing automation would otherwise re-arm the storm
+        # before every advertisement). Restore "auth" rather than merely keeping
+        # the current value -- the previous slot's expiry timer may have already
+        # overwritten it with "expired", which would otherwise be reported
+        # against this brand-new upload.
+        self._last_error = "auth" if self._auth_paused else None
         # Show the intended frame immediately (the image entity now reflects
         # what will be delivered, not what is on the panel).
         async_dispatcher_send(

--- a/custom_components/opendisplay/diagnostics.py
+++ b/custom_components/opendisplay/diagnostics.py
@@ -51,6 +51,7 @@ async def async_get_config_entry_diagnostics(
             "expires_at": state.expires_at,
             "attempts": state.attempts,
             "last_error": state.last_error,
+            "auth_paused": state.auth_paused,
         }
 
     # Transport diagnostics: WiFi/LAN endpoint (host/port/tls are not secret; the

--- a/custom_components/opendisplay/image.py
+++ b/custom_components/opendisplay/image.py
@@ -57,6 +57,7 @@ class OpenDisplayImageEntity(ImageEntity):
         self._pending: bool = False
         self._queued_at: float | None = None
         self._last_error: str | None = None
+        self._auth_paused: bool = False
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
@@ -65,6 +66,9 @@ class OpenDisplayImageEntity(ImageEntity):
             "pending": self._pending,
             "queued_at": _to_iso(self._queued_at),
             "last_error": self._last_error,
+            # Authoritative: an expiring slot can overwrite last_error with
+            # "expired" while delivery is still blocked on authentication.
+            "auth_paused": self._auth_paused,
         }
 
     async def async_image(self) -> bytes | None:
@@ -102,4 +106,5 @@ class OpenDisplayImageEntity(ImageEntity):
         self._pending = snapshot.pending
         self._queued_at = snapshot.queued_at
         self._last_error = snapshot.last_error
+        self._auth_paused = snapshot.auth_paused
         self.async_write_ha_state()

--- a/tests/test_delivery.py
+++ b/tests/test_delivery.py
@@ -469,8 +469,13 @@ async def test_key_invalid_sets_auth_error_and_notifies():
 
 
 @pytest.mark.asyncio
-async def test_mdns_and_post_probe_notifies_are_gated():
-    """Every wake route goes through _has_pending_work, so all are gated."""
+async def test_all_wake_sources_share_the_same_gate():
+    """Every wake route funnels through notify_device_seen, so one gate covers all.
+
+    ``source`` is only a log label; the BLE, mDNS
+    (``transport.async_notify_host_seen``) and post-probe (``services``) callers
+    all reach this same method, which is where the gate lives.
+    """
     hass, entry, _ = _make_env()
     with _auth_patches(AuthenticationFailedError("bad key")):
         mgr = DeliveryManager(hass, entry)
@@ -481,6 +486,31 @@ async def test_mdns_and_post_probe_notifies_are_gated():
         for source in ("ble", "mdns", "post-probe"):
             mgr.notify_device_seen(source)
         entry.async_create_background_task.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_submit_after_expiry_reports_auth_not_stale_expiry():
+    """auth failure -> slot expires -> new content: the error must read "auth".
+
+    ``_expire_upload`` overwrites ``last_error`` with "expired", so simply
+    declining to clear it on submit would report a stale expiry against a
+    brand-new pending upload.
+    """
+    hass, entry, _ = _make_env()
+    with _auth_patches(AuthenticationFailedError("bad key")):
+        mgr = DeliveryManager(hass, entry)
+        _submit(mgr)
+        await mgr._deliver()
+
+        mgr._expire_upload(mgr._pending_upload)
+        assert mgr.state.last_error == "expired"
+
+        _submit(mgr, device_id="dev2")
+
+    assert mgr.state.pending is True
+    assert mgr.state.auth_paused is True
+    assert mgr.state.last_error == "auth"
+    assert mgr._has_pending_work() is False
 
 
 @pytest.mark.asyncio

--- a/tests/test_delivery.py
+++ b/tests/test_delivery.py
@@ -9,10 +9,16 @@ namespace, since the resolver owns the connect/fallback flow.
 
 import asyncio
 import logging
+from contextlib import contextmanager
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
-from opendisplay import AuthenticationFailedError, BLEConnectionError, RefreshMode
+from opendisplay import (
+    AuthenticationFailedError,
+    AuthenticationRequiredError,
+    BLEConnectionError,
+    RefreshMode,
+)
 import pytest
 
 from homeassistant.exceptions import HomeAssistantError
@@ -22,12 +28,15 @@ from custom_components.opendisplay import transport as transport_mod
 from custom_components.opendisplay.ble_lock import async_get_ble_lock, ble_connection
 from custom_components.opendisplay.const import (
     CONF_BLOCKS_PER_ACK,
+    CONF_ENCRYPTION_KEY,
     CONF_MAX_QUEUE_SIZE,
     DEFAULT_BLOCKS_PER_ACK,
     DEFAULT_MAX_QUEUE_SIZE,
     EVENT_CONTENT_DELIVERED,
     EVENT_CONTENT_EXPIRED,
+    SIGNAL_PENDING_STATE,
 )
+from custom_components.opendisplay.binary_sensor import OpenDisplayUpdatePendingSensor
 from custom_components.opendisplay.delivery import DeliveryManager
 from custom_components.opendisplay.sleep import SleepProfile
 
@@ -308,29 +317,194 @@ async def test_drain_gives_up_after_max_attempts():
     assert expired[0]["attempts"] == delivery_mod.MAX_DELIVERY_ATTEMPTS
 
 
-@pytest.mark.asyncio
-async def test_drain_auth_failure_pauses_and_starts_reauth():
-    hass, entry, _ = _make_env()
+@contextmanager
+def _auth_patches(exc):
+    """Patch a drain so the connection attempt fails authentication with ``exc``."""
     with (
         patch.object(delivery_mod, "async_call_later", return_value=MagicMock()),
         patch.object(delivery_mod, "async_dispatcher_send"),
         patch.object(transport_mod, "async_ble_device_from_address", return_value=MagicMock()),
-        patch.object(
-            transport_mod,
-            "OpenDisplayDevice",
-            side_effect=_raising_device_ctx(AuthenticationFailedError("bad key")),
-        ),
+        patch.object(transport_mod, "OpenDisplayDevice", side_effect=_raising_device_ctx(exc)),
     ):
+        yield
+
+
+@pytest.mark.asyncio
+async def test_drain_auth_failure_pauses_and_starts_reauth():
+    hass, entry, _ = _make_env()
+    with _auth_patches(AuthenticationFailedError("bad key")):
         mgr = DeliveryManager(hass, entry)
         _submit(mgr)
         await mgr._deliver()
 
+    # The slot survives (a reload drops it); what stops the retry is the
+    # manager-wide pause, not a per-slot flag.
     assert mgr._pending_upload is not None
-    assert mgr._pending_upload.paused is True
+    assert mgr._auth_paused is True
+    assert mgr.state.auth_paused is True
     assert mgr.state.last_error == "auth"
     entry.async_start_reauth.assert_called_once()
-    # A paused slot is not retried on the next wake.
     assert mgr._has_pending_work() is False
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "exc",
+    [
+        AuthenticationFailedError("wrong key"),
+        # Issue #91's real case: firmware status 0x03 (encryption not configured)
+        # surfaces as AuthenticationRequiredError, not AuthenticationFailedError.
+        AuthenticationRequiredError("device has no encryption configured"),
+    ],
+    ids=["failed", "required"],
+)
+async def test_auth_failure_stops_resync_only_retry_loop(exc):
+    """Regression for issue #91.
+
+    With only a config resync queued, the old handler paused nothing at all, so
+    ``_has_pending_work()`` stayed True and the next advertisement immediately
+    started another identical, doomed session.
+    """
+    hass, entry, _ = _make_env()
+    with _auth_patches(exc):
+        mgr = DeliveryManager(hass, entry)
+        mgr.request_config_resync()
+        assert mgr._has_pending_work() is True
+        await mgr._deliver()
+
+        # The work is still queued, but it is no longer deliverable...
+        assert mgr._pending_config_resync is True
+        assert mgr._has_pending_work() is False
+
+        # ...so the next advertisement starts no second session.
+        entry.async_create_background_task.reset_mock()
+        mgr.notify_device_seen("ble")
+        entry.async_create_background_task.assert_not_called()
+        assert mgr._delivering is False
+
+
+@pytest.mark.asyncio
+async def test_submit_does_not_bypass_auth_pause():
+    """New content must not re-arm the storm while the pause stands.
+
+    ``submit_upload`` is routinely automation-driven, so clearing the pause there
+    would let a frame-changing automation restart delivery on every wake.
+    """
+    hass, entry, _ = _make_env()
+    with _auth_patches(AuthenticationFailedError("bad key")):
+        mgr = DeliveryManager(hass, entry)
+        mgr.request_config_resync()
+        await mgr._deliver()
+
+        _submit(mgr, device_id="dev2")
+
+    assert mgr._pending_upload is not None
+    assert mgr._has_pending_work() is False
+    # auth_paused is the authoritative signal; last_error is best-effort (an
+    # expiring slot can overwrite it with "expired").
+    assert mgr.state.auth_paused is True
+    assert mgr.state.last_error == "auth"
+
+
+@pytest.mark.asyncio
+async def test_config_resync_request_does_not_unblock_auth():
+    """The reboot edge fires on every wake for sleepy devices.
+
+    Clearing the pause in ``request_config_resync`` would therefore reopen the
+    exact loop this fix closes.
+    """
+    hass, entry, _ = _make_env()
+    with _auth_patches(AuthenticationFailedError("bad key")):
+        mgr = DeliveryManager(hass, entry)
+        mgr.request_config_resync()
+        await mgr._deliver()
+
+        mgr.request_config_resync()
+
+    assert mgr._auth_paused is True
+    assert mgr._has_pending_work() is False
+
+
+@pytest.mark.asyncio
+async def test_malformed_key_pauses_and_does_not_loop():
+    """A malformed stored key returns normally, so it needs the same pause.
+
+    ``_drain_once`` bails out on the ``_KEY_INVALID`` sentinel without raising,
+    which previously left the work deliverable and retried it every wake.
+    """
+    hass, entry, _ = _make_env(entry_data={CONF_ENCRYPTION_KEY: "not-32-chars"})
+    with (
+        patch.object(delivery_mod, "async_call_later", return_value=MagicMock()),
+        patch.object(delivery_mod, "async_dispatcher_send"),
+    ):
+        mgr = DeliveryManager(hass, entry)
+        mgr.request_config_resync()
+        await mgr._deliver()
+
+        assert mgr._has_pending_work() is False
+        entry.async_create_background_task.reset_mock()
+        mgr.notify_device_seen("ble")
+        entry.async_create_background_task.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_key_invalid_sets_auth_error_and_notifies():
+    """The sentinel path must publish state, not just set the flag."""
+    hass, entry, _ = _make_env(entry_data={CONF_ENCRYPTION_KEY: "not-32-chars"})
+    with (
+        patch.object(delivery_mod, "async_call_later", return_value=MagicMock()),
+        patch.object(delivery_mod, "async_dispatcher_send") as dispatch,
+    ):
+        mgr = DeliveryManager(hass, entry)
+        mgr.request_config_resync()
+        await mgr._deliver()
+
+    assert mgr.state.auth_paused is True
+    assert mgr.state.last_error == "auth"
+    # _resolve_key already started the flow; the pause must not start a second.
+    entry.async_start_reauth.assert_called_once()
+    assert any(
+        call.args[1] == f"{SIGNAL_PENDING_STATE}_{ADDRESS}" for call in dispatch.call_args_list
+    )
+
+
+@pytest.mark.asyncio
+async def test_mdns_and_post_probe_notifies_are_gated():
+    """Every wake route goes through _has_pending_work, so all are gated."""
+    hass, entry, _ = _make_env()
+    with _auth_patches(AuthenticationFailedError("bad key")):
+        mgr = DeliveryManager(hass, entry)
+        mgr.request_config_resync()
+        await mgr._deliver()
+
+        entry.async_create_background_task.reset_mock()
+        for source in ("ble", "mdns", "post-probe"):
+            mgr.notify_device_seen(source)
+        entry.async_create_background_task.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_auth_paused_surfaces_in_snapshot_and_entity():
+    """The flag must reach the reader, not just the dataclass.
+
+    ``last_error`` cannot carry this on its own: a paused slot's expiry timer
+    still fires and overwrites it with "expired".
+    """
+    hass, entry, _ = _make_env()
+    with _auth_patches(AuthenticationFailedError("bad key")):
+        mgr = DeliveryManager(hass, entry)
+        _submit(mgr)
+        await mgr._deliver()
+
+        # Expiry lands after the pause and clobbers last_error.
+        mgr._expire_upload(mgr._pending_upload)
+
+    assert mgr.state.last_error == "expired"
+    assert mgr.state.auth_paused is True
+
+    sensor = OpenDisplayUpdatePendingSensor(ADDRESS, mgr)
+    assert sensor.extra_state_attributes["auth_paused"] is True
+    assert sensor.extra_state_attributes["last_error"] == "expired"
 
 
 @pytest.mark.asyncio

--- a/tests/test_delivery.py
+++ b/tests/test_delivery.py
@@ -473,8 +473,8 @@ async def test_all_wake_sources_share_the_same_gate():
     """Every wake route funnels through notify_device_seen, so one gate covers all.
 
     ``source`` is only a log label; the BLE, mDNS
-    (``transport.async_notify_host_seen``) and post-probe (``services``) callers
-    all reach this same method, which is where the gate lives.
+    (``transport.note_mdns_seen``) and post-probe (``services``) callers all
+    reach this same method, which is where the gate lives.
     """
     hass, entry, _ = _make_env()
     with _auth_patches(AuthenticationFailedError("bad key")):


### PR DESCRIPTION
Fixes the advertisement-rate authentication retry loop reported in #91.

## The problem

Delivery is advertisement-driven with no throttle: every parsed advertisement
calls `notify_device_seen`, whose only guard is `if self._delivering` — a
mutual-exclusion guard, not a rate limiter. Once `_deliver`'s `finally` clears
it, the next advertisement starts another drain. The only thing that can end the
sequence is `_has_pending_work()` returning `False`.

That predicate was a disjunction:

```python
upload_ready = self._pending_upload is not None and not self._pending_upload.paused
return upload_ready or self._pending_config_resync
```

and the auth handler set `self._pending_upload.paused = True` — falsifying the
**left operand only**. With a config resync also queued the right operand stayed
`True`, so every advertisement started another identical, doomed
connect/auth/disconnect cycle: ~20 sessions per minute, indefinitely, draining
the tag's battery.

This is why it went unnoticed: with only an upload queued, falsifying the left
operand does stop the loop. It misfires only when a resync is pending — which is
exactly every dark (cache-based) startup and every advertised reboot edge on a
sleepy device.

## The fix

Replace the per-slot `PendingUpload.paused` with a manager-wide `_auth_paused`
checked at the top of `_has_pending_work()`, so the gate is indifferent to which
kind of work is queued.

It is cleared only by an entry reload, which rebuilds the manager. Two places
look like natural reset points and both re-arm the loop, so both are deliberately
left alone (with comments saying why):

* `request_config_resync()` — fires on every advertised reboot edge for sleepy
  devices, i.e. roughly every wake.
* `submit_upload()` — routinely automation-driven; a frame-changing automation
  would clear the pause before every advertisement.

Result: one doomed session per reload instead of one per advertisement.

### Second route: the malformed-key path

`_resolve_key()` returns the `_KEY_INVALID` sentinel and `_drain_once` returns
**normally** rather than raising, so no `except` clause in `_deliver` ever ran.
That route left the work deliverable and retried it on every advertisement too.
Both entry points now share `_pause_for_auth(*, start_reauth)`; the sentinel path
passes `start_reauth=False` because `_resolve_key` already starts the flow on both
of its branches.

### Why a separate flag rather than `last_error`

A paused slot's expiry timer keeps running and `_expire_upload` overwrites
`last_error` with `"expired"`, so it decays into a lie while delivery is still
blocked. `auth_paused` is carried on `DeliverySnapshot` and surfaced in
diagnostics and in the image and binary-sensor attributes. `submit_upload`
restores `"auth"` explicitly rather than merely declining to clear, so a
brand-new upload can't inherit a stale `"expired"`.

## Scope — this does not close the retry-loop class

`_register_attempt_failure` only counts attempts when `self._pending_upload is
not None`, so a **resync-only** queue hitting `BLEConnectionError`,
`BLETimeoutError` or a generic `OpenDisplayError` still increments no counter,
`_has_pending_work()` stays `True`, and the identical storm runs by a non-auth
route. `_drain_resync`'s `if device_config is None: return` is a third
counter-bypassing route.

Closing that needs execution-phase failure accounting (the failed phase cannot be
inferred from post-failure queue state — the expiry timer mutates it mid-await),
a bounded resync terminal state, and a catch-all in `_deliver`. That is a
follow-up PR, deliberately separated so this fix can land on its own.

## Testing

8 new/updated tests in `tests/test_delivery.py`, including:

* the headline regression, parameterized over **both** `AuthenticationFailedError`
  and `AuthenticationRequiredError` — issue #91's real firmware status `0x03`
  raises the latter, which the previous test never covered;
* new content and a repeat resync request each failing to re-arm the loop;
* the malformed-key route reaching the same terminal state;
* auth failure → expiry → resubmit restoring `"auth"` rather than reporting a
  stale `"expired"`.

> **Note for reviewers — the test suite has not been run against this base.**
> An earlier revision of this branch passed locally (28 delivery tests; 150 overall,
> with 2 unrelated pre-existing `test_services.py` failures), but that run was
> against a different base. The branch has since been rebased onto `main`.
>
> CI here runs only `hassfest` and the HACS action — there is no pytest workflow in
> `.github/workflows/`, so **green checks on this PR do not mean the tests ran**.
> Please run `pytest tests/` locally against this base before merging.

Refs #91

