### PR TITLE
fix: declare silabs-ble-ota explicitly in the manifest

### DIFF
--- a/custom_components/opendisplay/manifest.json
+++ b/custom_components/opendisplay/manifest.json
@@ -25,6 +25,7 @@
   ],
   "requirements": [
     "py-opendisplay[silabs-ota]==7.15.0",
+    "silabs-ble-ota==0.1.0",
     "odl-renderer==0.5.12"
   ],
   "version": "3.0.1",


### PR DESCRIPTION
Silabs OTA can fail on an otherwise healthy install with:

> Firmware update failed: silabs-ble-ota is required for Silabs firmware updates; install it with: pip install silabs-ble-ota

even though the manifest asks for `py-opendisplay[silabs-ota]`.

## Cause

`homeassistant/util/package.py:is_installed()` parses each requirement string and returns `req.specifier.contains(installed_version)`. It looks at the distribution name and the version specifier only, and never at `req.extras`. So once `py-opendisplay` is installed at a matching version, HA considers the requirement satisfied and skips the install entirely, and the extra never gets resolved. Any environment where the base package arrived without the extra stays broken across restarts and upgrades.

## Fix

List `silabs-ble-ota` as a requirement of its own so HA checks and installs it independently. The version matches what `uv.lock` resolves for the extra.

The `[silabs-ota]` extra stays declared on purpose, so upstream keeps owning the full dependency set for the OTA path and anything it gains later still comes along.

fixes #121 