### PR TITLE
fix: fetch camera and image sources from their still endpoint

### DIFF
--- a/custom_components/opendisplay/services.py
+++ b/custom_components/opendisplay/services.py
@@ -370,6 +370,25 @@ def _load_image_from_bytes(data: bytes) -> PILImage.Image:
     return ImageOps.exif_transpose(image)
 
 
+# media_source resolves these two domains to their *_proxy_stream sibling: an
+# endless multipart feed, because it resolves for media players, which want
+# something to keep playing. A panel wants the frame that is current now.
+_STILL_ENDPOINTS = {
+    "camera": "/api/camera_proxy/{}",
+    "image": "/api/image_proxy/{}",
+}
+
+
+def _still_endpoint(media_content_id: str) -> str | None:
+    """Return the still-image path for a camera/image source, else None."""
+    domain, _, entity_id = media_content_id.removeprefix("media-source://").partition(
+        "/"
+    )
+    if (path := _STILL_ENDPOINTS.get(domain)) is None:
+        return None
+    return path.format(entity_id)
+
+
 async def _async_download_image(hass: HomeAssistant, url: str) -> PILImage.Image:
     """Download an image from a URL and return a PIL Image."""
     if not url.startswith(("http://", "https://")):
@@ -381,7 +400,9 @@ async def _async_download_image(hass: HomeAssistant, url: str) -> PILImage.Image
         async with session.get(url, timeout=aiohttp.ClientTimeout(total=30)) as resp:
             resp.raise_for_status()
             data = await resp.read()
-    except aiohttp.ClientError as err:
+    except (aiohttp.ClientError, TimeoutError) as err:
+        # TimeoutError is not a ClientError: aiohttp raises it bare when the
+        # total timeout expires, so it needs naming here to be translated.
         raise HomeAssistantError(
             translation_domain=DOMAIN,
             translation_key="media_download_error",
@@ -746,6 +767,8 @@ async def _async_upload_image(call: ServiceCall) -> ServiceResponse:
     try:
         if isinstance(image_data, str):
             pil_image = await _async_download_image(call.hass, image_data)
+        elif (still := _still_endpoint(image_data["media_content_id"])) is not None:
+            pil_image = await _async_download_image(call.hass, still)
         else:
             media = await async_resolve_media(
                 call.hass, image_data["media_content_id"], None

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -9,6 +9,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import aiohttp
 from homeassistant import config_entries
 from homeassistant.core import HomeAssistant
+from homeassistant.core_config import async_process_ha_core_config
 from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 from homeassistant.helpers import device_registry as dr
 from opendisplay import (
@@ -204,18 +205,23 @@ async def test_upload_image_ble_error(
         )
 
 
+@pytest.mark.parametrize(
+    "exc",
+    [
+        aiohttp.ClientError("connection refused"),
+        TimeoutError(),
+    ],
+)
 async def test_upload_image_download_error(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
     aioclient_mock: AiohttpClientMocker,
+    exc: Exception,
 ) -> None:
     """Test that HomeAssistantError is raised on media download failure."""
     device_id = _device_id(hass, mock_config_entry)
 
-    aioclient_mock.get(
-        "http://example.com/image.png",
-        exc=aiohttp.ClientError("connection refused"),
-    )
+    aioclient_mock.get("http://example.com/image.png", exc=exc)
 
     mock_media = MagicMock()
     mock_media.path = None
@@ -240,6 +246,56 @@ async def test_upload_image_download_error(
             },
             blocking=True,
         )
+
+
+def _png_bytes() -> bytes:
+    """Return a small PNG as raw bytes."""
+    buf = io.BytesIO()
+    PILImage.new("RGB", (10, 10)).save(buf, format="PNG")
+    return buf.getvalue()
+
+
+@pytest.mark.parametrize(
+    ("domain", "entity_id", "path"),
+    [
+        ("camera", "camera.front_door", "/api/camera_proxy/camera.front_door"),
+        ("image", "image.tag_content", "/api/image_proxy/image.tag_content"),
+    ],
+)
+async def test_upload_image_entity_still_frame(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_upload_device: MagicMock,
+    aioclient_mock: AiohttpClientMocker,
+    domain: str,
+    entity_id: str,
+    path: str,
+) -> None:
+    """Camera/image entities are fetched from their still endpoint."""
+    device_id = _device_id(hass, mock_config_entry)
+    await async_process_ha_core_config(hass, {"internal_url": "http://127.0.0.1:8123"})
+    aioclient_mock.get(f"http://127.0.0.1:8123{path}", content=_png_bytes())
+
+    with patch(
+        "custom_components.opendisplay.services.async_resolve_media",
+    ) as mock_resolve:
+        await hass.services.async_call(
+            DOMAIN,
+            "upload_image",
+            {
+                "device_id": device_id,
+                "image": {
+                    "media_content_id": f"media-source://{domain}/{entity_id}",
+                    "media_content_type": "image/jpeg",
+                },
+            },
+            blocking=True,
+        )
+
+    assert aioclient_mock.call_count == 1
+    assert aioclient_mock.mock_calls[0][1].path == path
+    mock_resolve.assert_not_called()
+    mock_upload_device.upload_prepared_image.assert_called_once()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Fixes #114.

## What it does

Both domains serve the frame we want from the endpoint next to the stream, so
rewrite the media-source id to that path and let the existing download path
sign and fetch it:

```python
_STILL_ENDPOINTS = {
    "camera": "/api/camera_proxy/{}",
    "image": "/api/image_proxy/{}",
}
```

Plus naming `TimeoutError` in the `except`, so a timeout reports as
`media_download_error` rather than a raw traceback.

This is not a shortcut around the entity API: `CameraImageView` is a thin
wrapper over the same `_async_get_image()` that `camera.async_get_image()`
calls, which also means cameras with no still of their own work, via
`use_stream_for_stills`.

Calling `async_get_image()` directly was built first and dropped -- same
behaviour, but importing those components costs a cold-import guard, two
branches (the two functions differ in their optional parameters), and
`PyTurboJPEG` in the test groups.

## Verified

Live, HA 2026.8.3, Waveshare 7.3" BWGBRY over BLE:

| Source | Before | After |
|---|---|---|
| `media-source://camera/...`, no stream support | 30 s hang, `TimeoutError` | delivered |
| `media-source://camera/...`, stream only (RTSP/H264) | resolves to `.m3u8`, `UnidentifiedImageError` | delivered |
| `media-source://image/...` | 30 s hang, `TimeoutError` | delivered |
| `media-source://media_source/local/*.jpg` | delivered | delivered |
| `media-source://ai_task/...` | delivered | delivered |

The stream-only case is a `generic` camera over `rtsp://.../h264.sdp`, H264
1920x1080, no `still_image_url`, so `use_stream_for_stills` is what produces the
frame. `/api/camera_proxy/` on it returns a real 1920x1080 JPEG keyframe.

Worth noting for that row: because its media source declares
`application/vnd.apple.mpegurl`, an `accept: image/*` picker filters it out, so
it is only reachable by writing the `media_content_id` by hand.

Not verified: `image_upload` (none present, unaffected either way).

## Notes

- Only `_async_upload_image()` reaches the changed code; `drawcustom` does not.
- No manifest, `pyproject.toml`, `uv.lock` or translation change.
- Nothing that used to succeed changes behaviour.
