### PR TITLE
chore: hide internal commits from the release notes, add CONTRIBUTING

### DIFF
--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -11,5 +11,58 @@
         }
       ]
     }
-  }
+  },
+  "changelog-sections": [
+    {
+      "type": "feat",
+      "section": "Features"
+    },
+    {
+      "type": "fix",
+      "section": "Bug Fixes"
+    },
+    {
+      "type": "perf",
+      "section": "Performance Improvements"
+    },
+    {
+      "type": "revert",
+      "section": "Reverts"
+    },
+    {
+      "type": "refactor",
+      "section": "Code Refactoring",
+      "hidden": true
+    },
+    {
+      "type": "chore",
+      "section": "Miscellaneous Chores",
+      "hidden": true
+    },
+    {
+      "type": "docs",
+      "section": "Documentation",
+      "hidden": true
+    },
+    {
+      "type": "test",
+      "section": "Tests",
+      "hidden": true
+    },
+    {
+      "type": "ci",
+      "section": "Continuous Integration",
+      "hidden": true
+    },
+    {
+      "type": "build",
+      "section": "Build System",
+      "hidden": true
+    },
+    {
+      "type": "style",
+      "section": "Styles",
+      "hidden": true
+    }
+  ]
 }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,49 @@
+# Contributing
+
+Feature requests and bug reports are welcome, and pull requests are encouraged.
+The [Discord server](https://discord.com/invite/tw48NCrRxH) is the place to
+discuss ideas or get help.
+
+## Translations
+
+English is written by hand; every other language is filled in by
+`.github/workflows/translate.yml`. Corrections are welcome and are never
+overwritten, which the README explains.
+
+If you need to run or change the tooling, `scripts/translate.py` documents
+itself: its module docstring covers provider selection, why `en.json` rather
+than `strings.json` is the source of truth, and how manual edits are protected.
+`--dry-run` previews a run without writing. `scripts/verify_translations.py`
+checks the files on disk and is what CI runs.
+
+## Commits and releases
+
+Commit messages follow [Conventional Commits][cc]. Releases are cut
+automatically by release-please on every push to `main`, so the commit type
+decides both the next version and what the release notes say.
+
+| type | version | in the notes |
+|---|---|---|
+| `feat` | minor | yes |
+| `fix` | patch | yes |
+| `perf`, `revert` | none | yes |
+| `chore`, `refactor`, `docs`, `test`, `ci`, `build`, `style` | none | no |
+
+A `!` after the type, or a `BREAKING CHANGE:` footer, bumps the major version.
+
+Release notes are rendered on the HACS page, so they are written for someone
+deciding whether to install, not for someone reading the diff. That is why the
+internal types are hidden.
+
+**Bumping `py-opendisplay` or `odl-renderer` is a `fix:`, not a `chore:`** (or a
+`feat:` if the bump adds capability). Those are `manifest.json` requirements
+that Home Assistant installs at runtime, so the bump changes what users
+actually get. As a `chore:` it would neither appear in the release notes nor
+trigger the release that ships it, and would sit unreleased until some
+unrelated change landed.
+
+Pull requests are merged with a merge commit, so every commit on the branch
+lands on `main` and each one's type is read. Keep them all conventional, not
+just the pull request title, which is not read at all.
+
+[cc]: https://www.conventionalcommits.org/

--- a/README.md
+++ b/README.md
@@ -117,42 +117,13 @@ that style.
 
 Missing a language? Open an issue and we will add it.
 
-<details>
-<summary>Maintaining the translations (developer notes)</summary>
-
-`scripts/translate.py` fills in strings that are missing from a language, or
-whose English source was reworded since it was last translated. Nothing else is
-ever sent to a model. `.github/workflows/translate.yml` runs it when
-`translations/en.json` changes on a release branch and opens a pull request.
-
-**Adding a language.** Add its code and name to `LANGUAGES` in
-`scripts/translate.py`. The next run fills in the file.
-
-**Providers.** Any OpenAI-compatible chat endpoint works. OpenRouter and GitHub
-Models are configured out of the box in `PROVIDERS`, selected by whichever API
-key is present:
-
-| Variable | Provider | Notes |
-|---|---|---|
-| `OPENROUTER_API_KEY` | OpenRouter | Preferred. No output-token cap. |
-| `MODELS_TOKEN` | GitHub Models | Personal access token with `models:read`. |
-| `GITHUB_TOKEN` | GitHub Models | Only works if the repo's org has a Copilot plan. |
-
-`TRANSLATE_PROVIDER` and `TRANSLATE_MODEL` override the choice for one run:
-
-```bash
-OPENROUTER_API_KEY=... TRANSLATE_MODEL=google/gemini-2.5-flash-lite \
-  python3 scripts/translate.py --languages de --dry-run
-```
-
-**Checking output.** `scripts/verify_translations.py` re-checks the files on
-disk and fails on placeholder mismatches, empty values, or keys that no longer
-exist in `en.json`. It also warns when a translation addresses the reader
-directly, which the impersonal style above is meant to avoid.
-
-</details>
+See [CONTRIBUTING.md](CONTRIBUTING.md) for how the translation
+workflow is maintained.
 
 ## Contributing
-- Feature requests and bug reports are welcome! Please open an issue on GitHub
-- Pull requests are encouraged
-- Join the [Discord server](https://discord.com/invite/tw48NCrRxH) to discuss ideas and get help
+
+Pull requests are encouraged, and bug reports and feature requests are welcome.
+See [CONTRIBUTING.md](CONTRIBUTING.md) for the commit conventions and
+maintainer notes, or join the
+[Discord server](https://discord.com/invite/tw48NCrRxH) to discuss ideas and
+get help.


### PR DESCRIPTION
Two changes that both come down to who the README is for. `hacs.json` sets
`render_readme`, so the README *is* the integration's page in HACS, read by
someone deciding whether to install it.

## Release notes

They are rendered on that page too, and currently carry entries like

> ### Code Refactoring
> * make the platform lists public

`refactor` and `chore` are now hidden, leaving `feat`, `fix`, `perf` and
`revert`. The recurring `chore: update translations` from the automated
workflow goes with them.

Note that `changelog-sections` *replaces* the defaults rather than extending
them, which is why every type is listed explicitly.

### One thing this exposed

Hiding `chore` surfaced something the default config was papering over. Library
bumps have been typed as chores:

```
chore: bump py-opendisplay to 7.14.0
chore: pin py-opendisplay 7.12.0 and odl-renderer 0.5.12 releases
```

But those edit the `manifest.json` requirements Home Assistant installs at
runtime, so they change what users actually get. Typed as chores they would now
neither appear in the release notes **nor trigger the release that ships them**,
and would sit unreleased until some unrelated change landed. `CONTRIBUTING.md`
says to type those as `fix:` (or `feat:` if the bump adds capability).

## CONTRIBUTING.md

New file, holding the commit and release conventions, plus the translation
maintainer notes moved out of the README. API keys, provider tables and script
invocations are not install-decision material. Whoever wrote them had already
recognised that and collapsed them into a `<details>` block labelled "developer
notes", but `<details>` still renders on the HACS page.

The user-facing half stays in the README: which languages exist, that they are
machine-translated, and that corrections are welcome and will not be
overwritten.

GitHub also surfaces `CONTRIBUTING.md` automatically when someone opens a pull
request or issue, which the README is not.

## Ordering

This is deliberately ahead of #106, so that the changelog config is in place
before the release containing that work is cut, and so #106 can put its
development docs straight into `CONTRIBUTING.md` rather than adding them to the
README and moving them later.
