### PR TITLE
chore: drop the v prefix from GitHub release names

### DIFF
--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -1,6 +1,7 @@
 {
   "release-type": "simple",
   "include-v-in-tag": false,
+  "include-v-in-release-name": false,
   "packages": {
     ".": {
       "extra-files": [


### PR DESCRIPTION
3.0.1 was published as "v3.0.1" while 3.0.0 was "3.0.0". The tag was
correct in both cases: include-v-in-tag is false and 3.0.1 is tagged
3.0.1, which is what HACS resolves against and what the release zip
attaches to. Only the display name carried the v.

release-please treats the two independently. Its schema documents
include-v-in-tag as "when tagging a release, include v in the tag" and
include-v-in-release-name as "include v in the GitHub release name",
both defaulting to true. Only the first was set, so the name kept its
prefix. release-please-action@v4 floats, so the default most likely
started applying between the two releases.