### PR TITLE
fix: register the mDNS service type in the manifest

### DIFF
--- a/custom_components/opendisplay/manifest.json
+++ b/custom_components/opendisplay/manifest.json
@@ -27,5 +27,8 @@
     "py-opendisplay[silabs-ota]==7.15.0",
     "odl-renderer==0.5.12"
   ],
-  "version": "3.0.1"
+  "version": "3.0.1",
+  "zeroconf": [
+    "_opendisplay._tcp.local."
+  ]
 }


### PR DESCRIPTION
**mDNS discovery never ran.** `config_flow.py` implements `async_step_zeroconf` and
`async_step_zeroconf_confirm`, but `manifest.json` never declared the service type. Home
Assistant builds its mDNS browser subscription list from integration manifests, so
`_opendisplay._tcp.local.` was never subscribed to and never matched — the step was
unreachable, and nothing logged an error.

### Measured

A/B on a live 2026.8.3 install. Only `manifest.json` differs; with the key removed it is
byte-identical to `main`. Three-minute window after each restart, plus one
`opendisplay.upload_image` of the same file to the same tag in each.

| | with the key | without |
|---|---|---|
| `Discovered new device`, 3 min, 4 tags | 16 | **0** |
| other `zeroconf.discovery` lines, same window | normal | 20 — the component itself is fine |
| transport chosen for the upload | WiFi | **BLE** |
| chunks for the same 8871-byte payload | 3 | **38** |
| compress → transfer complete | 1.47 s | **2.78 s** |
| `binary_sensor.<device>_wifi` | `on`, `192.168.10.238:2446` | **`on`, `192.168.10.238:2446`** |

The last row is why this is easy to miss: the entity reports the same thing either way, so
from the UI the two columns are indistinguishable.

```
12:06:02.079 DEBUG [opendisplay.transport.ip] Connected to 192.168.10.238:2446 (tls=False)
12:06:03.527 DEBUG [opendisplay.device] All data chunks sent (3 chunks total)
```
```
12:21:24.261 DEBUG [custom_components.opendisplay.transport] 64:E8:33:7F:82:8D: host 192.168.10.238 known but mDNS presence stale/absent; using BLE
12:21:27.037 DEBUG [opendisplay.device] All data chunks sent (38 chunks total)
```

### Verification

Full suite green on both the `dev` and `min-ha` legs; ruff check/format clean. Live A/B as
tabulated above.
